### PR TITLE
The benchmarking code was flawed because it was accidentally copying the strings.

### DIFF
--- a/benchmarks/bench.cpp
+++ b/benchmarks/bench.cpp
@@ -31,7 +31,7 @@ std::string url_examples[] = {
 
 double url_examples_bytes =  []() {
     size_t bytes{0};
-    for(std::string url_string : url_examples) { bytes += url_string.size(); }
+    for(std::string& url_string : url_examples) { bytes += url_string.size(); }
     return bytes;
   }();
 
@@ -44,7 +44,7 @@ static void BasicBench_BoostURL(benchmark::State& state) {
   volatile size_t numbers_of_parameters = 0;
 
   for (auto _ : state) {
-    for(std::string url_string : url_examples) {
+    for(std::string& url_string : url_examples) {
         url_view uv(url_string);
         numbers_of_parameters += uv.params().size();
     }
@@ -67,7 +67,7 @@ static void BasicBench_CURL(benchmark::State& state) {
   volatile bool is_valid{true};
   CURLU *url = curl_url();
   for (auto _ : state) {
-    for(std::string url_string : url_examples) {
+    for(std::string& url_string : url_examples) {
       CURLUcode rc = curl_url_set(url, CURLUPART_URL, url_string.c_str(), 0);
       if(rc) { is_valid = false; }
     }
@@ -88,7 +88,7 @@ static void BasicBench_uriparser(benchmark::State& state) {
   const char * errorPos;
   UriUriA uri;
   for (auto _ : state) {
-    for(std::string url_string : url_examples) {
+    for(std::string& url_string : url_examples) {
         is_valid &= (uriParseSingleUriA(&uri, url_string.c_str(), &errorPos) == URI_SUCCESS);
     }
   }
@@ -106,7 +106,7 @@ static void BasicBench_urlparser(benchmark::State& state) {
   const char * errorPos;
   UriUriA uri;
   for (auto _ : state) {
-    for(std::string url_string : url_examples) {
+    for(std::string& url_string : url_examples) {
       std::unique_ptr<EdUrlParser> url(EdUrlParser::parseUrl(url_string));
     }
   }
@@ -121,7 +121,7 @@ static void BasicBench_http_parser(benchmark::State& state) {
   struct http_parser_url u;
   http_parser_url_init(&u);
   for (auto _ : state) {
-    for(std::string url_string : url_examples) {
+    for(std::string& url_string : url_examples) {
       is_valid &= !http_parser_parse_url(url_string.data(), url_string.size(), 0, &u);
     }
   }
@@ -136,7 +136,7 @@ static void BasicBench_AdaURL(benchmark::State& state) {
   // volatile to prevent optimizations.
   volatile bool is_valid = true;
   for (auto _ : state) {
-    for(std::string url_string : url_examples) {
+    for(std::string& url_string : url_examples) {
         auto url = ada::parser::parse_url(url_string, std::nullopt);
         is_valid &= url.is_valid;
     }


### PR DESCRIPTION
We definitively do not want to do that !