### PR TITLE
perf: precalculate fragment and scheme state

### DIFF
--- a/include/ada.h
+++ b/include/ada.h
@@ -9,6 +9,7 @@
 #include "ada/serializers.h"
 #include "ada/state.h"
 #include "ada/url.h"
+#include "ada/unicode.h"
 
 // Public API
 #include "ada/ada_version.h"

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -6,12 +6,13 @@
 
 #include <string_view>
 #include <vector>
+#include <optional>
 
 namespace ada::helpers {
 
   std::vector<std::string> split_string_view(std::string_view input, char delimiter, bool skip_empty = true);
   ada_really_inline uint64_t string_to_uint64(std::string_view view);
-
+  ada_really_inline std::optional<std::string_view> prune_fragment(std::string_view& input) noexcept;
 } // namespace ada::helpers
 
 #endif // ADA_HELPERS_H

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -16,8 +16,11 @@ namespace ada::unicode {
 
   unsigned constexpr convert_hex_to_binary(char c) noexcept;
 
-  std::string percent_decode(const std::string_view input) noexcept;
-  std::string percent_encode(const std::string_view input, const uint8_t character_set[]) noexcept;
+  // todo: these functions would be faster as noexcept maybe, but it could be unsafe since
+  // they are allocating.
+  std::string percent_decode(const std::string_view input);
+  std::string percent_encode(const std::string_view input, const uint8_t character_set[]);
+  void percent_encode_character(const char input, const uint8_t character_set[], std::string& out);
 
 } // namespace ada::unicode
 

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -1,0 +1,24 @@
+#ifndef ADA_UNICODE_H
+#define ADA_UNICODE_H
+
+#include "common_defs.h"
+#include <cstring>
+
+namespace ada::unicode {
+
+  ada_really_inline constexpr bool is_forbidden_host_code_point(const char c) noexcept;
+  ada_really_inline constexpr bool is_forbidden_domain_code_point(const char c) noexcept;
+  ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept;
+  ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept;
+  ada_really_inline constexpr bool is_ascii_tab_or_newline(const char c) noexcept;
+  ada_really_inline constexpr bool is_double_dot_path_segment(const std::string_view input) noexcept;
+  ada_really_inline bool is_single_dot_path_segment(const std::string_view input) noexcept;
+
+  unsigned constexpr convert_hex_to_binary(char c) noexcept;
+
+  std::string percent_decode(const std::string_view input) noexcept;
+  std::string percent_encode(const std::string_view input, const uint8_t character_set[]) noexcept;
+
+} // namespace ada::unicode
+
+#endif // ADA_UNICODE_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ else(MSVC)
   if(NOT WIN32)
     target_compile_options(ada INTERFACE -fPIC)
   endif()
-  target_compile_options(ada PRIVATE -Wall -Wextra -Weffc++)
+  target_compile_options(ada PRIVATE -Wall -Wextra -Weffc++ -Winline)
   target_compile_options(ada PRIVATE -Wfatal-errors -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif(MSVC)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ else(MSVC)
   if(NOT WIN32)
     target_compile_options(ada INTERFACE -fPIC)
   endif()
-  target_compile_options(ada PRIVATE -Wall -Wextra -Weffc++ -Winline)
+  target_compile_options(ada PRIVATE -Wall -Wextra -Weffc++)
   target_compile_options(ada PRIVATE -Wfatal-errors -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif(MSVC)
 

--- a/src/ada.cpp
+++ b/src/ada.cpp
@@ -5,3 +5,4 @@
 #include "url.cpp"
 #include "character_sets.cpp"
 #include "parser.cpp"
+#include "unicode.cpp"

--- a/src/character_sets.cpp
+++ b/src/character_sets.cpp
@@ -436,7 +436,7 @@ namespace ada::character_sets {
       0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 | 0x40 | 0x80
   };
 
-  bool bit_at(const uint8_t a[], const uint8_t i) {
+  ada_really_inline bool bit_at(const uint8_t a[], const uint8_t i) {
     return !!(a[i >> 3] & (1 << (i & 7)));
   }
 

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -1,5 +1,4 @@
 #include "ada.h"
-#include "unicode.cpp"
 
 #include <algorithm>
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -51,4 +51,21 @@ namespace ada::helpers {
     return val;
   }
 
+  // prune_fragment seeks the first '#' and returns everything after it as a
+  // strint_view, and modifies (in place) the input so that it points at everything
+  // before the '#'.
+  // If no '#' is found, the input is left unchanged and std::nullopt is returned.
+  // Note that the returned string_view might be empty!
+  // The function is non-allocating and it does not throw.
+  ada_really_inline std::optional<std::string_view> prune_fragment(std::string_view& input) noexcept {
+    // compiles down to 20--30 instructions including a class to memchr (C function).
+    // this function should be quite fast.
+    size_t location_of_first = input.find('#');
+    if(location_of_first == std::string_view::npos) { return std::nullopt; }
+    std::string_view fragment = input;
+    fragment.remove_prefix(location_of_first+1);
+    input.remove_suffix(input.size() - location_of_first);
+    return fragment;
+  }
+
 } // namespace ada::helpers

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -572,7 +572,7 @@ namespace ada::parser {
           // Otherwise, if one of the following is true:
           // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
           // - url is special and c is U+005C (\)
-          else if (pointer == pointer_end || *pointer == '/' || *pointer == '?' || *pointer == '#' || (url.is_special() && *pointer == '\\')) {
+          else if (pointer == pointer_end || *pointer == '/' || *pointer == '?' || (url.is_special() && *pointer == '\\')) {
             // If atSignSeen is true and buffer is the empty string, validation error, return failure.
             if (at_sign_seen && buffer.empty()) {
               buffer.clear();
@@ -703,7 +703,7 @@ namespace ada::parser {
         }
         case NO_SCHEME: {
           // If base is null, or base has an opaque path and c is not U+0023 (#), validation error, return failure.
-          if (!base_url.has_value() || (base_url->has_opaque_path && *pointer != '#')) {
+          if (!base_url.has_value() || (base_url->has_opaque_path && pointer != pointer_end)) {
             url.is_valid = false;
             return url;
           }
@@ -913,7 +913,7 @@ namespace ada::parser {
           // Otherwise, if one of the following is true:
           // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
           // - url is special and c is U+005C (\)
-          else if (pointer == pointer_end || *pointer == '/' || *pointer == '?' || *pointer == '#' || (url.is_special() && *pointer == '\\')) {
+          else if (pointer == pointer_end || *pointer == '/' || *pointer == '?' || (url.is_special() && *pointer == '\\')) {
             // then decrease pointer by 1, and then:
             pointer--;
 
@@ -996,7 +996,7 @@ namespace ada::parser {
           // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
           // - url is special and c is U+005C (\)
           // - state override is given
-          else if (pointer == pointer_end || *pointer == '/' || *pointer == '?' || *pointer == '#' ||
+          else if (pointer == pointer_end || *pointer == '/' || *pointer == '?' ||
                                 (url.is_special() && *pointer == '\\') ||
                                 state_override.has_value()) {
             // If buffer is not the empty string, then:
@@ -1078,7 +1078,7 @@ namespace ada::parser {
           // - c is the EOF code point or U+002F (/)
           // - url is special and c is U+005C (\)
           // - state override is not given and c is U+003F (?) or U+0023 (#)
-          if (pointer == pointer_end || *pointer == '/' || (url.is_special() && *pointer == '\\') || (!state_override.has_value() && (*pointer == '?' || *pointer == '#'))) {
+          if (pointer == pointer_end || *pointer == '/' || (url.is_special() && *pointer == '\\') || (!state_override.has_value() && *pointer == '?')) {
             // If buffer is a double-dot path segment, then:
             if (unicode::is_double_dot_path_segment(buffer)) {
               // Shorten url’s path.
@@ -1160,7 +1160,7 @@ namespace ada::parser {
         case FILE_HOST: {
           // If c is the EOF code point, U+002F (/), U+005C (\), U+003F (?), or U+0023 (#),
           // then decrease pointer by 1 and then:
-          if (pointer == pointer_end || *pointer == '/' || *pointer == '\\' || *pointer == '?' || *pointer == '#') {
+          if (pointer == pointer_end || *pointer == '/' || *pointer == '\\' || *pointer == '?') {
             pointer--;
 
             // If state override is not given and buffer is a Windows drive letter, validation error,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -520,8 +520,7 @@ namespace ada::parser {
     // Let pointer be a pointer for input.
     std::string_view::iterator pointer = pointer_start;
 
-    // TODO: Search from right to left, and find the last occurrence.
-    std::string_view::iterator fragment_pointer_start = std::find_if(pointer_start, pointer_end, [](char c) { return c == '#'; });
+    std::string_view::iterator fragment_pointer_start = std::find(pointer_start, pointer_end, '#');
 
     if (fragment_pointer_start != pointer_end) {
       url.fragment = unicode::percent_encode(std::string(fragment_pointer_start + 1, pointer_end),

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -710,7 +710,7 @@ namespace ada::parser {
           // Otherwise, if base has an opaque path and c is U+0023 (#),
           // set url’s scheme to base’s scheme, url’s path to base’s path, url’s query to base’s query,
           // url’s fragment to the empty string, and set state to fragment state.
-          else if (base_url->has_opaque_path && url.fragment.has_value()) {
+          else if (base_url->has_opaque_path && url.fragment.has_value() && pointer == pointer_end) {
             url.scheme = base_url->scheme;
             url.path = base_url->path;
             url.has_opaque_path = base_url->has_opaque_path;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -524,7 +524,8 @@ namespace ada::parser {
     std::string_view::iterator fragment_pointer_start = std::find_if(pointer_start, pointer_end, [](char c) { return c == '#'; });
 
     if (fragment_pointer_start != pointer_end) {
-      url.fragment = unicode::percent_encode(fragment_pointer_start + 1, ada::character_sets::FRAGMENT_PERCENT_ENCODE);
+      url.fragment = unicode::percent_encode(std::string(fragment_pointer_start + 1, pointer_end),
+                                             ada::character_sets::FRAGMENT_PERCENT_ENCODE);
       pointer_end = fragment_pointer_start;
     }
 
@@ -872,7 +873,7 @@ namespace ada::parser {
 
           // Percent-encode after encoding, with encoding, buffer, and queryPercentEncodeSet,
           // and append the result to url’s query.
-          url.query = ada::unicode::percent_encode(pointer, query_percent_encode_set);
+          url.query = ada::unicode::percent_encode(std::string(pointer, pointer_end), query_percent_encode_set);
 
           return url;
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -548,6 +548,7 @@ namespace ada::parser {
           // If c is an ASCII alpha, append c, lowercased, to buffer, and set state to scheme state.
           if (std::isalpha(*pointer)) {
             state = SCHEME;
+            pointer--;
           }
           // Otherwise, if state override is not given, set state to no scheme state and decrease pointer by 1.
           else if (!state_override.has_value()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -516,14 +516,11 @@ namespace ada::parser {
       pointer_end = internal_input.end();
     }
 
-    // Let pointer be a pointer for input.
-    std::string_view::iterator pointer = pointer_start;
-
     std::string_view url_data(pointer_start, pointer_end - pointer_start);
 
-    auto result = helpers::prune_fragment(url_data);
+    std::optional<std::string_view> result = helpers::prune_fragment(url_data);
     if(result.has_value()) {
-      url.fragment = unicode::percent_encode(result.value(),
+      url.fragment = unicode::percent_encode(*result,
                                              ada::character_sets::FRAGMENT_PERCENT_ENCODE);
 
     }
@@ -533,6 +530,9 @@ namespace ada::parser {
     // bring back the pointers.
     pointer_start = url_data.begin();
     pointer_end = url_data.end();
+
+    // Let pointer be a pointer for input.
+    std::string_view::iterator pointer = pointer_start;
 
     // Keep running the following state machine by switching on state.
     // If after a run pointer points to the EOF code point, go to the next step.

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -1,5 +1,3 @@
-#include <unordered_set>
-
 namespace ada::unicode {
 
   // A forbidden host code point is U+0000 NULL, U+0009 TAB, U+000A LF, U+000D CR, U+0020 SPACE, U+0023 (#),


### PR DESCRIPTION
Before:

```
BasicBench_AdaURL           12170 ns        12165 ns        57778 time/byte=15.0553ns
```

After:
```
BasicBench_AdaURL            7513 ns         7513 ns        93508 time/byte=9.29769ns
```