### PR TITLE
Getting rid of the unordered map.

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -634,11 +634,11 @@ namespace ada::parser {
 
             // If state override is given, then:
             if (state_override.has_value()) {
-              auto urls_scheme_port = ada::scheme::SPECIAL_SCHEME.find(url.scheme);
+              auto urls_scheme_port = ada::scheme::get_special_port(url.scheme);
 
-              if (urls_scheme_port != ada::scheme::SPECIAL_SCHEME.end()) {
+              if (urls_scheme_port.has_value()) {
                 // If url’s port is url’s scheme’s default port, then set url’s port to null.
-                if (url.port.has_value() && *url.port == urls_scheme_port->second) {
+                if (url.port.has_value() && *url.port == urls_scheme_port.value()) {
                   url.port = std::nullopt;
                 }
               }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -4,11 +4,7 @@
 namespace ada {
 
   ada_really_inline std::optional<uint16_t> url::scheme_default_port() const {
-    if (!is_special()) {
-      return std::nullopt;
-    }
-
-    return scheme::SPECIAL_SCHEME.find(scheme)->second;
+    return scheme::get_special_port(scheme);
   }
 
   ada_really_inline bool url::is_special() const {


### PR DESCRIPTION
This should be pretty clear. It is much simpler code. No more std::memcpy or std::unordered_map. It is just straight, clean code. And it should be pretty fast too.