### PR TITLE
Putting back -Winline by telling GCC12 that it is ok if the destructor is not inline.

### DIFF
--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -113,4 +113,16 @@
 /// If EXPR is an error, returns it.
 #define ADA_TRY(EXPR) { auto _err = (EXPR); if (_err) { return _err; } }
 
+// __has_cpp_attribute is part of C++20
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) 0
+#endif
+
+
+#if __has_cpp_attribute(gnu::noinline)
+#define ADA_ATTRIBUTE_NOINLINE [[gnu::noinline]]
+#else
+#define ADA_ATTRIBUTE_NOINLINE
+#endif
+
 #endif // ADA_COMMON_DEFS_H

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -124,6 +124,8 @@ namespace ada {
     }
 
     [[nodiscard]] std::optional<uint16_t> scheme_default_port() const;
+
+    ADA_ATTRIBUTE_NOINLINE ~url() = default;
   }; // struct url
 
 } // namespace ada

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ else(MSVC)
   if(NOT WIN32)
     target_compile_options(ada INTERFACE -fPIC)
   endif()
-  target_compile_options(ada PRIVATE -Wall -Wextra -Weffc++)
+  target_compile_options(ada PRIVATE -Wall -Wextra -Weffc++ -Winline)
   target_compile_options(ada PRIVATE -Wfatal-errors -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif(MSVC)
 


### PR DESCRIPTION
GCC12 seems to want to inline the destructor of url and is unhappy when it cannot. Of course, we do not care about that: if inlining the destructor ever becomes a performance bottleneck, we should deliberately work on this.

Note that the -Winline is only useful, in my view, when first building the code. It is useful to see what does not get inlined.