### PR TITLE
All around optimizations.

### DIFF
--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -4,8 +4,51 @@
 #include "common_defs.h"
 
 #include <string_view>
+#include <cstring>
 
 namespace ada::checkers {
+
+
+  // Assuming that x is an ASCII letter, this returns the lower case equivalent.
+  // More likely to be inlined by the compiler and constexpr.
+  constexpr char to_lower(char x) { return (x | 0x20); }
+  // Returns true if the character is an ASCII letter. Equivalent to std::isalpha but
+  // more likely to be inlined by the compiler. Also, std::isalpha is not constexpr
+  // generally.
+  constexpr bool is_alpha(char x) { return (to_lower(x) >= 'a') & (to_lower(x) <= 'z'); }
+
+  // Check whether a string starts with 0x or 0X. The function is only
+  // safe if input.size() >=2. See has_hex_prefix.
+  inline bool has_hex_prefix_unsafe(std::string_view input) {
+    // This is actualy efficient code, see has_hex_prefix for the assembly.
+    uint32_t value = 1;
+    bool is_little_endian = (static_cast<uint8_t>(value) == 1);
+    uint16_t word0x{};
+    std::memcpy(&word0x, "0x", 2); // we would use bit_cast in C++20 and the function could be constexpr.
+    uint16_t two_first_bytes{};
+    std::memcpy(&two_first_bytes, input.data(),2);
+    if(is_little_endian) { two_first_bytes |= 0x2000; } else { two_first_bytes |= 0x020; }
+    return two_first_bytes == word0x;
+  }
+
+  // Check whether a string starts with 0x or 0X.
+  inline bool has_hex_prefix(std::string_view input) {
+    return input.size() >=2 && has_hex_prefix_unsafe(input);
+  }
+
+  // Check whether x is an ASCII digit. More likely to be inlined than std::isdigit.
+  constexpr bool is_digit(char x) { return (x >= '0') & (x <= '9'); }
+
+  // A Windows drive letter is two code points, of which the first is an ASCII alpha
+  // and the second is either U+003A (:) or U+007C (|).
+  inline bool is_windows_drive_letter(const std::string_view input) noexcept {
+    return input.size() >= 2 && (is_alpha(input[0]) & ((input[1] == ':') | (input[1] == '|')));
+  }
+
+  // A normalized Windows drive letter is a Windows drive letter of which the second code point is U+003A (:).
+  inline bool is_normalized_windows_drive_letter(std::string_view input) noexcept {
+    return input.size() >= 2 && (is_alpha(input[0]) & (input[1] == ':'));
+  }
 
   bool ends_in_a_number(std::string_view input) noexcept;
   bool is_windows_drive_letter(std::string_view input) noexcept;

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -5,13 +5,12 @@
 #include "common_defs.h"
 
 #include <string_view>
-#include <vector>
 #include <optional>
 
 namespace ada::helpers {
 
-  std::vector<std::string> split_string_view(std::string_view input, char delimiter, bool skip_empty = true);
-  ada_really_inline uint64_t string_to_uint64(std::string_view view);
+  // return 256^x, might overflow. Valid inputs are 0,1,...,7.
+  constexpr uint64_t pow256(uint64_t x) { return uint64_t(1) << (8*x); }
   ada_really_inline std::optional<std::string_view> prune_fragment(std::string_view& input) noexcept;
 } // namespace ada::helpers
 

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -8,8 +8,8 @@
 #include <string_view>
 
 namespace ada::parser {
-
-  std::optional<std::string> to_ascii(std::string_view plain, bool be_strict) noexcept;
+  // first_percent should be  = plain.find('%')
+  std::optional<std::string> to_ascii(std::string_view plain, bool be_strict, size_t first_percent);
 
   std::optional<uint64_t> parse_ipv4_number(std::string_view input);
   std::optional<ada::url_host> parse_opaque_host(std::string_view input);

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -8,6 +8,7 @@ namespace ada::unicode {
 
   ada_really_inline constexpr bool is_forbidden_host_code_point(const char c) noexcept;
   ada_really_inline constexpr bool is_forbidden_domain_code_point(const char c) noexcept;
+  ada_really_inline constexpr bool is_alnum_plus(const char c) noexcept;
   ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept;
   ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept;
   ada_really_inline constexpr bool is_ascii_tab_or_newline(const char c) noexcept;
@@ -18,7 +19,8 @@ namespace ada::unicode {
 
   // todo: these functions would be faster as noexcept maybe, but it could be unsafe since
   // they are allocating.
-  std::string percent_decode(const std::string_view input);
+  // first_percent should be  = plain.find('%')
+  std::string percent_decode(const std::string_view input, size_t first_percent);
   std::string percent_encode(const std::string_view input, const uint8_t character_set[]);
   void percent_encode_character(const char input, const uint8_t character_set[], std::string& out);
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -1,23 +1,8 @@
-#include <vector>
 #include <algorithm>
 #include <cstring>
 #include <sstream>
 
 namespace ada::helpers {
-
-  std::vector<std::string> split_string_view(std::string_view input, char delimiter, bool skip_empty) {
-    std::vector<std::string> out;
-    if (input.empty())
-      return out;
-    std::istringstream in_stream(std::string{input});
-    while (in_stream.good()) {
-      std::string item;
-      std::getline(in_stream, item, delimiter);
-      if (item.empty() && skip_empty) continue;
-      out.emplace_back(std::move(item));
-    }
-    return out;
-  }
 
   ada_unused std::string get_state(ada::state state) {
     switch (state) {
@@ -43,12 +28,6 @@ namespace ada::helpers {
       case PORT: return "Port";
       default: return "";
     }
-  }
-
-  ada_really_inline uint64_t string_to_uint64(std::string_view view) {
-    uint64_t val;
-    std::memcpy(&val, view.data(), sizeof(uint64_t));
-    return val;
   }
 
   // prune_fragment seeks the first '#' and returns everything after it as a

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -499,7 +499,7 @@ namespace ada::parser {
     // Define parsed URL
     ada::url url = ada::url();
 
-    // most input strings will be ASCII which enables many optimizations.
+    // most input strings will be ASCII which may enable some optimizations.
     const bool is_ascii = 128>(std::reduce(user_input.begin()+1, user_input.end(), uint8_t(user_input[0]), std::bit_xor<uint8_t>()));
 
     // Remove any leading and trailing C0 control or space from input.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -539,7 +539,9 @@ namespace ada::parser {
             std::string _buffer = std::string(*scheme_start_pointer, *scheme_end_pointer - *scheme_start_pointer);
 
             if (scheme_needs_lowercase) {
-              std::transform(_buffer.begin(), _buffer.end(), _buffer.begin(), ::tolower);
+              // optimization opportunity. W
+              std::transform(_buffer.begin(), _buffer.end(), _buffer.begin(),
+                [](char c) -> char { return (uint8_t((c|0x20) - 0x61) <= 25 ? (c|0x20) : c);});
             }
 
             // If state override is given, then:
@@ -770,6 +772,7 @@ namespace ada::parser {
               url.query = std::nullopt;
 
               // Shorten url’s path.
+              // Optimization opportunity: shorten_path is maybe not inlined.
               url.shorten_path();
 
               // Set state to path state and decrease pointer by 1.
@@ -1059,6 +1062,7 @@ namespace ada::parser {
             // If buffer is a double-dot path segment, then:
             if (unicode::is_double_dot_path_segment(buffer)) {
               // Shorten url’s path.
+              // Optimization opportunity: shorten_path is maybe not inlined.
               url.shorten_path();
 
               // If neither c is U+002F (/), nor url is special and c is U+005C (\),
@@ -1226,6 +1230,7 @@ namespace ada::parser {
               // If the code point substring from pointer to the end of input does not start with a
               // Windows drive letter, then shorten url’s path.
               if (std::distance(pointer, pointer_end) >= 2 && !checkers::is_windows_drive_letter(std::string(pointer, pointer + 2))) {
+                // Optimization opportunity: shorten_path is maybe not inlined.
                 url.shorten_path();
               }
               // Otherwise:

--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <cmath>
 #include <cstring>
 
 namespace ada::serializers {
@@ -104,7 +103,7 @@ namespace ada::serializers {
       }
 
       // Set n to floor(n / 256).
-      n = static_cast<uint64_t>(floor((double)n / 256));
+      n >>= 8;
     }
 
     // Return output.

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -1,18 +1,119 @@
+#pragma once
 namespace ada::unicode {
 
   // A forbidden host code point is U+0000 NULL, U+0009 TAB, U+000A LF, U+000D CR, U+0020 SPACE, U+0023 (#),
   // U+002F (/), U+003A (:), U+003C (<), U+003E (>), U+003F (?), U+0040 (@), U+005B ([), U+005C (\), U+005D (]),
   // U+005E (^), or U+007C (|).
+  constexpr static bool is_forbidden_host_code_point_table[] = {
+    1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    static_assert(sizeof(is_forbidden_host_code_point_table) == 256);
+
   ada_really_inline constexpr bool is_forbidden_host_code_point(const char c) noexcept {
-    return c == '\0' || c == '\t' || c == '\n' || c == '\r' || c == ' ' ||
-              c == '#' || c == '/' || c == ':' || c == '?' || c == '@' ||
-              c == '[' || c == '<' || c == '>' || c == '\\' || c == ']' ||
-              c == '^' || c == '|';
+    return is_forbidden_host_code_point_table[uint8_t(c)];
   }
 
+  static_assert(unicode::is_forbidden_host_code_point('\0'));
+  static_assert(unicode::is_forbidden_host_code_point('\t'));
+  static_assert(unicode::is_forbidden_host_code_point('\n'));
+  static_assert(unicode::is_forbidden_host_code_point('\r'));
+  static_assert(unicode::is_forbidden_host_code_point(' '));
+  static_assert(unicode::is_forbidden_host_code_point('#'));
+  static_assert(unicode::is_forbidden_host_code_point('/'));
+  static_assert(unicode::is_forbidden_host_code_point(':'));
+  static_assert(unicode::is_forbidden_host_code_point('?'));
+  static_assert(unicode::is_forbidden_host_code_point('@'));
+  static_assert(unicode::is_forbidden_host_code_point('['));
+  static_assert(unicode::is_forbidden_host_code_point('?'));
+  static_assert(unicode::is_forbidden_host_code_point('<'));
+  static_assert(unicode::is_forbidden_host_code_point('>'));
+  static_assert(unicode::is_forbidden_host_code_point('\\'));
+  static_assert(unicode::is_forbidden_host_code_point(']'));
+  static_assert(unicode::is_forbidden_host_code_point('^'));
+  static_assert(unicode::is_forbidden_host_code_point('|'));
+
+  constexpr static bool is_forbidden_domain_code_point_table[] = {
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    static_assert(sizeof(is_forbidden_domain_code_point_table) == 256);
+
   ada_really_inline constexpr bool is_forbidden_domain_code_point(const char c) noexcept {
-    return is_forbidden_host_code_point(c) || std::iscntrl(c) || c == '%' || c == '\x7f';
+   // abort();
+    return is_forbidden_domain_code_point_table[uint8_t(c)];
+    // A table is almost surely much faster than the
+    // following under most compilers: return
+    // is_forbidden_host_code_point(c) |
+    // std::iscntrl(c) | c == '%' | c == '\x7f';
   }
+
+  static_assert(unicode::is_forbidden_domain_code_point('%'));
+  static_assert(unicode::is_forbidden_domain_code_point('\x7f'));
+  static_assert(unicode::is_forbidden_domain_code_point('\0'));
+  static_assert(unicode::is_forbidden_domain_code_point('\t'));
+  static_assert(unicode::is_forbidden_domain_code_point('\n'));
+  static_assert(unicode::is_forbidden_domain_code_point('\r'));
+  static_assert(unicode::is_forbidden_domain_code_point(' '));
+  static_assert(unicode::is_forbidden_domain_code_point('#'));
+  static_assert(unicode::is_forbidden_domain_code_point('/'));
+  static_assert(unicode::is_forbidden_domain_code_point(':'));
+  static_assert(unicode::is_forbidden_domain_code_point('?'));
+  static_assert(unicode::is_forbidden_domain_code_point('@'));
+  static_assert(unicode::is_forbidden_domain_code_point('['));
+  static_assert(unicode::is_forbidden_domain_code_point('?'));
+  static_assert(unicode::is_forbidden_domain_code_point('<'));
+  static_assert(unicode::is_forbidden_domain_code_point('>'));
+  static_assert(unicode::is_forbidden_domain_code_point('\\'));
+  static_assert(unicode::is_forbidden_domain_code_point(']'));
+  static_assert(unicode::is_forbidden_domain_code_point('^'));
+  static_assert(unicode::is_forbidden_domain_code_point('|'));
+
+  constexpr static bool is_alnum_plus_table[] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+  static_assert(sizeof(is_alnum_plus_table) == 256);
+
+  ada_really_inline constexpr bool is_alnum_plus(const char c) noexcept {
+    return is_alnum_plus_table[uint8_t(c)];
+    // A table is almost surely much faster than the
+    // following under most compilers: return
+    // return (std::isalnum(c) || c == '+' || c == '-' || c == '.');
+  }
+  static_assert(unicode::is_alnum_plus('+'));
+  static_assert(unicode::is_alnum_plus('-'));
+  static_assert(unicode::is_alnum_plus('.'));
+  static_assert(unicode::is_alnum_plus('0'));
+  static_assert(unicode::is_alnum_plus('1'));
+  static_assert(unicode::is_alnum_plus('a'));
+  static_assert(unicode::is_alnum_plus('b'));
 
   // An ASCII hex digit is an ASCII upper hex digit or ASCII lower hex digit.
   // An ASCII upper hex digit is an ASCII digit or a code point in the range U+0041 (A) to U+0046 (F), inclusive.
@@ -56,20 +157,16 @@ namespace ada::unicode {
   }
 
   /**
+   * first_percent should be  = input.find('%')
    * Adapted from Node.js
    * https://github.com/nodejs/node/blob/main/src/node_url.cc#L245
    *
    * @see https://encoding.spec.whatwg.org/#utf-8-decode-without-bom
    */
-  std::string percent_decode(const std::string_view input) {
-    // We want to optimize for the case where '%' is not found, then we can just
-    // do a quick copy.
-    size_t first_percent = input.find("%");
+  std::string percent_decode(const std::string_view input, size_t first_percent) {
+    // next line is for safety only, we expect users to avoid calling percent_decode
+    // when first_percent is outside the range.
     if(first_percent == std::string_view::npos) { return std::string(input); }
-    // Most times, the code stopped here.
-    //
-    // General case follows.
-    // Time spent looking for '%' is not wasted.
     std::string dest(input.substr(0, first_percent));
     dest.reserve(input.length());
     const char* pointer = input.begin() + first_percent;

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -149,7 +149,7 @@ bool toascii_encoding() {
     } else if (element.type() == ondemand::json_type::object) {
       ondemand::object object = element.get_object();
       std::string_view input = object["input"];
-      auto output = ada::parser::to_ascii(input, false).value_or("");
+      auto output = ada::parser::to_ascii(input, false, input.find("%")).value_or("");
       auto expected_output = object["output"];
 
       if (expected_output.type() == ondemand::json_type::string) {


### PR DESCRIPTION
This is part of a larger strategy which consists in pulling up some work so that later steps are cheap. Ideally, you'd have an integrated first step which does a bunch of work quickly... identify the location of the first #, check whether it is all ASCII and so forth.

```
GCC12
Linux ip-172-31-33-234 5.15.0-1022-aws #26-Ubuntu SMP Thu Oct 13 12:59:25 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
Main branch:
BasicBench_AdaURL      13879 ns        13800 ns        59962 time/byte=17.0797ns
This PR:
BasicBench_AdaURL       8330 ns         8330 ns        85169 time/byte=10.3091ns
```

Your numbers will vary, especially as the benchmark may vary from one commit to the other, and the 'main branch' is in flux. However, this code is simpler and that alone is a significant gain. We got rid entirely of `std::vector` !!!