### PR TITLE
perf: improve input trimming

### DIFF
--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -55,6 +55,13 @@ namespace ada::checkers {
   bool is_normalized_windows_drive_letter(std::string_view input) noexcept;
   ada_really_inline constexpr bool is_ipv4_number_valid(std::string_view::iterator iterator_start, std::string_view::iterator iterator_end) noexcept;
 
+  ada_really_inline constexpr bool is_next_equals(const std::string_view::iterator start,
+                                              const std::string_view::iterator end,
+                                              const char c);
+  ada_really_inline constexpr bool is_not_next_equals(const std::string_view::iterator start,
+                                              const std::string_view::iterator end,
+                                              const char c);
+
 } // namespace ada::checkers
 
 #endif //ADA_CHECKERS_H

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -79,4 +79,16 @@ namespace ada::checkers {
     return std::all_of(iterator_start, iterator_end, checkers::is_digit);
   }
 
+  ada_really_inline constexpr bool is_next_equals(const std::string_view::iterator start,
+                                              const std::string_view::iterator end,
+                                              const char c) {
+    return (std::distance(start, end) > 0) && (start[1] == c);
+  }
+
+  ada_really_inline constexpr bool is_not_next_equals(const std::string_view::iterator start,
+                                              const std::string_view::iterator end,
+                                              const char c) {
+    return (std::distance(start, end) > 0) && (start[1] != c);
+  }
+
 } // namespace ada::checkers

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -457,20 +457,9 @@ namespace ada::parser {
     std::string_view internal_input{user_input};
 
     // TODO: Find a better way to trim from leading and trailing.
-    std::string_view::iterator pointer_start = std::find_if(internal_input.begin(), internal_input.end(), [](char c) {
-      return !ada::unicode::is_c0_control_or_space(c);
-    });
-    std::string_view::iterator pointer_end = std::find_if(internal_input.rbegin(), internal_input.rend(), [](char c) {
-      return !ada::unicode::is_c0_control_or_space(c);
-    }).base();
-
-    if (pointer_start == pointer_end) {
-      pointer_start = internal_input.begin();
-      pointer_end = internal_input.end();
-    }
-    else if (std::distance(pointer_start, pointer_end) < 0) {
-      pointer_end = internal_input.end();
-    }
+    std::string_view::iterator pointer_start = std::find_if_not(internal_input.begin(), internal_input.end(), ada::unicode::is_c0_control_or_space);
+    if (pointer_start == internal_input.end()) { pointer_start = internal_input.begin(); }
+    std::string_view::iterator pointer_end = std::find_if_not(internal_input.rbegin(), std::make_reverse_iterator(pointer_start), ada::unicode::is_c0_control_or_space).base();
 
     std::string_view url_data(pointer_start, pointer_end - pointer_start);
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -175,7 +175,7 @@ namespace ada::parser {
     // If c is U+003A (:), then:
     if (*pointer == ':') {
       // If remaining does not start with U+003A (:), validation error, return failure.
-      if (std::distance(pointer, input.end()) > 0 && pointer[1] != ':') {
+      if (checkers::is_not_next_equals(pointer, input.end(), ':')) {
         return std::nullopt;
       }
 
@@ -577,7 +577,7 @@ namespace ada::parser {
               state = FILE;
             }
             // Otherwise, if url is special, base is non-null, and base’s scheme is url’s scheme:
-            else if (url.is_special() && base_url.has_value() && base_url->scheme == url.scheme) {
+            else if (url.is_special() && base_url->scheme == url.scheme) {
               // Set state to special relative or authority state.
               state = SPECIAL_RELATIVE_OR_AUTHORITY;
             }
@@ -704,7 +704,7 @@ namespace ada::parser {
         case SPECIAL_RELATIVE_OR_AUTHORITY: {
           // If c is U+002F (/) and remaining starts with U+002F (/),
           // then set state to special authority ignore slashes state and increase pointer by 1.
-          if (*pointer == '/' && std::distance(pointer, pointer_end) > 0 && pointer[1] == '/') {
+          if (*pointer == '/' && checkers::is_next_equals(pointer, pointer_end, '/')) {
             state = SPECIAL_AUTHORITY_IGNORE_SLASHES;
             pointer++;
           }
@@ -805,7 +805,7 @@ namespace ada::parser {
         case SPECIAL_AUTHORITY_SLASHES: {
           // If c is U+002F (/) and remaining starts with U+002F (/),
           // then set state to special authority ignore slashes state and increase pointer by 1.
-          if (*pointer == '/' && std::distance(pointer, pointer_end) > 0 && pointer[1] == '/') {
+          if (*pointer == '/' && checkers::is_next_equals(pointer, pointer_end, '/')) {
             pointer++;
           }
           // Otherwise, validation error, set state to special authority ignore slashes state and decrease pointer by 1.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -529,7 +529,7 @@ namespace ada::parser {
             std::string _buffer = std::string(*scheme_start_pointer, *scheme_end_pointer - *scheme_start_pointer);
 
             if (scheme_needs_lowercase) {
-              // optimization opportunity. W
+              // optimization opportunity. no need to start from beginning, just start from the first uppercase pointer
               std::transform(_buffer.begin(), _buffer.end(), _buffer.begin(),
                 [](char c) -> char { return (uint8_t((c|0x20) - 0x61) <= 25 ? (c|0x20) : c);});
             }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1110,6 +1110,7 @@ namespace ada::parser {
                 if (!checkers::is_windows_drive_letter({pointer, size_t(pointer_end - pointer)})) {
                   std::string first_base_url_path = base_url->path.substr(1, base_url->path.find_first_of('/', 1));
 
+                  // Optimization opportunity: Get rid of initializing a std::string
                   if (checkers::is_normalized_windows_drive_letter(first_base_url_path)) {
                     url.path += "/" + first_base_url_path;
                   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1215,7 +1215,7 @@ namespace ada::parser {
 
               // If the code point substring from pointer to the end of input does not start with a
               // Windows drive letter, then shorten url’s path.
-              if (std::distance(pointer, pointer_end) >= 2 && !checkers::is_windows_drive_letter(std::string(pointer, pointer + 2))) {
+              if (std::distance(pointer, pointer_end) >= 2 && !checkers::is_windows_drive_letter(std::string_view(pointer, 2))) {
                 // Optimization opportunity: shorten_path is maybe not inlined.
                 url.shorten_path();
               }


### PR DESCRIPTION
Before:

```
BasicBench_AdaURL            8234 ns         8233 ns        84999 time/byte=10.1898ns
```

After:

```
BasicBench_AdaURL            8075 ns         8075 ns        86405 time/byte=9.99371ns
```