### PR TITLE
Printing the time per url and the number of urls processed per second.

### DIFF
--- a/benchmarks/bench.cpp
+++ b/benchmarks/bench.cpp
@@ -57,6 +57,9 @@ static void BasicBench_BoostURL(benchmark::State& state) {
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(BasicBench_BoostURL);
 #endif
@@ -81,6 +84,9 @@ static void BasicBench_CURL(benchmark::State& state) {
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(BasicBench_CURL);
 #endif
@@ -100,6 +106,9 @@ static void BasicBench_uriparser(benchmark::State& state) {
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(BasicBench_uriparser);
 
@@ -115,6 +124,9 @@ static void BasicBench_urlparser(benchmark::State& state) {
   }
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
+          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(BasicBench_urlparser);
@@ -132,6 +144,9 @@ static void BasicBench_http_parser(benchmark::State& state) {
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(BasicBench_http_parser);
 
@@ -147,6 +162,9 @@ static void BasicBench_AdaURL(benchmark::State& state) {
   if(!is_valid) { std::cout << "ada: invalid? " << std::endl; }
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
+          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
 }
 BENCHMARK(BasicBench_AdaURL);

--- a/benchmarks/bench.cpp
+++ b/benchmarks/bench.cpp
@@ -60,6 +60,9 @@ static void BasicBench_BoostURL(benchmark::State& state) {
   state.counters["time/url"] = benchmark::Counter(
 	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK(BasicBench_BoostURL);
 #endif
@@ -87,6 +90,9 @@ static void BasicBench_CURL(benchmark::State& state) {
   state.counters["time/url"] = benchmark::Counter(
 	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK(BasicBench_CURL);
 #endif
@@ -109,6 +115,9 @@ static void BasicBench_uriparser(benchmark::State& state) {
   state.counters["time/url"] = benchmark::Counter(
 	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK(BasicBench_uriparser);
 
@@ -128,6 +137,9 @@ static void BasicBench_urlparser(benchmark::State& state) {
   state.counters["time/url"] = benchmark::Counter(
 	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK(BasicBench_urlparser);
 
@@ -147,6 +159,9 @@ static void BasicBench_http_parser(benchmark::State& state) {
   state.counters["time/url"] = benchmark::Counter(
 	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK(BasicBench_http_parser);
 
@@ -166,6 +181,9 @@ static void BasicBench_AdaURL(benchmark::State& state) {
   state.counters["time/url"] = benchmark::Counter(
 	        std::size(url_examples),
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+	        std::size(url_examples),
+          benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK(BasicBench_AdaURL);
 


### PR DESCRIPTION
Self-explanatory.