### PR TITLE
perf: remove std::optional creation for host parsing

### DIFF
--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -8,14 +8,13 @@
 
 namespace ada::checkers {
 
-
   // Assuming that x is an ASCII letter, this returns the lower case equivalent.
   // More likely to be inlined by the compiler and constexpr.
-  constexpr char to_lower(char x) { return (x | 0x20); }
+  constexpr char to_lower(char x) noexcept { return (x | 0x20); }
   // Returns true if the character is an ASCII letter. Equivalent to std::isalpha but
   // more likely to be inlined by the compiler. Also, std::isalpha is not constexpr
   // generally.
-  constexpr bool is_alpha(char x) { return (to_lower(x) >= 'a') & (to_lower(x) <= 'z'); }
+  constexpr bool is_alpha(char x) noexcept { return (to_lower(x) >= 'a') & (to_lower(x) <= 'z'); }
 
   // Check whether a string starts with 0x or 0X. The function is only
   // safe if input.size() >=2. See has_hex_prefix.
@@ -37,29 +36,29 @@ namespace ada::checkers {
   }
 
   // Check whether x is an ASCII digit. More likely to be inlined than std::isdigit.
-  constexpr bool is_digit(char x) { return (x >= '0') & (x <= '9'); }
+  constexpr bool is_digit(char x) noexcept { return (x >= '0') & (x <= '9'); }
 
   // A Windows drive letter is two code points, of which the first is an ASCII alpha
   // and the second is either U+003A (:) or U+007C (|).
-  inline bool is_windows_drive_letter(const std::string_view input) noexcept {
+  inline constexpr bool is_windows_drive_letter(std::string_view input) noexcept {
     return input.size() >= 2 && (is_alpha(input[0]) & ((input[1] == ':') | (input[1] == '|')));
   }
 
   // A normalized Windows drive letter is a Windows drive letter of which the second code point is U+003A (:).
-  inline bool is_normalized_windows_drive_letter(std::string_view input) noexcept {
+  inline constexpr bool is_normalized_windows_drive_letter(std::string_view input) noexcept {
     return input.size() >= 2 && (is_alpha(input[0]) & (input[1] == ':'));
   }
 
   ada_really_inline constexpr bool is_next_equals(const std::string_view::iterator start,
                                                   const std::string_view::iterator end,
-                                                  const char c) {
-    return (std::distance(start, end) > 0) && (start[1] == c);
+                                                  const char c) noexcept {
+    return (start != end) && (start[1] == c);
   }
 
   ada_really_inline constexpr bool is_not_next_equals(const std::string_view::iterator start,
                                                       const std::string_view::iterator end,
-                                                      const char c) {
-    return (std::distance(start, end) > 0) && (start[1] != c);
+                                                      const char c) noexcept {
+    return (start == end) || (start[1] != c);
   }
 
 } // namespace ada::checkers

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -52,13 +52,13 @@ namespace ada::checkers {
   ada_really_inline constexpr bool is_next_equals(const std::string_view::iterator start,
                                                   const std::string_view::iterator end,
                                                   const char c) noexcept {
-    return (start != end) && (start[1] == c);
+    return (std::distance(start, end) > 1) && (start[1] == c);
   }
 
   ada_really_inline constexpr bool is_not_next_equals(const std::string_view::iterator start,
                                                       const std::string_view::iterator end,
                                                       const char c) noexcept {
-    return (start == end) || (start[1] != c);
+    return (std::distance(start, end) > 1) && (start[1] != c);
   }
 
 } // namespace ada::checkers

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -49,16 +49,9 @@ namespace ada::checkers {
     return input.size() >= 2 && (is_alpha(input[0]) & (input[1] == ':'));
   }
 
-  ada_really_inline constexpr bool is_next_equals(const std::string_view::iterator start,
-                                                  const std::string_view::iterator end,
-                                                  const char c) noexcept {
-    return (std::distance(start, end) > 1) && (start[1] == c);
-  }
-
-  ada_really_inline constexpr bool is_not_next_equals(const std::string_view::iterator start,
-                                                      const std::string_view::iterator end,
-                                                      const char c) noexcept {
-    return (std::distance(start, end) > 1) && (start[1] != c);
+  ada_really_inline constexpr bool begins_with(std::string_view view, std::string_view prefix) {
+    // in C++20, you have view.begins_with(prefix)
+    return view.size() >= prefix.size() && (view.substr(0, prefix.size()) == prefix);
   }
 
 } // namespace ada::checkers

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -33,13 +33,13 @@ namespace ada {
                                  std::optional<ada::state> state = std::nullopt) noexcept;
 
   void set_scheme(ada::url &base, std::string input, ada::encoding_type encoding = ada::encoding_type::UTF8) noexcept;
-  void set_username(ada::url &base, std::string input) noexcept;
-  void set_password(ada::url &base, std::string input) noexcept;
+  void set_username(ada::url &base, std::string_view input) noexcept;
+  void set_password(ada::url &base, std::string_view input) noexcept;
   void set_host(ada::url &base, std::string_view input, ada::encoding_type encoding = ada::encoding_type::UTF8) noexcept;
   void set_port(ada::url &base, std::string_view input) noexcept;
-  void set_pathname(ada::url &base, std::string input, ada::encoding_type encoding = ada::encoding_type::UTF8) noexcept;
-  void set_search(ada::url &base, std::string input) noexcept;
-  void set_hash(ada::url &base, std::string input) noexcept;
+  void set_pathname(ada::url &base, std::string_view input, ada::encoding_type encoding = ada::encoding_type::UTF8) noexcept;
+  void set_search(ada::url &base, std::string_view input) noexcept;
+  void set_hash(ada::url &base, std::string_view input) noexcept;
 }
 
 #endif // ADA_IMPLEMENTATION_H

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -12,9 +12,10 @@ namespace ada::parser {
   // first_percent should be  = plain.find('%')
   std::optional<std::string> to_ascii(std::string_view plain, bool be_strict, size_t first_percent);
 
-  std::optional<ada::url_host> parse_opaque_host(std::string_view input);
-  std::optional<ada::url_host> parse_ipv6(std::string_view input);
-  std::optional<ada::url_host> parse_host(std::string_view input, bool is_not_special, bool input_is_ascii);
+  bool parse_opaque_host(std::optional<ada::url_host>& out, std::string_view input);
+  bool parse_ipv6(std::optional<ada::url_host>& out, std::string_view input);
+  bool parse_ipv4(std::optional<ada::url_host>& out, std::string_view input);
+  bool parse_host(std::optional<ada::url_host>& out, std::string_view input, bool is_not_special, bool input_is_ascii);
 
   url parse_url(std::string_view user_input,
                 std::optional<ada::url> base_url = std::nullopt,

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -12,10 +12,10 @@ namespace ada::parser {
   // first_percent should be  = plain.find('%')
   std::optional<std::string> to_ascii(std::string_view plain, bool be_strict, size_t first_percent);
 
-  bool parse_opaque_host(std::optional<ada::url_host>& out, std::string_view input);
-  bool parse_ipv6(std::optional<ada::url_host>& out, std::string_view input);
-  bool parse_ipv4(std::optional<ada::url_host>& out, std::string_view input);
-  bool parse_host(std::optional<ada::url_host>& out, std::string_view input, bool is_not_special, bool input_is_ascii);
+  bool parse_opaque_host(std::optional<std::string>& out, std::string_view input);
+  bool parse_ipv6(std::optional<std::string>& out, std::string_view input);
+  bool parse_ipv4(std::optional<std::string>& out, std::string_view input);
+  bool parse_host(std::optional<std::string>& out, std::string_view input, bool is_not_special, bool input_is_ascii);
 
   url parse_url(std::string_view user_input,
                 std::optional<ada::url> base_url = std::nullopt,

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -13,7 +13,7 @@ namespace ada::unicode {
   ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept;
   ada_really_inline constexpr bool is_ascii_tab_or_newline(const char c) noexcept;
   ada_really_inline constexpr bool is_double_dot_path_segment(const std::string_view input) noexcept;
-  ada_really_inline bool is_single_dot_path_segment(const std::string_view input) noexcept;
+  ada_really_inline constexpr bool is_single_dot_path_segment(const std::string_view input) noexcept;
   ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept;
 
   unsigned constexpr convert_hex_to_binary(char c) noexcept;

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -12,30 +12,6 @@
 namespace ada {
 
   /**
-   * @see https://url.spec.whatwg.org/#host-representation
-   */
-  enum class host_type {
-    BASIC_DOMAIN, // Had to use BASIC_ prefix due to global define in <cmath>
-    IPV6_ADDRESS,
-    IPV4_ADDRESS,
-    OPAQUE_HOST,
-  };
-
-  ada_warn_unused std::string to_string(ada::host_type type);
-
-  /**
-   * @see https://url.spec.whatwg.org/#host-representation
-   */
-  struct url_host {
-
-    ada::host_type type{ada::host_type::BASIC_DOMAIN};
-
-    std::string entry{};
-
-    ada_warn_unused std::string to_string();
-  };
-
-  /**
    * A URL is a struct that represents a universal identifier.
    * To disambiguate from a valid URL string it can also be referred to as a URL record.
    *
@@ -61,7 +37,7 @@ namespace ada {
     /**
      * A URL’s host is null or a host. It is initially null.
      */
-    std::optional<ada::url_host> host{};
+    std::optional<std::string> host{};
 
     /**
      * A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port. It is initially null.
@@ -112,7 +88,7 @@ namespace ada {
      * A URL cannot have a username/password/port if its host is null or the empty string, or its scheme is "file".
      */
     [[nodiscard]] bool cannot_have_credentials_or_port() const {
-      return !host.has_value() || host.value().entry.empty() || scheme == "file";
+      return !host.has_value() || host.value().empty() || scheme == "file";
     }
     /** For development purposes, we want to know when a copy is made. */
     url() = default;

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -74,7 +74,7 @@ namespace ada {
    *
    * @see https://url.spec.whatwg.org/#dom-url-username
    */
-  void set_username(ada::url &base, std::string input) noexcept {
+  void set_username(ada::url &base, std::string_view input) noexcept {
     // If this’s URL cannot have a username/password/port, then return.
     if (base.cannot_have_credentials_or_port()) {
       return;
@@ -83,7 +83,7 @@ namespace ada {
     // Set the username given this’s URL and the given value.
     // To set the username given a url and username, set url’s username to the result of running UTF-8 percent-encode
     // on username using the userinfo percent-encode set.
-    base.username = ada::unicode::percent_encode(std::string_view(input), character_sets::USERINFO_PERCENT_ENCODE);
+    base.username = ada::unicode::percent_encode(input, character_sets::USERINFO_PERCENT_ENCODE);
   }
 
   /**
@@ -91,7 +91,7 @@ namespace ada {
    *
    * @see https://url.spec.whatwg.org/#dom-url-password
    */
-  void set_password(ada::url &base, std::string input) noexcept {
+  void set_password(ada::url &base, std::string_view input) noexcept {
     // If this’s URL cannot have a username/password/port, then return.
     if (base.cannot_have_credentials_or_port()) {
       return;
@@ -100,7 +100,7 @@ namespace ada {
     // Set the username given this’s URL and the given value.
     // To set the password given a url and password, set url’s password to the result of running UTF-8 percent-encode
     // on password using the userinfo percent-encode set.
-    base.password = unicode::percent_encode(std::string_view(input), character_sets::USERINFO_PERCENT_ENCODE);
+    base.password = unicode::percent_encode(input, character_sets::USERINFO_PERCENT_ENCODE);
   }
 
   /**
@@ -182,7 +182,7 @@ namespace ada {
    *
    * @see https://url.spec.whatwg.org/#dom-url-pathname
    */
-  void set_pathname(ada::url& base, std::string input, ada::encoding_type encoding) noexcept {
+  void set_pathname(ada::url& base, std::string_view input, ada::encoding_type encoding) noexcept {
     // If this’s URL has an opaque path, then return.
     if (base.has_opaque_path) {
       return;
@@ -197,7 +197,7 @@ namespace ada {
      * specialize and just call what is needed: a path computation.
      */
     // Basic URL parse the given value with this’s URL as url and path start state as state override.
-    auto result = ada::parser::parse_url(std::move(input), std::nullopt, encoding,
+    auto result = ada::parser::parse_url(input, std::nullopt, encoding,
 #if ADA_DEVELOP_MODE
       base.oh_no_we_need_to_copy_url(),
 #else
@@ -215,7 +215,7 @@ namespace ada {
   /**
    * @see https://url.spec.whatwg.org/#dom-url-search
    */
-  void set_search(ada::url &base, std::string input) noexcept {
+  void set_search(ada::url &base, std::string_view input) noexcept {
     // If the given value is the empty string:
     if (input.empty()) {
       // Set url’s query to null.
@@ -229,7 +229,8 @@ namespace ada {
       return;
     }
 
-    auto new_value = input[0] == '?' ? input.substr(1) : input;
+    std::string new_value;
+    new_value = input[0] == '?' ? input.substr(1) : input;
     helpers::remove_ascii_tab_or_newline(new_value);
 
     auto query_percent_encode_set = base.is_special() ?
@@ -247,7 +248,7 @@ namespace ada {
   /**
    * @see https://url.spec.whatwg.org/#dom-url-hash
    */
-  void set_hash(ada::url &base, std::string input) noexcept {
+  void set_hash(ada::url &base, std::string_view input) noexcept {
     // If the given value is the empty string:
     if (input.empty()) {
       // Set this’s URL’s fragment to null
@@ -259,7 +260,8 @@ namespace ada {
     }
 
     // Let input be the given value with a single leading U+0023 (#) removed, if any.
-    auto new_value = input[0] == '#' ? input.substr(1) : input;
+    std::string new_value;
+    new_value = input[0] == '#' ? input.substr(1) : input;
     helpers::remove_ascii_tab_or_newline(new_value);
 
     // Set this’s URL’s fragment to the empty string.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -163,6 +163,10 @@ namespace ada::parser {
    * @see https://url.spec.whatwg.org/#concept-ipv6-parser
    */
   bool parse_ipv6(std::optional<std::string>& out, std::string_view input) {
+  #if ADA_DEVELOP_MODE
+    // prove that this is not necessary:
+    if(input.empty()) { return false; }
+  #endif
     // Let address be a new IPv6 address whose IPv6 pieces are all 0.
     std::array<uint16_t, 8> address{};
 
@@ -176,9 +180,9 @@ namespace ada::parser {
     std::string_view::iterator pointer = input.begin();
 
     // If c is U+003A (:), then:
-    if (*pointer == ':') {
+    if (input[0] == ':') {
       // If remaining does not start with U+003A (:), validation error, return failure.
-      if (checkers::is_not_next_equals(pointer, input.end(), ':')) {
+      if(input.size() == 1 && input[2] != ':') {
         return false;
       }
 
@@ -717,7 +721,8 @@ namespace ada::parser {
           // If c is U+002F (/) and remaining starts with U+002F (/),
           // then set state to special authority ignore slashes state and increase pointer by 1.
           // Note: we cannot access *pointer safely if (pointer == pointer_end).
-          if ((pointer != pointer_end) && (*pointer == '/') && checkers::is_next_equals(pointer, pointer_end, '/')) {
+          std::string_view view (pointer, size_t(pointer_end-pointer));
+          if (ada::checkers::begins_with(view, "//")) {
             state = ada::state::SPECIAL_AUTHORITY_IGNORE_SLASHES;
             pointer++;
           }
@@ -835,7 +840,8 @@ namespace ada::parser {
           // If c is U+002F (/) and remaining starts with U+002F (/),
           // then set state to special authority ignore slashes state and increase pointer by 1.
           // Note: we cannot access *pointer safely if (pointer == pointer_end).
-          if ((pointer != pointer_end) && (*pointer == '/') && checkers::is_next_equals(pointer, pointer_end, '/')) {
+           std::string_view view (pointer, size_t(pointer_end-pointer));
+          if (ada::checkers::begins_with(view, "//")) {
             pointer++;
           }
           // Otherwise, validation error, set state to special authority ignore slashes state and decrease pointer by 1.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -471,14 +471,10 @@ namespace ada::parser {
 
     std::string_view url_data(pointer_start, pointer_end - pointer_start);
 
-    // This is required for pathname state override.
-    // '#' character is included in the pathname.
-    if (!state_override.has_value()) {
-      std::optional<std::string_view> result = helpers::prune_fragment(url_data);
-      if(result.has_value()) {
-        url.fragment = unicode::percent_encode(*result,
-                                               ada::character_sets::FRAGMENT_PERCENT_ENCODE);
-      }
+    std::optional<std::string_view> fragment = helpers::prune_fragment(url_data);
+    if(fragment.has_value()) {
+      url.fragment = unicode::percent_encode(*fragment,
+                                             ada::character_sets::FRAGMENT_PERCENT_ENCODE);
     }
 
     // Here url_data no longer has its fragment.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -469,6 +469,7 @@ namespace ada::parser {
 
     std::string_view url_data(pointer_start, pointer_end - pointer_start);
 
+    // Optimization opportunity. Most websites does not have fragment.
     std::optional<std::string_view> fragment = helpers::prune_fragment(url_data);
     if(fragment.has_value()) {
       url.fragment = unicode::percent_encode(*fragment,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1000,7 +1000,7 @@ namespace ada::parser {
             state = ada::state::PATH;
 
             // If c is neither U+002F (/) nor U+005C (\), then decrease pointer by 1.
-            if (*pointer != '/' && *pointer != '\\') {
+            if ((pointer == pointer_end) || ((*pointer != '/') && (*pointer != '\\'))) {
               pointer--;
             }
           }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -454,7 +454,7 @@ namespace ada::parser {
 
     std::string tmp_buffer;
     std::string_view internal_input;
-    if(std::any_of(user_input.begin(),user_input.end(),ada::unicode::is_ascii_tab_or_newline)) {
+    if(std::any_of(user_input.begin(), user_input.end(), ada::unicode::is_ascii_tab_or_newline)) {
       tmp_buffer = user_input;
       // Optimization opportunity: Instead of copying and then pruning, we could just directly
       // build the string from user_input.
@@ -498,9 +498,6 @@ namespace ada::parser {
     // Let pointer be a pointer for input.
     std::string_view::iterator pointer = pointer_start;
 
-    /** An std::optional<> has overhead, so let us record directly the iterator: */
-    const std::string_view::iterator start_pointer{pointer}; /* we record the beginning of the URL which is a potential starting point for the scheme. */
-
     // Keep running the following state machine by switching on state.
     // If after a run pointer points to the EOF code point, go to the next step.
     // Otherwise, increase pointer by 1 and continue with the state machine.
@@ -522,15 +519,11 @@ namespace ada::parser {
             pointer--;
           }
           // Otherwise, if state override is not given, set state to no scheme state and decrease pointer by 1.
-          else if (!state_override.has_value()) {
+          else {
             state = ada::state::NO_SCHEME;
             pointer--;
           }
-          // Otherwise, validation error, return failure.
-          else {
-            url.is_valid = false;
-            return url;
-          }
+
           break;
         }
         case ada::state::SCHEME: {
@@ -544,7 +537,7 @@ namespace ada::parser {
             // Instead of copying and then changing the case,
             // we could directly append lower-cased to the string, thus doing one pass.
             std::string _buffer;
-            std::transform(start_pointer, pointer, std::back_inserter(_buffer),
+            std::transform(pointer_start, pointer, std::back_inserter(_buffer),
                 [](char c) -> char { return (uint8_t((c|0x20) - 0x61) <= 25 ? (c|0x20) : c);});
 
             // If state override is given, then:

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -661,16 +661,20 @@ namespace ada::parser {
             // If c is U+0040 (@), then:
             // Note: we cannot access *pointer safely if (pointer == pointer_end).
             if ((pointer != pointer_end) && (*pointer == '@')) {
-              std::string authority_buffer(authority_view); // TODO: We don't need to allocate a new string.
               // If atSignSeen is true, then prepend "%40" to buffer.
               if (at_sign_seen) {
-                authority_buffer.insert(0, "%40"); // TODO: avoid inserting a prefix, as it is more expensive.
+                if (password_token_seen) {
+                  url.password += "%40";
+                } else {
+                  url.username += "%40";
+                }
               }
 
               // Set atSignSeen to true.
               at_sign_seen = true;
+
               // For each codePoint in authority_buffer:
-              for (auto code_point: authority_buffer) {
+              for (auto code_point: authority_view) {
                 // If codePoint is U+003A (:) and passwordTokenSeen is false, then set passwordTokenSeen to true and continue.
                 if (code_point == ':' && !password_token_seen) {
                   password_token_seen = true;

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -181,7 +181,7 @@ namespace ada::unicode {
 
 
   // A single-dot path segment must be "." or an ASCII case-insensitive match for "%2e".
-  ada_really_inline bool is_single_dot_path_segment(std::string_view input) noexcept {
+  ada_really_inline constexpr bool is_single_dot_path_segment(std::string_view input) noexcept {
     return input == "." || input == "%2e" || input == "%2E";
   }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -3,20 +3,6 @@
 
 namespace ada {
 
-  ada_warn_unused std::string to_string(ada::host_type type) {
-    switch(type) {
-    case ada::host_type::BASIC_DOMAIN : return "basic";
-    case ada::host_type::IPV6_ADDRESS : return "ipv6";
-    case ada::host_type::IPV4_ADDRESS : return "ipv4";
-    case ada::host_type::OPAQUE_HOST : return "opaque";
-    default: unreachable();
-    }
-  }
-
-  ada_warn_unused std::string url_host::to_string() {
-    return "{\"type\":\"" + ada::to_string(type) + "\",\"entry\":\"" + entry + "\"}";
-  }
-
   ada_really_inline uint16_t url::scheme_default_port() const {
     return scheme::get_special_port(scheme);
   }
@@ -33,7 +19,7 @@ namespace ada {
     return "{\"scheme\":\"" + scheme + "\"" + ","
          + "\"username\":\"" + username + "\"" + "," + "\"password\":\"" +
          password + "\"" + "," +
-         (host.has_value() ? "\"host\":\"" + host.value().to_string() + "\"" + "," : "") +
+         (host.has_value() ? "\"host\":\"" + host.value() + "\"" + "," : "") +
          (port.has_value() ? "\"port\":" + std::to_string(port.value()) + "" + ","
                          : "") +
          "\"path\":\"" + path + "\"" +

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -157,7 +157,7 @@ bool setters_tests_encoding() {
         // TODO: Handle invalid utf-8 tests too.
         if (!element["expected"]["hostname"].get(expected)) {
           ada::set_host(base, std::string{new_value});
-          TEST_ASSERT(base.host.value_or(ada::url_host{ada::host_type::BASIC_DOMAIN, ""}).entry, expected, "Hostname");
+          TEST_ASSERT(base.host.value_or(""), expected, "Hostname");
         }
       }
       else if (category == "port") {
@@ -267,7 +267,7 @@ bool urltestdata_encoding() {
         TEST_ASSERT(input_url.password, password, "Password");
 
         std::string_view hostname = object["hostname"];
-        TEST_ASSERT(input_url.host.value_or(ada::url_host{ada::host_type::BASIC_DOMAIN, ""}).entry, hostname, "Hostname");
+        TEST_ASSERT(input_url.host.value_or(""), hostname, "Hostname");
 
         std::string_view port = object["port"];
         std::string expected_port = (input_url.port.has_value()) ? std::to_string(input_url.port.value()) : "";


### PR DESCRIPTION
improves parsing by around ~0.32ns per byte.

before

```
BasicBench_AdaURL       5097 ns         5093 ns       104205 time/byte=6.20336ns time/url=463.01ns url/s=2.15978M/s
```

after

```
BasicBench_AdaURL       4775 ns         4775 ns       107061 time/byte=5.90992ns time/url=434.11ns url/s=2.30356M/s
```