### PR TITLE
perf remove optional creation

### DIFF
--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -49,16 +49,9 @@ namespace ada::checkers {
     return input.size() >= 2 && (is_alpha(input[0]) & (input[1] == ':'));
   }
 
-  ada_really_inline constexpr bool is_next_equals(const std::string_view::iterator start,
-                                                  const std::string_view::iterator end,
-                                                  const char c) noexcept {
-    return (std::distance(start, end) > 1) && (start[1] == c);
-  }
-
-  ada_really_inline constexpr bool is_not_next_equals(const std::string_view::iterator start,
-                                                      const std::string_view::iterator end,
-                                                      const char c) noexcept {
-    return (std::distance(start, end) > 1) && (start[1] != c);
+  ada_really_inline constexpr bool begins_with(std::string_view view, std::string_view prefix) {
+    // in C++20, you have view.begins_with(prefix)
+    return view.size() >= prefix.size() && (view.substr(0, prefix.size()) == prefix);
   }
 
 } // namespace ada::checkers

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -163,6 +163,10 @@ namespace ada::parser {
    * @see https://url.spec.whatwg.org/#concept-ipv6-parser
    */
   bool parse_ipv6(std::optional<std::string>& out, std::string_view input) {
+  #if ADA_DEVELOP_MODE
+    // prove that this is not necessary:
+    if(input.empty()) { return false; }
+  #endif
     // Let address be a new IPv6 address whose IPv6 pieces are all 0.
     std::array<uint16_t, 8> address{};
 
@@ -176,9 +180,9 @@ namespace ada::parser {
     std::string_view::iterator pointer = input.begin();
 
     // If c is U+003A (:), then:
-    if (*pointer == ':') {
+    if (input[0] == ':') {
       // If remaining does not start with U+003A (:), validation error, return failure.
-      if (checkers::is_not_next_equals(pointer, input.end(), ':')) {
+      if(input.size() == 1 && input[2] != ':') {
         return false;
       }
 
@@ -717,7 +721,8 @@ namespace ada::parser {
           // If c is U+002F (/) and remaining starts with U+002F (/),
           // then set state to special authority ignore slashes state and increase pointer by 1.
           // Note: we cannot access *pointer safely if (pointer == pointer_end).
-          if ((pointer != pointer_end) && (*pointer == '/') && checkers::is_next_equals(pointer, pointer_end, '/')) {
+          std::string_view view (pointer, size_t(pointer_end-pointer));
+          if (ada::checkers::begins_with(view, "//")) {
             state = ada::state::SPECIAL_AUTHORITY_IGNORE_SLASHES;
             pointer++;
           }
@@ -835,7 +840,8 @@ namespace ada::parser {
           // If c is U+002F (/) and remaining starts with U+002F (/),
           // then set state to special authority ignore slashes state and increase pointer by 1.
           // Note: we cannot access *pointer safely if (pointer == pointer_end).
-          if ((pointer != pointer_end) && (*pointer == '/') && checkers::is_next_equals(pointer, pointer_end, '/')) {
+           std::string_view view (pointer, size_t(pointer_end-pointer));
+          if (ada::checkers::begins_with(view, "//")) {
             pointer++;
           }
           // Otherwise, validation error, set state to special authority ignore slashes state and decrease pointer by 1.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1000,7 +1000,7 @@ namespace ada::parser {
             state = ada::state::PATH;
 
             // If c is neither U+002F (/) nor U+005C (\), then decrease pointer by 1.
-            if (*pointer != '/' && *pointer != '\\') {
+            if ((pointer == pointer_end) || ((*pointer != '/') && (*pointer != '\\'))) {
               pointer--;
             }
           }


### PR DESCRIPTION
This is a PR for perf-remove-optional-creation.

Basically, we just need `std::string_view::begins_with` but that's C++20. However, we can roll our own.

Performance...

```
This PR:
BasicBench_AdaURL       5304 ns         5304 ns       131773 time/byte=6.56434ns time/url=482.181ns url/s=2.07391M/s
perf remove optional creation:
BasicBench_AdaURL       5373 ns         5372 ns       129493 time/byte=6.64898ns time/url=488.398ns url/s=2.04751M/s
Main branch:
BasicBench_AdaURL       5805 ns         5804 ns       120171 time/byte=7.18339ns time/url=527.653ns url/s=1.89519M/s
```