### PR TITLE
refactor: apply recommendations for to_ascii

### DIFF
--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -10,7 +10,7 @@
 
 namespace ada::parser {
   // first_percent should be  = plain.find('%')
-  bool to_ascii(std::optional<std::string>& out, std::string_view plain, bool be_strict, size_t first_percent);
+  std::optional<std::string> to_ascii(std::string_view plain, bool be_strict, size_t first_percent);
 
   bool parse_opaque_host(std::optional<std::string>& out, std::string_view input);
   bool parse_ipv6(std::optional<std::string>& out, std::string_view input);

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -25,7 +25,7 @@ namespace ada::unicode {
   std::string percent_decode(const std::string_view input, size_t first_percent);
   std::string percent_encode(const std::string_view input, const uint8_t character_set[]);
   void percent_encode_character(const char input, const uint8_t character_set[], std::string& out);
-  ada_really_inline bool to_lower_ascii_string(std::optional<std::string>& out, size_t first_percent) noexcept;
+  ada_really_inline void to_lower_ascii_string(std::optional<std::string>& out, size_t first_percent) noexcept;
 
 } // namespace ada::unicode
 

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -286,19 +286,19 @@ namespace ada::unicode {
   // This function attemps to convert an ASCII string to a lower-case version.
   // Once the lower cased version has been materialized, we check for the presence
   // of the substring 'xn-', if it is found (unlikely), we then call the expensive 'to_ascii'.
-  ada_really_inline bool to_lower_ascii_string(std::optional<std::string>& out, size_t first_percent) noexcept {
-#if ADA_DEVELOP_MODE
-    if(!out.has_value()) { abort(); }
-#endif
-    if(std::any_of(out.value().begin(), out.value().end(), ada::unicode::is_forbidden_domain_code_point)) { return false; }
+  ada_really_inline void to_lower_ascii_string(std::optional<std::string>& out, size_t first_percent) noexcept {
+    if(std::any_of(out.value().begin(), out.value().end(), ada::unicode::is_forbidden_domain_code_point)) {
+      out = std::nullopt;
+      return;
+    }
     std::transform(out.value().begin(), out.value().end(), out.value().begin(), [](char c) -> char {
       return (uint8_t((c|0x20) - 0x61) <= 25 ? (c|0x20) : c);}
     );
     if (out.value().find("xn-") == std::string_view::npos) {
-      return true;
+      return;
     }
 
-    return ada::parser::to_ascii(out, out.value(), false, first_percent);
+    out = ada::parser::to_ascii(out.value(), false, first_percent);
   }
 
 } // namespace ada::unicode

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -203,8 +203,7 @@ bool toascii_encoding() {
     } else if (element.type() == ondemand::json_type::object) {
       ondemand::object object = element.get_object();
       std::string_view input = object["input"];
-      std::optional<std::string> output;
-      ada::parser::to_ascii(output, input, false, input.find('%'));
+      std::optional<std::string> output = ada::parser::to_ascii(input, false, input.find('%'));
       auto expected_output = object["output"];
 
       if (expected_output.type() == ondemand::json_type::string) {


### PR DESCRIPTION
Applied recommendations for internal testing:

- This branch

```
BasicBench_AdaURL       4678 ns         4675 ns       149984 time/byte=5.78642ns time/url=425.039ns url/s=2.35273M/s
```

- Previous pull request

```
BasicBench_AdaURL       4499 ns         4498 ns       112609 time/byte=5.56744ns time/url=408.954ns url/s=2.44526M/s
```

- Main

```
BasicBench_AdaURL       4825 ns         4824 ns       106667 time/byte=5.97064ns time/url=438.571ns url/s=2.28014M/s
```