### PR TITLE
Mostly this avoids constructing the 'scheme' string in most cases

### DIFF
--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -191,7 +191,8 @@ namespace ada {
     }
 
     /**
-     * Take the scheme from another URL.
+     * Take the scheme from another URL. The scheme string is moved from the
+     * provided url.
      */
     void copy_scheme(ada::url&& u) {
       non_special_scheme = u.non_special_scheme;
@@ -199,7 +200,8 @@ namespace ada {
     }
 
     /**
-     * Take the scheme from another URL.
+     * Take the scheme from another URL. The scheme string is copied from the
+     * provided url.
      */
     void copy_scheme(const ada::url& u) {
       non_special_scheme = u.non_special_scheme;
@@ -270,6 +272,9 @@ namespace ada {
      * URL for further processing after parsing. It is initially the empty string.
      * We only set non_special_scheme when the scheme is non-special, otherwise we avoid constructing
      * string.
+     *
+     * Special schemes are stored in ada::scheme::details::is_special_list so we typically do not need
+     * to store them in each url instance.
      */
     std::string non_special_scheme{};
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -62,7 +62,7 @@ namespace ada {
     std::string::iterator pointer = std::find_if_not(input.begin(), input.end(), unicode::is_alnum_plus);
 
     if (pointer != input.end() && *pointer == ':') {
-      return base.parse_scheme(std::string_view(input.data(), pointer - input.begin()), true);
+      return base.parse_scheme<true>(std::string_view(input.data(), pointer - input.begin()));
     }
 
     return false;

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -152,7 +152,7 @@ bool setters_tests_encoding() {
       if (category == "protocol") {
         std::string_view expected = element["expected"]["protocol"];
         ada::set_scheme(base, std::string{new_value});
-        TEST_ASSERT(base.get_scheme() + ":", expected, "Protocol");
+        TEST_ASSERT(std::string(base.get_scheme()) + ":", expected, "Protocol");
       }
       else if (category == "username") {
         std::string_view expected = element["expected"]["username"];


### PR DESCRIPTION
It is only present if the input string is not special.