### PR TITLE
feat: adding perf counters

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -2,11 +2,13 @@
 add_executable(bench bench.cpp)
 target_link_libraries(bench PRIVATE ada)
 target_include_directories(bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
 
 
 add_executable(bbc_bench bbc_bench.cpp)
 target_link_libraries(bbc_bench PRIVATE ada)
 target_include_directories(bbc_bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(bbc_bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
 
 
 include(${PROJECT_SOURCE_DIR}/cmake/import.cmake)

--- a/benchmarks/benchmark_header.h
+++ b/benchmarks/benchmark_header.h
@@ -5,5 +5,8 @@
 #include <http_parser.h>
 
 #include "ada.h"
+#include "performancecounters/event_counter.h"
+event_collector collector;
+size_t N = 1000;
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -2,19 +2,42 @@
 #if BOOST_ENABLED
 #include <boost/url/src.hpp>
 using namespace boost::urls;
-
+/** Boost URL does some lazy parsing. **/
 static void BasicBench_BoostURL(benchmark::State& state) {
   // volatile to prevent optimizations.
   volatile size_t numbers_of_parameters = 0;
-
+  event_aggregate aggregate{};
   for (auto _ : state) {
+    collector.start();
     for(std::string& url_string : url_examples) {
         url_view uv(url_string);
         numbers_of_parameters += uv.params().size();
+        // TODO: use the content.
     }
+    event_count allocate_count = collector.end();
+    aggregate << allocate_count;
+  }
+  if(collector.has_events()) {
+    
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : url_examples) {
+        url_view uv(url_string);
+        numbers_of_parameters += uv.params().size();
+        // TODO: use the content.
+      }
+      std::atomic_thread_fence(std::memory_order_release);  
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }  
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / url_examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
   }
   (void)numbers_of_parameters;
-
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
@@ -37,14 +60,32 @@ static void BasicBench_CURL(benchmark::State& state) {
   volatile bool is_valid{true};
   CURLU *url = curl_url();
   for (auto _ : state) {
+    collector.start();
     for(std::string& url_string : url_examples) {
       CURLUcode rc = curl_url_set(url, CURLUPART_URL, url_string.c_str(), 0);
       if(rc) { is_valid = false; }
     }
   }
+  if(collector.has_events()) {
+    
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : url_examples) {
+        CURLUcode rc = curl_url_set(url, CURLUPART_URL, url_string.c_str(), 0);
+        if(rc) { is_valid = false; }
+      }
+      std::atomic_thread_fence(std::memory_order_release);   
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }  
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / url_examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
   curl_url_cleanup(url);
-
-
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
@@ -68,8 +109,27 @@ static void BasicBench_uriparser(benchmark::State& state) {
         is_valid &= (uriParseSingleUriA(&uri, url_string.c_str(), &errorPos) == URI_SUCCESS);
     }
   }
-  uriFreeUriMembersA(&uri);
   if(!is_valid) { std::cout << "uri-parser: invalid? " << std::endl; }
+  if(collector.has_events()) {
+    
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : url_examples) {
+        is_valid &= (uriParseSingleUriA(&uri, url_string.c_str(), &errorPos) == URI_SUCCESS);
+      }
+      std::atomic_thread_fence(std::memory_order_release);   
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / url_examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+   uriFreeUriMembersA(&uri);
+
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
@@ -85,12 +145,30 @@ BENCHMARK(BasicBench_uriparser);
 
 static void BasicBench_urlparser(benchmark::State& state) {
   // volatile to prevent optimizations.
-  const char * errorPos;
   for (auto _ : state) {
     for(std::string& url_string : url_examples) {
       std::unique_ptr<EdUrlParser> url(EdUrlParser::parseUrl(url_string));
     }
   }
+  if(collector.has_events()) {
+    
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : url_examples) {
+        std::unique_ptr<EdUrlParser> url(EdUrlParser::parseUrl(url_string));
+      }
+      std::atomic_thread_fence(std::memory_order_release);   
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / url_examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
           benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
@@ -112,6 +190,25 @@ static void BasicBench_http_parser(benchmark::State& state) {
       is_valid &= !http_parser_parse_url(url_string.data(), url_string.size(), 0, &u);
     }
   }
+  if(collector.has_events()) {
+    
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : url_examples) {
+        is_valid &= !http_parser_parse_url(url_string.data(), url_string.size(), 0, &u);
+      }
+      std::atomic_thread_fence(std::memory_order_release);   
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / url_examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+
   if(!is_valid) { std::cout << "http_parser: invalid? " << std::endl; }
   state.counters["time/byte"] = benchmark::Counter(
 	        url_examples_bytes,
@@ -128,11 +225,31 @@ BENCHMARK(BasicBench_http_parser);
 static void BasicBench_AdaURL(benchmark::State& state) {
   // volatile to prevent optimizations.
   volatile bool is_valid = true;
+
   for (auto _ : state) {
     for(std::string& url_string : url_examples) {
+      auto url = ada::parser::parse_url(url_string, std::nullopt);
+      is_valid &= url.is_valid;
+    }
+  }
+  if(collector.has_events()) {
+    
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : url_examples) {
         auto url = ada::parser::parse_url(url_string, std::nullopt);
         is_valid &= url.is_valid;
+      }
+      std::atomic_thread_fence(std::memory_order_release); 
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
     }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / url_examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
   }
   if(!is_valid) { std::cout << "ada: invalid? " << std::endl; }
   state.counters["time/byte"] = benchmark::Counter(
@@ -148,29 +265,6 @@ static void BasicBench_AdaURL(benchmark::State& state) {
 BENCHMARK(BasicBench_AdaURL);
 
 
-static void BasicBench_AdaURLJustInstantion(benchmark::State& state) {
-  // volatile to prevent optimizations.
-  volatile size_t count = 0;
-  for (auto _ : state) {
-    std::vector<ada::url> container;
-    // We want to measure the cost of just creating the URL instances.
-    for(std::string& url_string : url_examples) {
-      container.emplace_back(ada::url());
-    }
-    count += container.size();
-  }
-  state.counters["time/byte"] = benchmark::Counter(
-	        url_examples_bytes,
-          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
-  state.counters["time/url"] = benchmark::Counter(
-	        std::size(url_examples),
-          benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
-  state.counters["url/s"] = benchmark::Counter(
-	        std::size(url_examples),
-          benchmark::Counter::kIsIterationInvariantRate);
-}
-BENCHMARK(BasicBench_AdaURLJustInstantion);
-
 
 int main(int argc, char **argv) {
 #if CURL_ENABLED
@@ -182,6 +276,21 @@ int main(int argc, char **argv) {
 #if !BOOST_ENABLED
     benchmark::AddCustomContext("boost ", "OMITTED");
 #endif
+#if (__APPLE__ &&  __aarch64__) || defined(__linux__)
+    if(!collector.has_events()) {
+      benchmark::AddCustomContext("performance counters", "No privileged access (sudo may help).");
+    }
+#else
+    if(!collector.has_events()) {
+      benchmark::AddCustomContext("performance counters", "Unsupported system.");
+    }
+#endif
+    if(collector.has_events()) {
+      benchmark::AddCustomContext("performance counters", "Enabled");
+      if(url_examples_bytes < 1000) {
+        benchmark::AddCustomContext("Warning", "URL volume too small for accurate counters");
+      }
+    }
     benchmark::Initialize(&argc, argv);
     benchmark::RunSpecifiedBenchmarks();
     benchmark::Shutdown();

--- a/benchmarks/performancecounters/apple_arm_events.h
+++ b/benchmarks/performancecounters/apple_arm_events.h
@@ -1,0 +1,228 @@
+/*
+ * From:
+ * Duc Tri Nguyen (CERG GMU)
+ * Modified from M1:
+ * https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155#file-m1_robsize-c-L390
+ *
+ * Adapted by D. Lemire
+ */
+#ifndef M1CYCLES_H
+#define M1CYCLES_H
+
+#include <cstdint>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct performance_counters {
+  double cycles;
+  double cachemiss;
+  double missed_branches;
+  double instructions;
+  performance_counters(uint64_t c, uint64_t b, uint64_t m, uint64_t i)
+      : cycles(c), cachemiss(b), missed_branches(m), instructions(i) {}
+  performance_counters(double c, double b, double m, double i)
+      : cycles(c), cachemiss(b), missed_branches(m), instructions(i) {}
+  performance_counters(double init)
+      : cycles(init), cachemiss(init), missed_branches(init),
+        instructions(init) {}
+
+  inline performance_counters &operator-=(const performance_counters &other) {
+    cycles -= other.cycles;
+    cachemiss -= other.cachemiss;
+    missed_branches -= other.missed_branches;
+    instructions -= other.instructions;
+    return *this;
+  }
+  inline performance_counters &min(const performance_counters &other) {
+    cycles = other.cycles < cycles ? other.cycles : cycles;
+    cachemiss = other.cachemiss < cachemiss ? other.cachemiss : cachemiss;
+    missed_branches = other.missed_branches < missed_branches
+                          ? other.missed_branches
+                          : missed_branches;
+    instructions =
+        other.instructions < instructions ? other.instructions : instructions;
+    return *this;
+  }
+  inline performance_counters &operator+=(const performance_counters &other) {
+    cycles += other.cycles;
+    cachemiss += other.cachemiss;
+    missed_branches += other.missed_branches;
+    instructions += other.instructions;
+    return *this;
+  }
+
+  inline performance_counters &operator/=(double numerator) {
+    cycles /= numerator;
+    cachemiss /= numerator;
+    missed_branches /= numerator;
+    instructions /= numerator;
+    return *this;
+  }
+};
+
+inline performance_counters operator-(const performance_counters &a,
+                                      const performance_counters &b) {
+  return performance_counters(a.cycles - b.cycles, a.cachemiss - b.cachemiss,
+                              a.missed_branches - b.missed_branches,
+                              a.instructions - b.instructions);
+}
+
+inline bool setup_performance_counters();
+
+
+#define KPERF_LIST                                                             \
+  /*  ret, name, params */                                                     \
+  F(int, kpc_get_counting, void)                                               \
+  F(int, kpc_force_all_ctrs_set, int)                                          \
+  F(int, kpc_set_counting, uint32_t)                                           \
+  F(int, kpc_set_thread_counting, uint32_t)                                    \
+  F(int, kpc_set_config, uint32_t, void *)                                     \
+  F(int, kpc_get_config, uint32_t, void *)                                     \
+  F(int, kpc_set_period, uint32_t, void *)                                     \
+  F(int, kpc_get_period, uint32_t, void *)                                     \
+  F(uint32_t, kpc_get_counter_count, uint32_t)                                 \
+  F(uint32_t, kpc_get_config_count, uint32_t)                                  \
+  F(int, kperf_sample_get, int *)                                              \
+  F(int, kpc_get_thread_counters, int, unsigned int, void *)
+
+#define F(ret, name, ...)                                                      \
+  typedef ret name##proc(__VA_ARGS__);                                         \
+  static name##proc *name;
+KPERF_LIST
+#undef F
+
+#define CFGWORD_EL0A32EN_MASK (0x10000)
+#define CFGWORD_EL0A64EN_MASK (0x20000)
+#define CFGWORD_EL1EN_MASK (0x40000)
+#define CFGWORD_EL3EN_MASK (0x80000)
+#define CFGWORD_ALLMODES_MASK (0xf0000)
+
+#define CPMU_NONE 0
+#define CPMU_CORE_CYCLE 0x02
+#define CPMU_INST_A64 0x8c
+#define CPMU_INST_BRANCH 0x8d
+#define CPMU_SYNC_DC_LOAD_MISS 0xbf
+#define CPMU_SYNC_DC_STORE_MISS 0xc0
+#define CPMU_SYNC_DTLB_MISS 0xc1
+#define CPMU_SYNC_ST_HIT_YNGR_LD 0xc4
+#define CPMU_SYNC_BR_ANY_MISP 0xcb
+#define CPMU_FED_IC_MISS_DEM 0xd3
+#define CPMU_FED_ITLB_MISS 0xd4
+
+#define KPC_CLASS_FIXED (0)
+#define KPC_CLASS_CONFIGURABLE (1)
+#define KPC_CLASS_POWER (2)
+#define KPC_CLASS_RAWPMU (3)
+#define KPC_CLASS_FIXED_MASK (1u << KPC_CLASS_FIXED)
+#define KPC_CLASS_CONFIGURABLE_MASK (1u << KPC_CLASS_CONFIGURABLE)
+#define KPC_CLASS_POWER_MASK (1u << KPC_CLASS_POWER)
+#define KPC_CLASS_RAWPMU_MASK (1u << KPC_CLASS_RAWPMU)
+
+#define COUNTERS_COUNT 10
+#define CONFIG_COUNT 8
+#define KPC_MASK (KPC_CLASS_CONFIGURABLE_MASK | KPC_CLASS_FIXED_MASK)
+static uint64_t g_counters[COUNTERS_COUNT];
+static uint64_t g_config[COUNTERS_COUNT];
+
+static bool configure_rdtsc() {
+  static bool init = false;
+  static bool worked = false;
+
+  if(init) { return worked; }
+  init = true;
+  if (kpc_set_config(KPC_MASK, g_config)) {
+    printf("kpc_set_config failed, run the program with sudo\n");
+    return false;
+  }
+
+  if (kpc_force_all_ctrs_set(1)) {
+    printf("kpc_force_all_ctrs_set failed\n");
+    return false;
+  }
+
+  if (kpc_set_counting(KPC_MASK)) {
+    printf("kpc_set_counting failed\n");
+    return false;
+  }
+
+  if (kpc_set_thread_counting(KPC_MASK)) {
+    printf("kpc_set_thread_counting failed\n");
+    return false;
+  }
+  worked = true;
+  return true;
+}
+
+static bool init_rdtsc() {
+  static bool init = false;
+  static bool worked = false;
+
+  if(init) { return worked; }
+  init = true;
+  void *kperf = dlopen(
+      "/System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf",
+      RTLD_LAZY);
+  if (!kperf) {
+    printf("kperf = %p\n", kperf);
+    return false;
+  }
+#define F(ret, name, ...)                                                      \
+  name = (name##proc *)(dlsym(kperf, #name));                                  \
+  if (!name) {                                                                 \
+    printf("%s = %p\n", #name, (void *)name);                                  \
+    return false;                                                                    \
+  }
+  KPERF_LIST
+#undef F
+
+
+  if (kpc_get_counter_count(KPC_MASK) != COUNTERS_COUNT) {
+    printf("wrong fixed counters count\n");
+    return false;
+  }
+
+  if (kpc_get_config_count(KPC_MASK) != CONFIG_COUNT) {
+    printf("wrong fixed config count\n");
+    return false;
+  }
+  g_config[0] = CPMU_CORE_CYCLE | CFGWORD_EL0A64EN_MASK;
+  g_config[3] = CPMU_SYNC_DC_LOAD_MISS | CFGWORD_EL0A64EN_MASK;
+  g_config[4] = CPMU_SYNC_BR_ANY_MISP | CFGWORD_EL0A64EN_MASK;
+  g_config[5] = CPMU_INST_A64 | CFGWORD_EL0A64EN_MASK;
+
+  return (worked = configure_rdtsc());
+}
+
+bool setup_performance_counters() {
+  static bool init = false;
+  static bool worked = false;
+
+  if(init) { return worked; }
+  int test_high_perf_cores = 1;
+
+  if (test_high_perf_cores) {
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+  } else {
+    pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+  }
+  return  (worked = init_rdtsc() && configure_rdtsc());
+}
+
+inline performance_counters get_counters() {
+  static bool warned = false;
+  if (kpc_get_thread_counters(0, COUNTERS_COUNT, g_counters)) {
+    if (!warned) {
+      printf("kpc_get_thread_counters failed, run as sudo?\n");
+      warned = true;
+    }
+    return 1;
+  }
+  // g_counters[3 + 2] might be the number of decoded instructions
+  // whereas g_counters[0] is the number of retired instructions.
+  return performance_counters{g_counters[0 + 2], g_counters[0],
+                              g_counters[4 + 2], g_counters[5 + 2]};
+}
+
+#endif

--- a/benchmarks/performancecounters/event_counter.h
+++ b/benchmarks/performancecounters/event_counter.h
@@ -1,0 +1,144 @@
+#ifndef __EVENT_COUNTER_H
+#define __EVENT_COUNTER_H
+
+#include <cctype>
+#ifndef _MSC_VER
+#include <dirent.h>
+#endif
+#include <cinttypes>
+
+#include <cstring>
+
+#include <chrono>
+#include <vector>
+
+#include "linux-perf-events.h"
+#ifdef __linux__
+#include <libgen.h>
+#endif
+
+#if __APPLE__ &&  __aarch64__
+#include "apple_arm_events.h"
+#endif
+
+struct event_count {
+  std::chrono::duration<double> elapsed;
+  std::vector<unsigned long long> event_counts;
+  event_count() : elapsed(0), event_counts{0,0,0,0,0} {}
+  event_count(const std::chrono::duration<double> _elapsed, const std::vector<unsigned long long> _event_counts) : elapsed(_elapsed), event_counts(_event_counts) {}
+  event_count(const event_count& other): elapsed(other.elapsed), event_counts(other.event_counts) { }
+
+  // The types of counters (so we can read the getter more easily)
+  enum event_counter_types {
+    CPU_CYCLES,
+    INSTRUCTIONS,
+  };
+
+  double elapsed_sec() const { return std::chrono::duration<double>(elapsed).count(); }
+  double elapsed_ns() const { return std::chrono::duration<double, std::nano>(elapsed).count(); }
+  double cycles() const { return static_cast<double>(event_counts[CPU_CYCLES]); }
+  double instructions() const { return static_cast<double>(event_counts[INSTRUCTIONS]); }
+
+  event_count& operator=(const event_count& other) {
+    this->elapsed = other.elapsed;
+    this->event_counts = other.event_counts;
+    return *this;
+  }
+  event_count operator+(const event_count& other) const {
+    return event_count(elapsed+other.elapsed, {
+      event_counts[0]+other.event_counts[0],
+      event_counts[1]+other.event_counts[1],
+      event_counts[2]+other.event_counts[2],
+      event_counts[3]+other.event_counts[3],
+      event_counts[4]+other.event_counts[4],
+    });
+  }
+
+  void operator+=(const event_count& other) {
+    *this = *this + other;
+  }
+};
+
+struct event_aggregate {
+  bool has_events = false;
+  int iterations = 0;
+  event_count total{};
+  event_count best{};
+  event_count worst{};
+
+  event_aggregate() = default;
+
+  void operator<<(const event_count& other) {
+    if (iterations == 0 || other.elapsed < best.elapsed) {
+      best = other;
+    }
+    if (iterations == 0 || other.elapsed > worst.elapsed) {
+      worst = other;
+    }
+    iterations++;
+    total += other;
+  }
+
+  double elapsed_sec() const { return total.elapsed_sec() / iterations; }
+  double elapsed_ns() const { return total.elapsed_ns() / iterations; }
+  double cycles() const { return total.cycles() / iterations; }
+  double instructions() const { return total.instructions() / iterations; }
+};
+
+struct event_collector {
+  event_count count{};
+  std::chrono::time_point<std::chrono::steady_clock> start_clock{};
+
+#if defined(__linux__)
+  LinuxEvents<PERF_TYPE_HARDWARE> linux_events;
+  event_collector() : linux_events(std::vector<int>{
+    PERF_COUNT_HW_CPU_CYCLES,
+    PERF_COUNT_HW_INSTRUCTIONS,
+  }) {}
+  bool has_events() {
+    return linux_events.is_working();
+  }
+#elif __APPLE__ &&  __aarch64__
+  performance_counters diff;
+  event_collector() : diff(0) {
+    setup_performance_counters();
+  }
+  bool has_events() {
+    return setup_performance_counters();
+  }
+#else
+  event_collector() {}
+  bool has_events() {
+    return false;
+  }
+#endif
+
+  inline void start() {
+#if defined(__linux)
+    linux_events.start();
+#elif __APPLE__ &&  __aarch64__
+    if(has_events()) { diff = get_counters(); }
+#endif
+    start_clock = std::chrono::steady_clock::now();
+  }
+  inline event_count& end() {
+    const auto end_clock = std::chrono::steady_clock::now();
+#if defined(__linux)
+    linux_events.end(count.event_counts);
+#elif __APPLE__ &&  __aarch64__
+    if(has_events()) {
+      performance_counters end = get_counters();
+      diff = end - diff;
+    }
+    count.event_counts[0] = diff.cycles;
+    count.event_counts[1] = diff.instructions;
+    count.event_counts[2] = diff.missed_branches;
+    count.event_counts[3] = 0;
+    count.event_counts[4] = diff.cachemiss;
+#endif
+    count.elapsed = end_clock - start_clock;
+    return count;
+  }
+};
+
+#endif

--- a/benchmarks/performancecounters/linux-perf-events.h
+++ b/benchmarks/performancecounters/linux-perf-events.h
@@ -1,0 +1,99 @@
+// https://github.com/WojciechMula/toys/blob/master/000helpers/linux-perf-events.h
+#pragma once
+#ifdef __linux__
+
+#include <asm/unistd.h>       // for __NR_perf_event_open
+#include <linux/perf_event.h> // for perf event constants
+#include <sys/ioctl.h>        // for ioctl
+#include <unistd.h>           // for syscall
+
+#include <cerrno>  // for errno
+#include <cstring> // for memset
+#include <stdexcept>
+
+#include <iostream>
+#include <vector>
+
+template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
+  int fd;
+  bool working;
+  perf_event_attr attribs{};
+  size_t num_events{};
+  std::vector<uint64_t> temp_result_vec{};
+  std::vector<uint64_t> ids{};
+
+public:
+  explicit LinuxEvents(std::vector<int> config_vec) : fd(0), working(true) {
+    memset(&attribs, 0, sizeof(attribs));
+    attribs.type = TYPE;
+    attribs.size = sizeof(attribs);
+    attribs.disabled = 1;
+    attribs.exclude_kernel = 1;
+    attribs.exclude_hv = 1;
+
+    attribs.sample_period = 0;
+    attribs.read_format = PERF_FORMAT_GROUP | PERF_FORMAT_ID;
+    const int pid = 0;  // the current process
+    const int cpu = -1; // all CPUs
+    const unsigned long flags = 0;
+
+    int group = -1; // no group
+    num_events = config_vec.size();
+    ids.resize(config_vec.size());
+    uint32_t i = 0;
+    for (auto config : config_vec) {
+      attribs.config = config;
+      fd = static_cast<int>(syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags));
+      if (fd == -1) {
+        report_error("perf_event_open");
+      }
+      ioctl(fd, PERF_EVENT_IOC_ID, &ids[i++]);
+      if (group == -1) {
+        group = fd;
+      }
+    }
+
+    temp_result_vec.resize(num_events * 2 + 1);
+  }
+
+  ~LinuxEvents() { if (fd != -1) { close(fd); } }
+
+  inline void start() {
+    if (fd != -1) {
+      if (ioctl(fd, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP) == -1) {
+        report_error("ioctl(PERF_EVENT_IOC_RESET)");
+      }
+
+      if (ioctl(fd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP) == -1) {
+        report_error("ioctl(PERF_EVENT_IOC_ENABLE)");
+      }
+    }
+  }
+
+  inline void end(std::vector<unsigned long long> &results) {
+    if (fd != -1) {
+      if (ioctl(fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP) == -1) {
+        report_error("ioctl(PERF_EVENT_IOC_DISABLE)");
+      }
+
+      if (read(fd, temp_result_vec.data(), temp_result_vec.size() * 8) == -1) {
+        report_error("read");
+      }
+    }
+    // our actual results are in slots 1,3,5, ... of this structure
+    // we really should be checking our ids obtained earlier to be safe
+    for (uint32_t i = 1; i < temp_result_vec.size(); i += 2) {
+      results[i / 2] = temp_result_vec[i];
+    }
+  }
+
+  bool is_working() {
+    return working;
+  }
+
+private:
+  void report_error(const std::string &) {
+    working = false;
+  }
+};
+#endif

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -402,7 +402,7 @@ namespace ada {
       buffer.reserve(input.size());
       std::transform(input.begin(), input.end(), std::back_inserter(buffer), [&is_forbidden, &ascii_runner](char c) -> char {
         is_forbidden |= ada::unicode::is_forbidden_domain_code_point(c);
-        ascii_runner |= c;
+        ascii_runner |= uint8_t(c);
         return (uint8_t((c|0x20) - 0x61) <= 25 ? (c|0x20) : c);}
       );
       if (ascii_runner < 128 && !is_forbidden && buffer.find("xn-") == std::string_view::npos) {


### PR DESCRIPTION
This adds performance counters for Linux and ARM-based apple systems. Privileged access is typically needed to get these counters which typically implies that one needs to run the benchmarks using sudo (e.g., `sudo ./bench`).

An interesting metric is `instructions/byte`. Counting instructions is useful because...

1. It is rock solid. You will notice that on the same system, with the same benchmark, you always get almost the same number of instructions for a given task. The main variation source are branch predictions, but modern processors are very good in this respect so that there is little run-to-run difference.
2. We are neither memory bound (we basically run in cache), nor IO bound, nor multithreaded, and we are not dealing with problems that have much data dependencies (the processor has always something to do) and that implies that we can sustain high instructions per cycle... thus is likely that the instruction count is a critical limit... meaning that if you reduce the instruction count, you will almost always go faster (there are exceptions, it is a heuristic). There are diminishing returns... as you reduce instructions too much, the number of instructions being retired per cycle will even go down because you will discover hard data dependencies...