### PR TITLE
Supporting older systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Specification for URL parser can be found from
 
 ## Requirements
 
-- A recent C++ compiler supporting C++17.
+- A recent C++ compiler supporting C++17 (e.g., gcc 8 or better)
 - [ICU](https://icu.unicode.org).
 
 ## Usage (CMake)
@@ -17,3 +17,4 @@ cmake --build build
 cd build
 ctest .
 ```
+

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -44,34 +44,54 @@ target_include_directories(httpparser PUBLIC "${httpparser_SOURCE_DIR}")
 target_link_libraries(bench PRIVATE httpparser)
 target_link_libraries(bbc_bench PRIVATE httpparser)
 
-import_dependency(boost_url boostorg/url boost-1.81.0)
-add_library(boost_url INTERFACE)
-target_include_directories(boost_url INTERFACE
-           "${boost_url_SOURCE_DIR}/include")
-
 find_package(CURL)
 if(CURL_FOUND)
     message(STATUS "curl version ${CURL_VERSION}")
-    include_directories(${CURL_INCLUDE_DIRS})
-    if(NOT CURL_LIBRARIES)
-        target_link_libraries(bench PRIVATE CURL::libcurl)
-        target_link_libraries(bbc_bench PRIVATE CURL::libcurl)
+    if (CURL_VERSION VERSION_LESS 7.62.0)
+        message(STATUS "curl is too old, we need version 7.62.0 or better")
     else()
-        target_link_libraries(bench PRIVATE ${CURL_LIBRARIES})
-        target_link_libraries(bbc_bench PRIVATE ${CURL_LIBRARIES})
+        include_directories(${CURL_INCLUDE_DIRS})
+        if(NOT CURL_LIBRARIES)
+            target_link_libraries(bench PRIVATE CURL::libcurl)
+            target_link_libraries(bbc_bench PRIVATE CURL::libcurl)
+        else()
+            target_link_libraries(bench PRIVATE ${CURL_LIBRARIES})
+           target_link_libraries(bbc_bench PRIVATE ${CURL_LIBRARIES})
+        endif()
+        target_compile_definitions(bench PRIVATE CURL_ENABLED=1)
+        target_compile_definitions(bbc_bench PRIVATE CURL_ENABLED=1)
     endif()
-    target_compile_definitions(bench PRIVATE CURL_ENABLED=1)
-    target_compile_definitions(bbc_bench PRIVATE CURL_ENABLED=1)
 else(CURL_FOUND)
     message(STATUS "Curl not found! Please install the curl library.")
 endif(CURL_FOUND)
 
+option(ADA_BOOST_URL "Whether to install boost URL." ON)
+
+message(STATUS "Compiler is "${CMAKE_CXX_COMPILER_ID})
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+message(STATUS "Compiler version "${CMAKE_CXX_COMPILER_VERSION})
+
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+message(STATUS "Compiler is too old, disabling boost url.")
+SET(ADA_BOOST_URL OFF CACHE BOOL "Whether to install boost URL." FORCE)
+endif()
+endif()
+
+if(ADA_BOOST_URL)
 find_package(
     Boost 1.80
     COMPONENTS system
 )
+endif(ADA_BOOST_URL)
 
 if(Boost_FOUND)
+
+    import_dependency(boost_url boostorg/url boost-1.81.0)
+    add_library(boost_url INTERFACE)
+    target_include_directories(boost_url INTERFACE
+           "${boost_url_SOURCE_DIR}/include")
+
     target_link_libraries(bench PRIVATE Boost::system)
     target_link_libraries(bench PRIVATE boost_url)
     target_compile_definitions(bench PRIVATE BOOST_ENABLED=1)
@@ -81,5 +101,7 @@ if(Boost_FOUND)
     target_link_libraries(bbc_bench PRIVATE boost_url)
     target_compile_definitions(bbc_bench PRIVATE BOOST_ENABLED=1)
 else(Boost_FOUND)
+if(ADA_BOOST_URL)
     message(STATUS "Boost 1.80 or better was not found, please install it for benchmarking purposes.")
+endif(ADA_BOOST_URL)
 endif(Boost_FOUND)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -46,8 +46,8 @@ target_link_libraries(bbc_bench PRIVATE httpparser)
 
 find_package(CURL)
 if(CURL_FOUND)
-    message(STATUS "curl version ${CURL_VERSION}")
-    if (CURL_VERSION VERSION_LESS 7.62.0)
+    message(STATUS "curl version " ${CURL_VERSION_STRING})
+    if (CURL_VERSION_STRING VERSION_LESS "7.62.0")
         message(STATUS "curl is too old, we need version 7.62.0 or better")
     else()
         include_directories(${CURL_INCLUDE_DIRS})
@@ -67,10 +67,10 @@ endif(CURL_FOUND)
 
 option(ADA_BOOST_URL "Whether to install boost URL." ON)
 
-message(STATUS "Compiler is "${CMAKE_CXX_COMPILER_ID})
+message(STATUS "Compiler is " ${CMAKE_CXX_COMPILER_ID})
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-message(STATUS "Compiler version "${CMAKE_CXX_COMPILER_VERSION})
+message(STATUS "Compiler version " ${CMAKE_CXX_COMPILER_VERSION})
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
 message(STATUS "Compiler is too old, disabling boost url.")

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -54,7 +54,7 @@ namespace ada::checkers {
     return view.size() >= prefix.size() && (view.substr(0, prefix.size()) == prefix);
   }
 
-  ada_really_inline constexpr bool is_ipv4(std::string_view view) noexcept;
+  ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept;
 
 } // namespace ada::checkers
 

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -140,4 +140,18 @@ namespace ada {
   }
 }
 
+
+
+#if defined(__GNUC__) && !defined(__clang__)
+#if __GNUC__ <= 8
+#define ADA_OLD_GCC 1
+#endif //  __GNUC__ <= 8
+#endif // defined(__GNUC__) && !defined(__clang__)
+
+#if ADA_OLD_GCC
+#define ada_constexpr
+#else
+#define ada_constexpr constexpr
+#endif
+
 #endif // ADA_COMMON_DEFS_H

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -16,7 +16,7 @@ namespace ada::unicode {
   ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept;
   ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept;
   ada_really_inline constexpr bool is_ascii_tab_or_newline(const char c) noexcept;
-  ada_really_inline constexpr bool is_double_dot_path_segment(const std::string_view input) noexcept;
+  ada_really_inline ada_constexpr bool is_double_dot_path_segment(const std::string_view input) noexcept;
   ada_really_inline constexpr bool is_single_dot_path_segment(const std::string_view input) noexcept;
   ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept;
 

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -3,7 +3,7 @@
 
 namespace ada::checkers {
 
-  ada_really_inline constexpr bool is_ipv4(std::string_view view) noexcept {
+  ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept {
     size_t last_dot = view.rfind('.');
     if(last_dot == view.size() - 1) {
       view.remove_suffix(1);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -552,7 +552,7 @@ namespace ada::parser {
 
                   // Optimization opportunity: Get rid of initializing a std::string
                   if (checkers::is_normalized_windows_drive_letter(first_base_url_path)) {
-                    url.path += '/'; 
+                    url.path += '/';
                     url.path += first_base_url_path;
                   }
                 }

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -49,18 +49,18 @@ namespace ada::unicode {
   static_assert(unicode::is_forbidden_host_code_point('^'));
   static_assert(unicode::is_forbidden_host_code_point('|'));
 
-  constexpr static bool is_forbidden_domain_code_point_table[] = {
+constexpr static bool is_forbidden_domain_code_point_table[] = {
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
     static_assert(sizeof(is_forbidden_domain_code_point_table) == 256);
 
@@ -146,7 +146,7 @@ namespace ada::unicode {
 
 
   // A double-dot path segment must be ".." or an ASCII case-insensitive match for ".%2e", "%2e.", or "%2e%2e".
-  ada_really_inline constexpr bool is_double_dot_path_segment(std::string_view input) noexcept {
+  ada_really_inline ada_constexpr bool is_double_dot_path_segment(std::string_view input) noexcept {
     // This will catch most cases:
     // The length must be 2,4 or 6.
     // We divide by two and require

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,13 @@ add_cpp_test(wpt_tests)
 target_link_libraries(wpt_tests PUBLIC simdjson)
 target_link_libraries(wpt_tests PUBLIC ada)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+target_link_libraries(wpt_tests PUBLIC stdc++fs)
+endif()
+endif()
+
+
 add_cpp_test(basic_fuzzer)
 target_link_libraries(basic_fuzzer PUBLIC ada)
 


### PR DESCRIPTION
This seeks to make ada more robust with respect to older systems. In particular, older version of ICU can allow some non-ASCII punycode, so we need a careful check.