### PR TITLE
perf: add percent_encode benchmarks

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,15 +1,20 @@
-
+# Bench
 add_executable(bench bench.cpp)
 target_link_libraries(bench PRIVATE ada)
 target_include_directories(bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 target_include_directories(bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
 
-
+# BBC Bench
 add_executable(bbc_bench bbc_bench.cpp)
 target_link_libraries(bbc_bench PRIVATE ada)
 target_include_directories(bbc_bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 target_include_directories(bbc_bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
 
+# Percent Encode
+add_executable(percent_encode percent_encode.cpp)
+target_link_libraries(percent_encode PRIVATE ada)
+target_include_directories(percent_encode PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(percent_encode PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
 
 include(${PROJECT_SOURCE_DIR}/cmake/import.cmake)
 
@@ -21,9 +26,9 @@ import_dependency(google_benchmarks google/benchmark f91b6b4)
 add_dependency(google_benchmarks)
 target_link_libraries(bench PRIVATE benchmark::benchmark)
 target_link_libraries(bbc_bench PRIVATE benchmark::benchmark)
+target_link_libraries(percent_encode PRIVATE benchmark::benchmark)
 
-
-
+# URI Parser
 set_off(URIPARSER_BUILD_TESTS)
 set_off(URIPARSER_BUILD_DOCS)
 import_dependency(uriparser uriparser/uriparser 634b678)
@@ -31,12 +36,14 @@ add_dependency(uriparser)
 target_link_libraries(bench PRIVATE uriparser)
 target_link_libraries(bbc_bench PRIVATE uriparser)
 
+# URL Parser
 import_dependency(urlparser netmindms/urlparser 69c09ed)
 add_library(urlparser STATIC "${urlparser_SOURCE_DIR}/src/EdUrlParser.cpp")
 target_include_directories(urlparser PUBLIC "${urlparser_SOURCE_DIR}/src")
 target_link_libraries(bench PRIVATE urlparser)
 target_link_libraries(bbc_bench PRIVATE urlparser)
 
+# HTTP Parser
 import_dependency(httpparser nodejs/http-parser v2.9.4)
 add_library(httpparser STATIC "${httpparser_SOURCE_DIR}/http_parser.c")
 set_source_files_properties("${httpparser_SOURCE_DIR}/http_parser.c" PROPERTIES LANGUAGE C)
@@ -44,6 +51,7 @@ target_include_directories(httpparser PUBLIC "${httpparser_SOURCE_DIR}")
 target_link_libraries(bench PRIVATE httpparser)
 target_link_libraries(bbc_bench PRIVATE httpparser)
 
+# CURL
 find_package(CURL)
 if(CURL_FOUND)
     message(STATUS "curl version " ${CURL_VERSION_STRING})
@@ -78,6 +86,7 @@ SET(ADA_BOOST_URL OFF CACHE BOOL "Whether to install boost URL." FORCE)
 endif()
 endif()
 
+# Boost
 if(ADA_BOOST_URL)
 find_package(
     Boost 1.80
@@ -86,7 +95,6 @@ find_package(
 endif(ADA_BOOST_URL)
 
 if(Boost_FOUND)
-
     import_dependency(boost_url boostorg/url boost-1.81.0)
     add_library(boost_url INTERFACE)
     target_include_directories(boost_url INTERFACE
@@ -95,7 +103,6 @@ if(Boost_FOUND)
     target_link_libraries(bench PRIVATE Boost::system)
     target_link_libraries(bench PRIVATE boost_url)
     target_compile_definitions(bench PRIVATE BOOST_ENABLED=1)
-
 
     target_link_libraries(bbc_bench PRIVATE Boost::system)
     target_link_libraries(bbc_bench PRIVATE boost_url)

--- a/benchmarks/percent_encode.cpp
+++ b/benchmarks/percent_encode.cpp
@@ -1,0 +1,182 @@
+#include <memory>
+
+#include "ada.h"
+#include "ada/character_sets.h"
+#include "ada/unicode.h"
+#include "performancecounters/event_counter.h"
+event_collector collector;
+size_t N = 1000;
+
+#include <benchmark/benchmark.h>
+
+std::string examples[] = {
+    "á|",
+    "other:9818274x1!!",
+    "ref=web-twc-ao-gbl-adsinfo&utm_source=twc&utm_",
+    "connect_timeout=10&application_name=myapp"
+};
+
+double examples_bytes = []() {
+  size_t bytes{0};
+  for(std::string& url_string : examples) { bytes += url_string.size(); }
+  return bytes;
+}();
+
+static void Fragment(benchmark::State& state) {
+  for (auto _ : state) {
+    for(std::string& url_string : examples) {
+      benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::FRAGMENT_PERCENT_ENCODE));
+    }
+  }
+  if(collector.has_events()) {
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : examples) {
+        benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::FRAGMENT_PERCENT_ENCODE));
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+  state.counters["time/byte"] = benchmark::Counter(
+      examples_bytes,
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(Fragment);
+
+static void Query(benchmark::State& state) {
+  for (auto _ : state) {
+    for(std::string& url_string : examples) {
+      benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::QUERY_PERCENT_ENCODE));
+    }
+  }
+  if(collector.has_events()) {
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : examples) {
+        benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::QUERY_PERCENT_ENCODE));
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+  state.counters["time/byte"] = benchmark::Counter(
+      examples_bytes,
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(Query);
+
+static void SpecialQuery(benchmark::State& state) {
+  for (auto _ : state) {
+    for(std::string& url_string : examples) {
+      benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::FRAGMENT_PERCENT_ENCODE));
+    }
+  }
+  if(collector.has_events()) {
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : examples) {
+        benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE));
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+  state.counters["time/byte"] = benchmark::Counter(
+      examples_bytes,
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(SpecialQuery);
+
+static void UserInfo(benchmark::State& state) {
+  for (auto _ : state) {
+    for(std::string& url_string : examples) {
+      benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::USERINFO_PERCENT_ENCODE));
+    }
+  }
+  if(collector.has_events()) {
+    event_aggregate aggregate{};
+    for(size_t i = 0 ; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for(std::string& url_string : examples) {
+        benchmark::DoNotOptimize(ada::unicode::percent_encode(url_string, ada::character_sets::USERINFO_PERCENT_ENCODE));
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/url"] = aggregate.best.instructions() / std::size(examples);
+    state.counters["instructions/cycle"] = aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["instructions/byte"] = aggregate.best.instructions() / examples_bytes;
+    state.counters["GHz"] = aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+  state.counters["time/byte"] = benchmark::Counter(
+      examples_bytes,
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["time/url"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+  state.counters["url/s"] = benchmark::Counter(
+      std::size(examples),
+      benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK(UserInfo);
+
+
+int main(int argc, char **argv) {
+#if (__APPLE__ &&  __aarch64__) || defined(__linux__)
+  if(!collector.has_events()) {
+    benchmark::AddCustomContext("performance counters", "No privileged access (sudo may help).");
+  }
+#else
+  if(!collector.has_events()) {
+    benchmark::AddCustomContext("performance counters", "Unsupported system.");
+  }
+#endif
+  if(collector.has_events()) {
+    benchmark::AddCustomContext("performance counters", "Enabled");
+  }
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+}

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -27,7 +27,6 @@ namespace ada::unicode {
   // first_percent should be  = plain.find('%')
   std::string percent_decode(const std::string_view input, size_t first_percent);
   std::string percent_encode(const std::string_view input, const uint8_t character_set[]);
-  ada_really_inline bool to_lower_ascii_string(std::optional<std::string>& out, size_t first_percent) noexcept;
 
 } // namespace ada::unicode
 

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -415,22 +415,4 @@ constexpr static bool is_forbidden_domain_code_point_table[] = {
     return true;
   }
 
-  // This function attemps to convert an ASCII string to a lower-case version.
-  // Once the lower cased version has been materialized, we check for the presence
-  // of the substring 'xn-', if it is found (unlikely), we then call the expensive 'to_ascii'.
-  ada_really_inline bool to_lower_ascii_string(std::optional<std::string>& out, size_t first_percent) noexcept {
-#if ADA_DEVELOP_MODE
-    if(!out.has_value()) { abort(); }
-#endif
-    if(std::any_of(out.value().begin(), out.value().end(), ada::unicode::is_forbidden_domain_code_point)) { return false; }
-    std::transform(out.value().begin(), out.value().end(), out.value().begin(), [](char c) -> char {
-      return (uint8_t((c|0x20) - 0x61) <= 25 ? (c|0x20) : c);}
-    );
-    if (out.value().find("xn-") == std::string_view::npos) {
-      return true;
-    }
-
-    return to_ascii(out, out.value(), false, first_percent);
-  }
-
 } // namespace ada::unicode

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -229,12 +229,9 @@ constexpr static bool is_forbidden_domain_code_point_table[] = {
 
   unsigned constexpr convert_hex_to_binary(const char c) noexcept {
     // this code can be optimized.
-    if (c >= '0' && c <= '9')
-      return c - '0';
-    else if (c >= 'A' && c <= 'F')
-      return 10 + (c - 'A');
-    else // if (c >= 'a' && c <= 'f')
-      return 10 + (c - 'a');
+    if (c <= '9') { return c - '0'; }
+    char del = c >= 'a' ? 'a' : 'A';
+    return 10 + (c - del);
   }
 
   /**


### PR DESCRIPTION
Some useful insights: UserInfo percent encode takes 3x slower

<img width="828" alt="Screenshot 2023-01-22 at 12 06 21 PM" src="https://user-images.githubusercontent.com/1935246/213929451-290549ff-798e-45e9-b346-65e5551b9585.png">
