### PR TITLE
We need more recent boost for boost-url to build, and we should try to have libcurl installed.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,11 +23,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install ICU
         run: sudo apt-get install -y libicu-dev pkg-config
+      - name: Install curl
+        run: sudo apt-get install -y libcurl4-openssl-dev
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
-          boost_version: 1.73.0
+          boost_version: 1.81.0
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu_clang.yml
+++ b/.github/workflows/ubuntu_clang.yml
@@ -23,11 +23,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install ICU
         run: sudo apt-get install -y libicu-dev pkg-config
+      - name: Install curl
+        run: sudo apt-get install -y libcurl4-openssl-dev
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
-          boost_version: 1.73.0
+          boost_version: 1.81.0
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu_pedantic.yml
+++ b/.github/workflows/ubuntu_pedantic.yml
@@ -27,7 +27,7 @@ jobs:
         uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
-          boost_version: 1.73.0
+          boost_version: 1.81.0
       - name: Use cmake
         run: |
           mkdir build &&


### PR DESCRIPTION
Old boost won't do.