### PR TITLE
This will add a singleheader script. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ else()
 endif()
 ### Going forward, we have ICU for sure, except under Windows.
 
+add_subdirectory(singleheader)
 
 install(
   FILES include/ada.h

--- a/include/ada/character_sets.h
+++ b/include/ada/character_sets.h
@@ -7,7 +7,7 @@
 #ifndef ADA_CHARACTER_SETS_H
 #define ADA_CHARACTER_SETS_H
 
-#include "common_defs.h"
+#include "ada/common_defs.h"
 #include <stdint.h>
 
 namespace ada::character_sets {

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -5,7 +5,7 @@
 #ifndef ADA_CHECKERS_H
 #define ADA_CHECKERS_H
 
-#include "common_defs.h"
+#include "ada/common_defs.h"
 
 #include <string_view>
 #include <cstring>

--- a/include/ada/encoding_type.h
+++ b/include/ada/encoding_type.h
@@ -5,7 +5,7 @@
 #ifndef ADA_ENCODING_TYPE_H
 #define ADA_ENCODING_TYPE_H
 
-#include "common_defs.h"
+#include "ada/common_defs.h"
 #include <string>
 
 namespace ada {

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -5,9 +5,9 @@
 #ifndef ADA_HELPERS_H
 #define ADA_HELPERS_H
 
-#include "common_defs.h"
-#include "url.h"
-#include "state.h"
+#include "ada/common_defs.h"
+#include "ada/url.h"
+#include "ada/state.h"
 
 #include <string_view>
 #include <optional>

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <optional>
 
-#include "common_defs.h"
-#include "encoding_type.h"
-#include "url.h"
-#include "state.h"
+#include "ada/common_defs.h"
+#include "ada/encoding_type.h"
+#include "ada/url.h"
+#include "ada/state.h"
 
 namespace ada {
 

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -5,9 +5,9 @@
 #ifndef ADA_PARSER_H
 #define ADA_PARSER_H
 
-#include "state.h"
-#include "url.h"
-#include "encoding_type.h"
+#include "ada/state.h"
+#include "ada/url.h"
+#include "ada/encoding_type.h"
 
 #include <optional>
 #include <string_view>

--- a/include/ada/scheme.h
+++ b/include/ada/scheme.h
@@ -5,7 +5,7 @@
 #ifndef ADA_SCHEME_H
 #define ADA_SCHEME_H
 
-#include "common_defs.h"
+#include "ada/common_defs.h"
 
 #include <array>
 #include <optional>

--- a/include/ada/state.h
+++ b/include/ada/state.h
@@ -5,7 +5,7 @@
 #ifndef ADA_STATE_H
 #define ADA_STATE_H
 
-#include "common_defs.h"
+#include "ada/common_defs.h"
 
 #include <string>
 

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -5,7 +5,7 @@
 #ifndef ADA_UNICODE_H
 #define ADA_UNICODE_H
 
-#include "common_defs.h"
+#include "ada/common_defs.h"
 #include <string>
 #include <optional>
 

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -5,10 +5,10 @@
 #ifndef ADA_URL_H
 #define ADA_URL_H
 
-#include "checkers.h"
-#include "scheme.h"
-#include "common_defs.h"
-#include "serializers.h"
+#include "ada/checkers.h"
+#include "ada/scheme.h"
+#include "ada/common_defs.h"
+#include "ada/serializers.h"
 
 #include <charconv>
 #include <optional>

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -1,0 +1,63 @@
+#
+# Amalgamation
+#
+set(SINGLEHEADER_FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/ada.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/ada.h
+  ${CMAKE_CURRENT_BINARY_DIR}/demo.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/README.md
+)
+set_source_files_properties(${SINGLEHEADER_FILES} PROPERTIES GENERATED TRUE)
+
+# In theory, this is unneeded, because the tests module does the same test:
+find_package (Python3 COMPONENTS Interpreter)
+
+if (Python3_Interpreter_FOUND)
+  MESSAGE( STATUS "Python found, we are going to amalgamate.py." )
+
+  add_custom_command(
+    OUTPUT ${SINGLEHEADER_FILES}
+    COMMAND ${CMAKE_COMMAND} -E env
+      AMALGAMATE_SOURCE_PATH=${PROJECT_SOURCE_DIR}/src
+      AMALGAMATE_INPUT_PATH=${PROJECT_SOURCE_DIR}/include
+      AMALGAMATE_OUTPUT_PATH=${CMAKE_CURRENT_BINARY_DIR}
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.py
+      #
+      # This is the best way I could find to make amalgamation trigger whenever source files or
+      # header files change: since the "ada" library has to get rebuilt when that happens, we
+      # take a dependency on the generated library file (even though we're not using it). Depending
+      # on ada-source doesn't do the trick because DEPENDS here can only depend on an
+      # *artifact*--it won't scan source and include files the way a concrete library or executable
+      # will.
+      #
+      # It sucks that we have to build the actual library to make it happen, but it's better than\
+      # nothing!
+      #
+      DEPENDS amalgamate.py ada
+  )
+  add_custom_target(singleheader-files DEPENDS ${SINGLEHEADER_FILES})
+
+  #
+  # Include this if you intend to #include "ada.cpp" in your own .cpp files.
+  #
+  add_library(ada-singleheader-include-source INTERFACE)
+  target_include_directories(ada-singleheader-include-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+  add_dependencies(ada-singleheader-include-source singleheader-files)
+
+  add_library(ada-singleheader-source INTERFACE)
+  target_sources(ada-singleheader-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/ada.cpp>)
+  target_link_libraries(ada-singleheader-source INTERFACE ada-singleheader-include-source)
+  if(MSVC) 
+    target_link_libraries(ada-singleheader-include-source INTERFACE Normaliz)
+  else() 
+    target_link_libraries(ada-singleheader-include-source INTERFACE ICU::uc ICU::i18n)
+  endif()
+  if (BUILD_TESTING)
+    add_executable(demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/demo.cpp>)
+    target_link_libraries(demo ada-singleheader-include-source)
+
+    add_test(demo demo)
+  endif()
+else()
+  MESSAGE( STATUS "Python not found, we are unable to test amalgamate.py." )
+endif()

--- a/singleheader/README.md
+++ b/singleheader/README.md
@@ -1,13 +1,22 @@
 While in the ada main directory, using Python 3, type:
 
+```
 python singleheader/amalgamate.py
+```
 
 This will create two new files (ada.h and ada.cpp).
 
 You can then compile the demo file as follows:
 
+```
 c++ -std=c++17 -c demo.cpp
+```
 
 It will produce a binary file (e.g., demo.o) which contains ada.cpp.
 
-It remains to link with libicuuc and libicui18n. This is specific to your system.
+It remains to link with libicuuc and libicui18n. This is specific to your system. It may be as simple as doing:
+
+```
+c++ -std=c++17 -o demo demo.cpp -licuuc -licui18n
+./demo
+```

--- a/singleheader/README.md
+++ b/singleheader/README.md
@@ -1,3 +1,5 @@
+## Amalgamation demo
+
 While in the ada main directory, using Python 3, type:
 
 ```
@@ -14,11 +16,11 @@ c++ -std=c++17 -c demo.cpp
 
 It will produce a binary file (e.g., demo.o) which contains ada.cpp.
 
-It remains to link with libicuuc and libicui18n. This is specific to your system. It may be as simple as doing:
+It remains to link with libicuuc and libicui18n under Linux and macOS. This is specific to your system. It may be as simple as doing:
 
 ```
 c++ -std=c++17 -o demo demo.cpp -licuuc -licui18n
 ./demo
 ```
 
-You may build and link using CMake (--target demo), because CMake is smart enough to configure all the necessary flags.
+You may build and link using CMake (--target demo), because CMake can configure all the necessary flags.

--- a/singleheader/README.md
+++ b/singleheader/README.md
@@ -1,0 +1,13 @@
+While in the ada main directory, using Python 3, type:
+
+python singleheader/amalgamate.py
+
+This will create two new files (ada.h and ada.cpp).
+
+You can then compile the demo file as follows:
+
+c++ -std=c++17 -c demo.cpp
+
+It will produce a binary file (e.g., demo.o) which contains ada.cpp.
+
+It remains to link with libicuuc and libicui18n. This is specific to your system.

--- a/singleheader/README.md
+++ b/singleheader/README.md
@@ -20,3 +20,5 @@ It remains to link with libicuuc and libicui18n. This is specific to your system
 c++ -std=c++17 -o demo demo.cpp -licuuc -licui18n
 ./demo
 ```
+
+You may build and link using CMake (--target demo), because CMake is smart enough to configure all the necessary flags.

--- a/singleheader/amalgamate.py
+++ b/singleheader/amalgamate.py
@@ -108,6 +108,8 @@ print(f"timestamp is {timestamp}")
 os.makedirs(AMALGAMATE_OUTPUT_PATH, exist_ok=True)
 AMAL_H = os.path.join(AMALGAMATE_OUTPUT_PATH, "ada.h")
 AMAL_C = os.path.join(AMALGAMATE_OUTPUT_PATH, "ada.cpp")
+DEMOCPP = os.path.join(AMALGAMATE_OUTPUT_PATH, "cpp")
+README = os.path.join(AMALGAMATE_OUTPUT_PATH, "README.md")
 
 print(f"Creating {AMAL_H}")
 amal_h = open(AMAL_H, 'w')
@@ -126,6 +128,10 @@ for c in ALLCFILES:
 
 amal_c.close()
 
+# copy the README and DEMOCPP
+if SCRIPTPATH != AMALGAMATE_OUTPUT_PATH:
+  shutil.copy2(os.path.join(SCRIPTPATH,"demo.cpp"),AMALGAMATE_OUTPUT_PATH)
+  shutil.copy2(os.path.join(SCRIPTPATH,"README.md"),AMALGAMATE_OUTPUT_PATH)
 
 import zipfile
 zf = zipfile.ZipFile(os.path.join(AMALGAMATE_OUTPUT_PATH,'singleheader.zip'), 'w', zipfile.ZIP_DEFLATED)

--- a/singleheader/amalgamate.py
+++ b/singleheader/amalgamate.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+# Creates the amalgamated source files.
+#
+
+import sys
+import os.path
+import subprocess
+import os
+import re
+import shutil
+import datetime
+if sys.version_info[0] < 3:
+    sys.stdout.write("Sorry, requires Python 3.x or better\n")
+    sys.exit(1)
+
+SCRIPTPATH = os.path.dirname(os.path.abspath(sys.argv[0]))
+PROJECTPATH = os.path.dirname(SCRIPTPATH)
+print(f"SCRIPTPATH={SCRIPTPATH} PROJECTPATH={PROJECTPATH}")
+
+
+print("We are about to amalgamate all ada files into one source file.")
+print("See https://www.sqlite.org/amalgamation.html and https://en.wikipedia.org/wiki/Single_Compilation_Unit for rationale.")
+if "AMALGAMATE_SOURCE_PATH" not in os.environ:
+    AMALGAMATE_SOURCE_PATH = os.path.join(PROJECTPATH, "src")
+else:
+    AMALGAMATE_SOURCE_PATH = os.environ["AMALGAMATE_SOURCE_PATH"]
+if "AMALGAMATE_INCLUDE_PATH" not in os.environ:
+    AMALGAMATE_INCLUDE_PATH = os.path.join(PROJECTPATH, "include")
+else:
+    AMALGAMATE_INCLUDE_PATH = os.environ["AMALGAMATE_INCLUDE_PATH"]
+if "AMALGAMATE_OUTPUT_PATH" not in os.environ:
+    AMALGAMATE_OUTPUT_PATH = os.path.join(SCRIPTPATH)
+else:
+    AMALGAMATE_OUTPUT_PATH = os.environ["AMALGAMATE_OUTPUT_PATH"]
+
+# this list excludes the "src/generic headers"
+ALLCFILES = ["ada.cpp"]
+
+# order matters
+ALLCHEADERS = ["ada.h"]
+
+found_includes = []
+
+current_implementation=''
+
+def doinclude(fid, file, line, origin):
+
+    p = os.path.join(AMALGAMATE_INCLUDE_PATH, file)
+    pi = os.path.join(AMALGAMATE_SOURCE_PATH, file)
+
+    if os.path.exists(p):
+        if file not in found_includes:
+            found_includes.append(file)
+            dofile(fid, AMALGAMATE_INCLUDE_PATH, file)
+        else:
+            pass
+    elif os.path.exists(pi):
+        if file not in found_includes:
+            found_includes.append(file)
+            dofile(fid, AMALGAMATE_SOURCE_PATH, file)
+        else:
+            pass
+    else:
+        # If we don't recognize it, just emit the #include
+        print("unrecognized:", file, " from ", line, " in ", origin)
+        print(line, file=fid)
+
+def dofile(fid, prepath, filename):
+    print(f"// dofile: invoked with prepath={prepath}, filename={filename}",file=fid)
+    file = os.path.join(prepath, filename)
+    RELFILE = os.path.relpath(file, PROJECTPATH)
+    # Last lines are always ignored. Files should end by an empty lines.
+    print(f"/* begin file {RELFILE} */", file=fid)
+    includepattern = re.compile('\s*#\s*include "(.*)"')
+    with open(file, 'r') as fid2:
+        for line in fid2:
+            line = line.rstrip('\n')
+            s = includepattern.search(line)
+            if s:
+                includedfile = s.group(1)
+                if includedfile == "ada.h" and filename == "ada.cpp":
+                    print(line, file=fid)
+                    continue
+
+                if includedfile.startswith('../'):
+                    includedfile = includedfile[2:]
+                # we explicitly include ada headers, one time each 
+                doinclude(fid, includedfile, line, filename)
+            else:
+                print(line, file=fid)
+    print(f"/* end file {RELFILE} */", file=fid)
+
+
+# Get the generation date from git, so the output is reproducible.
+# The %ci specifier gives the unambiguous ISO 8601 format, and
+# does not change with locale and timezone at time of generation.
+# Forcing it to be UTC is difficult, because it needs to be portable
+# between gnu date and busybox date.
+try:
+    timestamp = subprocess.run(['git', 'show', '-s', '--format=%ci', 'HEAD'],
+                           stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+except:
+    print("git not found, timestamp based on current time")
+    timestamp = str(datetime.datetime.now())
+print(f"timestamp is {timestamp}")
+
+os.makedirs(AMALGAMATE_OUTPUT_PATH, exist_ok=True)
+AMAL_H = os.path.join(AMALGAMATE_OUTPUT_PATH, "ada.h")
+AMAL_C = os.path.join(AMALGAMATE_OUTPUT_PATH, "ada.cpp")
+
+print(f"Creating {AMAL_H}")
+amal_h = open(AMAL_H, 'w')
+print(f"/* auto-generated on {timestamp}. Do not edit! */", file=amal_h)
+for h in ALLCHEADERS:
+    doinclude(amal_h, h, f"ERROR {h} not found", h)
+
+amal_h.close()
+print()
+print()
+print(f"Creating {AMAL_C}")
+amal_c = open(AMAL_C, 'w')
+print(f"/* auto-generated on {timestamp}. Do not edit! */", file=amal_c)
+for c in ALLCFILES:
+    doinclude(amal_c, c, f"ERROR {c} not found", c)
+
+amal_c.close()
+
+
+import zipfile
+zf = zipfile.ZipFile(os.path.join(AMALGAMATE_OUTPUT_PATH,'singleheader.zip'), 'w', zipfile.ZIP_DEFLATED)
+zf.write(os.path.join(AMALGAMATE_OUTPUT_PATH,"ada.cpp"), "ada.cpp")
+zf.write(os.path.join(AMALGAMATE_OUTPUT_PATH,"ada.h"), "ada.h")
+
+
+print("Done with all files generation.")
+
+print(f"Files have been written to directory: {AMALGAMATE_OUTPUT_PATH}/")
+print("Done with all files generation.")
+

--- a/singleheader/demo.cpp
+++ b/singleheader/demo.cpp
@@ -5,5 +5,7 @@
 int main(int , char *[]) {
   ada::url url = ada::parse("https://www.google.com");
   ada::set_scheme(url, "http");
+  std::cout << url.get_scheme() << std::endl;
+  std::cout << *url.host << std::endl;
   return EXIT_SUCCESS;
 }

--- a/singleheader/demo.cpp
+++ b/singleheader/demo.cpp
@@ -1,0 +1,9 @@
+
+#include "ada.cpp"
+#include "ada.h"
+
+int main(int , char *[]) {
+  ada::url url = ada::parse("https://www.google.com");
+  ada::set_scheme(url, "http");
+  return EXIT_SUCCESS;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ link_libraries(ada)
 
 add_cpp_test(wpt_tests)
 target_link_libraries(wpt_tests PUBLIC simdjson)
-target_link_libraries(wpt_tests PUBLIC ada)
+# target_link_libraries(wpt_tests PUBLIC ada)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
@@ -27,5 +27,5 @@ endif()
 
 
 add_cpp_test(basic_fuzzer)
-target_link_libraries(basic_fuzzer PUBLIC ada)
+# target_link_libraries(basic_fuzzer PUBLIC ada)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,6 @@ link_libraries(ada)
 
 add_cpp_test(wpt_tests)
 target_link_libraries(wpt_tests PUBLIC simdjson)
-# target_link_libraries(wpt_tests PUBLIC ada)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
@@ -27,5 +26,4 @@ endif()
 
 
 add_cpp_test(basic_fuzzer)
-# target_link_libraries(basic_fuzzer PUBLIC ada)
 


### PR DESCRIPTION
It builds a 'demo' file. Unfortunately, because we have a dependency on ICU (for example), one then needs to do extra work to link the result with the library.

I accidentally found out that we linked twice against ada when building our test executables.