### PR TITLE
Simplify the API.

### DIFF
--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -7,7 +7,7 @@ static void BasicBench_AdaURL(benchmark::State& state) {
 
   for (auto _ : state) {
     for(std::string& url_string : url_examples) {
-      auto url = ada::parser::parse_url(url_string, std::nullopt);
+      auto url = ada::parser::parse_url(url_string);
       numbers_of_parameters += url.path.size()
        + (url.query.has_value() ? url.query->size() : 0) + url.get_scheme().size() + url.host->size();
       is_valid &= url.is_valid;
@@ -20,7 +20,7 @@ static void BasicBench_AdaURL(benchmark::State& state) {
       std::atomic_thread_fence(std::memory_order_acquire);
       collector.start();
       for(std::string& url_string : url_examples) {
-        auto url = ada::parser::parse_url(url_string, std::nullopt);
+        auto url = ada::parser::parse_url(url_string);
         numbers_of_parameters += url.path.size()
          + (url.query.has_value() ? url.query->size() : 0) + url.get_scheme().size()
          + (url.host.has_value() ? url.host->size() : 0);

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -31,7 +31,7 @@ namespace ada {
    * ```
    */
   ada_warn_unused ada::url parse(std::string_view input,
-                                 std::optional<ada::url> base_url = std::nullopt,
+                                 const ada::url* base_url = nullptr,
                                  ada::encoding_type encoding = ada::encoding_type::UTF8);
 
 }

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -18,9 +18,9 @@ namespace ada::parser {
    * Parses a url.
    */
   url parse_url(std::string_view user_input,
-                std::optional<ada::url> base_url = std::nullopt,
+                const ada::url* base_url = nullptr,
                 ada::encoding_type encoding = ada::encoding_type::UTF8,
-                std::optional<ada::url> optional_url = std::nullopt);
+                const ada::url* optional_url = nullptr);
 
 } // namespace ada
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -9,7 +9,7 @@
 namespace ada {
 
   ada_warn_unused url parse(std::string_view input,
-                            std::optional<ada::url> base_url,
+                            const ada::url* base_url,
                             ada::encoding_type encoding) {
     if(encoding != encoding_type::UTF8) {
       // @todo Add support for non UTF8 input

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -54,7 +54,7 @@ size_t fancy_fuzz(size_t N, size_t seed = 0) {
     size_t counter = seed;
     for(size_t trial = 0; trial < N; trial++) {
         std::string copy = url_examples[(seed++)%(sizeof(url_examples)/sizeof(std::string))];
-        auto url = ada::parser::parse_url(copy, std::nullopt);
+        auto url = ada::parser::parse_url(copy);
         while(url.is_valid) {
             // mutate the string.
             int k = ((321321*counter++) %3);
@@ -81,7 +81,7 @@ size_t simple_fuzz(size_t N, size_t seed = 0) {
     size_t counter = seed;
     for(size_t trial = 0; trial < N; trial++) {
         std::string copy = url_examples[(seed++)%(sizeof(url_examples)/sizeof(std::string))];
-        auto url = ada::parser::parse_url(copy, std::nullopt);
+        auto url = ada::parser::parse_url(copy);
         while(url.is_valid) {
             // mutate the string.
             copy[(13134*counter++)%copy.size()] = char(counter++*71117);

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -21,11 +21,11 @@ std::set<std::string> exceptions = {"\x68\x74\x74\x70\x73\x3a\x2f\x2f\x66\x61\xc
 // This function copies your input onto a memory buffer that
 // has just the necessary size. This will entice tools to detect
 // an out-of-bound access.
-ada::url ada_parse(std::string_view view, std::optional<ada::url> base = std::nullopt) {
+ada::url ada_parse(std::string_view view,const ada::url* base = nullptr) {
   std::cout << "about to parse '" << view << "' [" << view.size() << " bytes]" << std::endl;
   std::unique_ptr<char[]> buffer(new char[view.size()]);
   memcpy(buffer.get(), view.data(), view.size());
-  return ada::parse(std::string_view(buffer.get(), view.size()), std::move(base));
+  return ada::parse(std::string_view(buffer.get(), view.size()), base);
 }
 
 #include "simdjson.h"
@@ -294,7 +294,7 @@ bool urltestdata_encoding(const char* source) {
       }
       bool failure = false;
       ada::url input_url = (!object["base"].get(base)) ?
-      ada_parse(input, std::optional<ada::url>(std::move(base_url)))
+      ada_parse(input, &base_url)
       : ada_parse(input);
       if (!object["failure"].get(failure)) {
         TEST_ASSERT(input_url.is_valid, !failure, "Should not have succeeded " + element_string);


### PR DESCRIPTION
This replaces the user-facing `std::optional<ada::url>` with the more conventional `ada::url` pointer. It saves about 10 instructions per URL, so performance-wise it is not impactful. However, it makes the API "more conventional".