### PR TITLE
fix: href should return correct value

### DIFF
--- a/src/url-getters.cpp
+++ b/src/url-getters.cpp
@@ -26,7 +26,7 @@ namespace ada {
       output += "/.";
     }
 
-    output += get_pathname() + (query.has_value() ? "?" + query.value() : "") + (fragment.has_value() ? "#" + fragment.value() : "");
+    output += get_pathname() + get_search() + get_hash();
     return output;
   }
 


### PR DESCRIPTION
This fixes a bug on Node, but the way we parse fragments are not correct, and points a more underlying issue.