### PR TITLE
fix: normalize (some) of the benchmarks

### DIFF
--- a/benchmarks/benchmark_header.h
+++ b/benchmarks/benchmark_header.h
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <cstdlib>
 #if ADA_VARIOUS_COMPETITION_ENABLED
 #include <uriparser/Uri.h>
 #include <EdUrlParser.h>

--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -172,7 +172,7 @@ static void BasicBench_CURL(benchmark::State& state) {
     url_container.clear();
     for(std::string& url_string : url_examples) {
       CURLUcode rc = curl_url_set(url, CURLUPART_URL, url_string.c_str(), 0);
-      //if(rc) { url_container.emplace_back(to_standard_url(url)); }
+      if(rc) { url_container.emplace_back(to_standard_url(url)); }
     }
     numbers_of_parameters += url_container.size();
   }


### PR DESCRIPTION
It is difficult compare directly different approaches that might solve different problems. This PR is an attempt at 'normalizing' the task. Everyone must populate a standard URL data structure. This should be relatively fair (even though fairness is relative).