### PR TITLE
fix: improve longest sequence finder

### DIFF
--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -4,33 +4,22 @@
 namespace ada::serializers {
 
   size_t find_longest_sequence_of_ipv6_pieces(const std::array<uint16_t, 8>& address) noexcept {
-    size_t max_index = -1;
-    size_t max_length = 1;
-    size_t current_start = -1;
-    size_t current_length = 0;
-
+    size_t last_count = 1;
+    size_t result = -1;
     for (size_t i = 0; i < 8; i++) {
-      if (address[i] != 0) {
-        if (current_length > max_length) {
-          max_index = current_start;
-          max_length = current_length;
+      if (address[i] == 0) {
+        size_t next = i + 1;
+        while (next != 8 && address[next] == 0) ++next;
+        const size_t count = next - i;
+        if (last_count < count) {
+          last_count = count;
+          result = i;
+          if (next == 8) break;
+          i = next;
         }
-
-        current_start = -1;
-        current_length = 0;
-      } else {
-        if (current_start == size_t(-1)) {
-          current_start = i;
-        }
-        current_length++;
       }
     }
-
-    if (current_length > max_length) {
-      return current_start;
-    }
-
-    return max_index;
+    return result;
   }
 
   std::string ipv6(const std::array<uint16_t, 8>& address) noexcept {


### PR DESCRIPTION
Before:

```
BasicBench_AdaURL     225401 ns       225387 ns         3102 GHz=3.14456 cycle/byte=29.7942 cycles/url=926.337 instructions/byte=120.381 instructions/cycle=4.04042 instructions/ns=12.7054 instructions/url=3.74279k ns/url=294.584 speed=104.425M/s time/byte=9.57625ns time/url=297.736ns url/s=3.35867M/s
```

After:

```
BasicBench_AdaURL     218966 ns       218942 ns         3200 GHz=3.25426 cycle/byte=29.8658 cycles/url=928.561 instructions/byte=120.501 instructions/cycle=4.03474 instructions/ns=13.1301 instructions/url=3.7465k ns/url=285.337 speed=107.499M/s time/byte=9.30241ns time/url=289.223ns url/s=3.45754M/s```