### PR TITLE
test: add code coverage for nodejs

### DIFF
--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -50,11 +50,13 @@ namespace ada {
   void url::set_search(const std::string_view input) {
     if (input.empty()) {
       query = std::nullopt;
-      if (has_opaque_path) {
-        size_t non_whitespace_location = path.find_first_of(' ');
-        if (non_whitespace_location != std::string_view::npos) {
-          path = path.substr(0, non_whitespace_location);
-        }
+
+      // Potentially strip trailing spaces from an opaque path
+      if (!has_opaque_path || fragment.has_value()) return;
+
+      size_t non_whitespace_location = path.find_first_of(' ');
+      if (non_whitespace_location != std::string_view::npos) {
+        path = path.substr(0, non_whitespace_location);
       }
       return;
     }

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -50,9 +50,12 @@ namespace ada {
   void url::set_search(const std::string_view input) {
     if (input.empty()) {
       query = std::nullopt;
-      // Empty this’s query object’s list.
-      // @todo Implement this if/when we have URLSearchParams.
-      // Potentially strip trailing spaces from an opaque path with this.
+      if (has_opaque_path) {
+        size_t non_whitespace_location = path.find_first_of(' ');
+        if (non_whitespace_location != std::string_view::npos) {
+          path = path.substr(0, non_whitespace_location);
+        }
+      }
       return;
     }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -139,6 +139,17 @@ bool nodejs1() {
   TEST_SUCCEED()
 }
 
+bool nodejs2() {
+  TEST_START()
+  auto url = ada::parse("data:space    ?test");
+  TEST_ASSERT(url->get_search(), "?test", "search is not equal");
+  url->set_search("");
+  TEST_ASSERT(url->get_search(), "", "search should have been empty");
+  TEST_ASSERT(url->get_pathname(), "space", "pathname should have been 'space' without trailing spaces");
+  TEST_ASSERT(url->get_href(), "data:space", "href is not equal");
+  TEST_SUCCEED()
+}
+
 int main() {
     bool success = set_host_should_return_false_sometimes()
      && set_host_should_return_true_sometimes()
@@ -146,7 +157,7 @@ int main() {
      && set_hostname_should_return_true_sometimes()
      && readme1() && readme2() && readme3() 
      && readme4() && readme5() && readme6()
-     && readme7() && nodejs1();
+     && readme7() && nodejs1() && nodejs2();
     if(success) { return EXIT_SUCCESS; }
     return EXIT_FAILURE;
 }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -150,6 +150,17 @@ bool nodejs2() {
   TEST_SUCCEED()
 }
 
+bool nodejs3() {
+  TEST_START()
+  auto url = ada::parse("data:space    ?test#test");
+  TEST_ASSERT(url->get_search(), "?test", "search is not equal");
+  url->set_search("");
+  TEST_ASSERT(url->get_search(), "", "search should have been empty");
+  TEST_ASSERT(url->get_pathname(), "space    ", "pathname should have been 'space' without trailing spaces");
+  TEST_ASSERT(url->get_href(), "data:space    #test", "href is not equal");
+  TEST_SUCCEED()
+}
+
 int main() {
     bool success = set_host_should_return_false_sometimes()
      && set_host_should_return_true_sometimes()
@@ -157,7 +168,8 @@ int main() {
      && set_hostname_should_return_true_sometimes()
      && readme1() && readme2() && readme3() 
      && readme4() && readme5() && readme6()
-     && readme7() && nodejs1() && nodejs2();
+     && readme7() && nodejs1() && nodejs2()
+     && nodejs3();
     if(success) { return EXIT_SUCCESS; }
     return EXIT_FAILURE;
 }

--- a/tests/wpt/ada_extra_setters_tests.json
+++ b/tests/wpt/ada_extra_setters_tests.json
@@ -87,5 +87,16 @@
         "pathname": "/Users/yagiz/Developer/node/test/fixtures/loop.%25.js"
       }
     }
+  ],
+  "search": [
+    {
+      "comment": "Remove non-existent param removes ? from URL",
+      "href": "data:space    ?test",
+      "new_value": "",
+      "expected": {
+        "search": "",
+        "pathname": "space"
+      }
+    }
   ]
 }

--- a/tests/wpt/ada_extra_urltestdata.json
+++ b/tests/wpt/ada_extra_urltestdata.json
@@ -206,5 +206,20 @@
     "input": "file://localhost:8098/path/to/file.txt",
     "base": "about:blank",
     "failure": true
+  },
+  {
+    "input": "data:space    ?test#test",
+    "base": "about:blank",
+    "href": "data:space    ?test#test",
+    "origin": "null",
+    "protocol": "data:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "space    ",
+    "search": "?test",
+    "hash": "#test"
   }
 ]

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -207,6 +207,11 @@ bool setters_tests_encoding(const char *source) {
         std::string_view expected = element["expected"]["search"];
         base->set_search(new_value);
         TEST_ASSERT(base->get_search(), expected, "Search " + element_string + base->to_string());
+
+        std::string_view expected_pathname;
+        if (!element["expected"]["pathname"].get(expected_pathname)) {
+          TEST_ASSERT(base->get_pathname(), expected_pathname, "Pathname " + element_string);
+        }
       }
       else if (category == "hash") {
         std::string_view expected = element["expected"]["hash"];


### PR DESCRIPTION
WIP

Web platform tests does not include the tests for `search setter`

[Potentially strip trailing spaces from an opaque path](https://url.spec.whatwg.org/#potentially-strip-trailing-spaces-from-an-opaque-path) with [this](https://webidl.spec.whatwg.org/#this).