### PR TITLE
Optimize the ipv6 serializer

### DIFF
--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -40,7 +40,7 @@ namespace ada::serializers {
       if (piece_index == compress) {
         *point++ = ':';
         if(piece_index != 0) { *point++ = ':'; }
-        piece_index += compress_length
+        piece_index += compress_length;
         if(piece_index == 8) { break; }
       }
       point = std::to_chars(point, point_end, address[piece_index]).ptr;

--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -22,8 +22,8 @@ namespace ada::serializers {
   }
 
   std::string ipv6(const std::array<uint16_t, 8>& address) noexcept {
-    size_t compress_length = 0;
-    size_t compress = 0;
+    size_t compress_length = 0; // The length of a long sequence of zeros.
+    size_t compress = 0; // The start of a long sequence of zeros.
     find_longest_sequence_of_ipv6_pieces(address, compress, compress_length);
 
     if (compress_length <= 1) {
@@ -39,11 +39,13 @@ namespace ada::serializers {
     while (true) {
       if (piece_index == compress) {
         *point++ = ':';
-        if(piece_index != 0) { *point++ = ':'; }
+        // If we skip a value initially, we need to write '::', otherwise
+        // a single ':' will do since it follows a previous ':'.
+        if(piece_index == 0) { *point++ = ':'; }
         piece_index += compress_length;
         if(piece_index == 8) { break; }
       }
-      point = std::to_chars(point, point_end, address[piece_index]).ptr;
+      point = std::to_chars(point, point_end, address[piece_index], 16).ptr;
       piece_index++;
       if(piece_index == 8) { break; }
       *point++ = ':';


### PR DESCRIPTION
The current ipv6 serializer takes each 16-bit integer and...

1. Writes the hex version using `snprintf` to a local buffer. Though `snprintf` is likely efficient, it is still a function call.
2. We call 'append' to a string... this append must find out the length of what `snprintf` wrote, so that's a possible 'strlen' call. Furthermore, the string must potentially allocate.


By replacing all of it by a single call to `std::to_chars` on a generously allocated string, we avoid multiple function calls. The `std::to_chars` gets inlined (very likely in optimized builds). It should result in faster serialization, saving up to 16 function calls in a tight loop.

This is not nearly "as fast as one can go", but it should be faster.