### PR TITLE
src: find_first_of-related perf improvements

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -94,26 +94,35 @@ namespace ada::helpers {
     return pos > input.size() ? std::string_view() : input.substr(pos);
   }
 
-  ada_really_inline size_t get_host_delimiter_location(const ada::url& url, std::string_view& view, bool& inside_brackets) noexcept {
-    size_t location = url.is_special() ? view.find_first_of(":[/?\\") : view.find_first_of(":[/?");
+ada_really_inline size_t get_host_delimiter_location(const ada::url& url, std::string_view& view, bool& inside_brackets) noexcept {
+    const size_t view_size = view.size();
+    size_t location = 0;
 
-    // Next while loop is almost never taken!
-    while((location != std::string_view::npos) && (view[location] == '[')) {
-      location = view.find(']',location);
-      if(location == std::string_view::npos) {
-        inside_brackets = true;
-        /**
-         * TODO: Ok. So if we arrive here then view has an unclosed [,
-         * Is the URL valid???
-         */
+    while (location < view_size) {
+      if (view[location] == '[') {
+        location = view.find(']', location);
+        if (location == std::string_view::npos) {
+          inside_brackets = true;
+          // TODO: Ok. So if we arrive here then view has an unclosed [,
+          // Is the URL valid???
+          break;
+        }
+      } else if (url.is_special()) {
+        if (view[location] == ':' || view[location] == '/' || view[location] == '?' || view[location] == '\\') {
+          break;
+        }
       } else {
-        location = url.is_special() ? view.find_first_of(":[/?\\#", location) : view.find_first_of(":[/?#", location);
+        if (view[location] == ':' || view[location] == '/' || view[location] == '?') {
+          break;
+        }
       }
+      ++location;
     }
 
     if (location != std::string_view::npos) {
-      view.remove_suffix(view.size() - location);
+      view.remove_suffix(view_size - location);
     }
+
     return location;
   }
 

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -77,8 +77,8 @@ namespace ada {
     std::optional<std::string> previous_host = host;
     std::optional<uint16_t> previous_port = port;
 
-    std::string_view::iterator _host_end = std::find(input.begin(), input.end(), '#');
-    std::string _host(input.data(), std::distance(input.begin(), _host_end));
+    size_t host_end_pos = input.find('#');
+    std::string _host(input.data(), host_end_pos != std::string_view::npos ? host_end_pos : input.size());
     helpers::remove_ascii_tab_or_newline(_host);
     std::string_view new_host(_host);
 


### PR DESCRIPTION
refs: https://github.com/ada-url/ada/issues/219
This PR is not the result of an analysis of all uses of **find_first_of** in the repo. The perf gain is not that big, so it might be interesting to consider things like code readability before merging. 

```
**This PR**
time: 2776 ns
instructions/ns=18.4029 
instructions/url=4.60073k

**Without this PR**
time: 2834 ns
instructions/ns=18.61
instructions/url=4.72355k
```
