### PR TITLE
faster replace find first of with find

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -66,7 +66,7 @@ namespace ada::helpers {
    * Returns a host's delimiter location depending on the state of the instance.
    * Used by the host parser.
    */
-  ada_really_inline size_t get_host_delimiter_location(const ada::url& url, std::string_view& view, bool& inside_brackets) noexcept;
+  ada_really_inline size_t get_host_delimiter_location(const bool is_special, std::string_view& view, bool& inside_brackets) noexcept;
 
   /**
    * Removes leading and trailing C0 control and whitespace characters from string.

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -63,10 +63,10 @@ namespace ada::helpers {
   ada_really_inline std::string_view substring(std::string_view input, size_t pos) noexcept;
 
   /**
-   * Returns a host's delimiter location depending on the state of the instance.
+   * Returns a host's delimiter location depending on the state of the instance, and whether a colon was found.
    * Used by the host parser.
    */
-  ada_really_inline size_t get_host_delimiter_location(const bool is_special, std::string_view& view, bool& inside_brackets) noexcept;
+  ada_really_inline std::pair<size_t,bool> get_host_delimiter_location(const bool is_special, std::string_view& view) noexcept;
 
   /**
    * Removes leading and trailing C0 control and whitespace characters from string.

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -79,6 +79,10 @@ namespace ada::helpers {
    */
   ada_really_inline void strip_trailing_spaces_from_opaque_path(ada::url& url) noexcept;
 
+  /**
+   * Reverse the order of the bytes.
+   */
+  ada_really_inline uint64_t swap_bytes(uint64_t val);
 } // namespace ada::helpers
 
 #endif // ADA_HELPERS_H

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -82,7 +82,12 @@ namespace ada::helpers {
   /**
    * Reverse the order of the bytes.
    */
-  ada_really_inline uint64_t swap_bytes(uint64_t val);
+  ada_really_inline uint64_t swap_bytes(uint64_t val) noexcept;
+
+  /**
+   * Reverse the order of the bytes but only if the system is big endian
+   */
+  ada_really_inline uint64_t swap_bytes_if_big_endian(uint64_t val) noexcept;
 } // namespace ada::helpers
 
 #endif // ADA_HELPERS_H

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -63,7 +63,8 @@ namespace ada::helpers {
   ada_really_inline std::string_view substring(std::string_view input, size_t pos) noexcept;
 
   /**
-   * Returns a host's delimiter location depending on the state of the instance, and whether a colon was found.
+   * Returns a host's delimiter location depending on the state of the instance, and 
+   * whether a colon was found outside brackets.
    * Used by the host parser.
    */
   ada_really_inline std::pair<size_t,bool> get_host_delimiter_location(const bool is_special, std::string_view& view) noexcept;

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -54,7 +54,7 @@ namespace ada::checkers {
 
 
   ada_really_inline constexpr bool verify_dns_length(std::string_view input) noexcept {
-    if(input.back() == '.') { 
+    if(input.back() == '.') {
       if(input.size() > 254) return false;
     } else if (input.size() > 253) return false;
 

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -47,7 +47,7 @@ namespace ada::checkers {
                     path_signature_table[uint8_t(input[i + 7])]);
     }
     for (; i < input.size(); i++) {
-      accumulator |= path_signature_table[uint8_t(input[i])];
+      accumulator |= uint8_t(path_signature_table[uint8_t(input[i])]);
     }
     return accumulator;
   }

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -94,30 +94,36 @@ namespace ada::helpers {
     return pos > input.size() ? std::string_view() : input.substr(pos);
   }
 
-ada_really_inline size_t get_host_delimiter_location(const ada::url& url, std::string_view& view, bool& inside_brackets) noexcept {
+  ada_really_inline size_t get_host_delimiter_location(const bool is_special, std::string_view& view, bool& inside_brackets) noexcept {
     const size_t view_size = view.size();
     size_t location = 0;
-
-    while (location < view_size) {
-      if (view[location] == '[') {
-        location = view.find(']', location);
-        if (location == std::string_view::npos) {
-          inside_brackets = true;
-          // TODO: Ok. So if we arrive here then view has an unclosed [,
-          // Is the URL valid???
+    // It is marginally better to have two loops.
+    if(is_special) {
+      for (;location < view_size; ++location) {
+        if (view[location] == '[') {
+          location = view.find(']', location);
+          if (location == std::string_view::npos) {
+            inside_brackets = true;
+            break;
+          }
+        } else if (view[location] == ':' || view[location] == '/' || view[location] == '?' || view[location] == '\\') {
           break;
-        }
-      } else if (url.is_special()) {
-        if (view[location] == ':' || view[location] == '/' || view[location] == '?' || view[location] == '\\') {
-          break;
-        }
-      } else {
-        if (view[location] == ':' || view[location] == '/' || view[location] == '?') {
+        } 
+      }
+    } else {
+      for (;location < view_size; ++location) {
+        if (view[location] == '[') {
+          location = view.find(']', location);
+          if (location == std::string_view::npos) {
+            inside_brackets = true;
+            break;
+          }
+        } else if (view[location] == ':' || view[location] == '/' || view[location] == '?') {
           break;
         }
       }
-      ++location;
     }
+
 
     if (location != std::string_view::npos) {
       view.remove_suffix(view_size - location);

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -110,7 +110,7 @@ namespace ada::helpers {
 
     /**
      * Performance  analysis:
-     * 
+     *
      * Here, we are basically seeking the end of the hostname which can be indicated
      * by the end of the view, or by one of the characters ':', '/', '?', '\\' (where '\\' is only
      * applicable for special URLs). However, these must appear outside a bracket range. E.g.,
@@ -129,7 +129,7 @@ namespace ada::helpers {
         } else if (view[location] == ':' || view[location] == '/' || view[location] == '?' || view[location] == '\\') {
           found_colon = view[location] == ':';
           break;
-        } 
+        }
       }
     } else {
       for (;location < view_size; ++location) {
@@ -200,11 +200,11 @@ namespace ada::helpers {
             if(path.empty()) { path = '/'; return true; }
             // Fast case where we have nothing to do:
             if(path.back() == '/') { return true; }
-            // If you have the path "/joe/myfriend", 
+            // If you have the path "/joe/myfriend",
             // then you delete 'myfriend'.
             path.resize(path.rfind('/') + 1);
             return true;
-          } 
+          }
           path += '/';
           if (path_view != ".") {
             path.append(path_view);

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -95,9 +95,29 @@ namespace ada::helpers {
   }
 
   ada_really_inline std::pair<size_t,bool> get_host_delimiter_location(const bool is_special, std::string_view& view) noexcept {
+    /**
+     * The spec at https://url.spec.whatwg.org/#hostname-state expects us to compute
+     * a variable called insideBrackets but this variable is only used once, to check
+     * whether a ':' character was found outside brackets.
+     * Exact text:
+     * "Otherwise, if c is U+003A (:) and insideBrackets is false, then:".
+     * It is conceptually simpler and arguably more efficient to just return a Boolean
+     * indicating whether ':' was found outside brackets.
+     */
     const size_t view_size = view.size();
     size_t location = 0;
     bool found_colon = false;
+
+    /**
+     * Performance  analysis:
+     * 
+     * Here, we are basically seeking the end of the hostname which can be indicated
+     * by the end of the view, or by one of the characters ':', '/', '?', '\\' (where '\\' is only
+     * applicable for special URLs). However, these must appear outside a bracket range. E.g.,
+     * if you have [something?]fd: then the '?' does not count.
+     */
+
+
     // It is marginally better to have two loops.
     if(is_special) {
       for (;location < view_size; ++location) {

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -96,7 +96,7 @@ namespace ada::helpers {
   }
 
   // Reverse the byte order.
-  ada_really_inline uint64_t swap_bytes(uint64_t val) {
+  ada_really_inline uint64_t swap_bytes(uint64_t val) noexcept {
         return ((((val) & 0xff00000000000000ull) >> 56) |
                 (((val) & 0x00ff000000000000ull) >> 40) |
                 (((val) & 0x0000ff0000000000ull) >> 24) |
@@ -107,6 +107,14 @@ namespace ada::helpers {
                 (((val) & 0x00000000000000ffull) << 56));
   }
 
+  ada_really_inline uint64_t swap_bytes_if_big_endian(uint64_t val) noexcept {
+#if ADA_IS_BIG_ENDIAN
+    return swap_bytes(val);
+#else
+    return val; // unchanged (trivial)
+#endif
+  }
+
   // starting at index location, this finds the next location of a character
   // :, /, \\, ? or [. If none is found, view.size() is returned.
   // For use within get_host_delimiter_location.
@@ -115,9 +123,7 @@ namespace ada::helpers {
       return ((v - 0x0101010101010101) & ~(v)&0x8080808080808080);
     };
     auto index_of_first_set_byte = [](uint64_t v) {
-#if ADA_IS_BIG_ENDIAN
-      v = swap_bytes(v);
-#endif
+      v = swap_bytes_if_big_endian(v);
       return ((((v - 1) & 0x101010101010101) * 0x101010101010101) >> 56) - 1;
     };
     auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
@@ -164,11 +170,8 @@ namespace ada::helpers {
       return ((v - 0x0101010101010101) & ~(v)&0x8080808080808080);
     };
     auto index_of_first_set_byte = [](uint64_t v) {
-#if ADA_IS_BIG_ENDIAN
-      v = swap_bytes(v);
-#endif
+      v = swap_bytes_if_big_endian(v);
       return ((((v - 1) & 0x101010101010101) * 0x101010101010101) >> 56) - 1;
-
     };
     auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
     size_t i = location;

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -94,26 +94,35 @@ namespace ada::helpers {
     return pos > input.size() ? std::string_view() : input.substr(pos);
   }
 
-  ada_really_inline size_t get_host_delimiter_location(const ada::url& url, std::string_view& view, bool& inside_brackets) noexcept {
-    size_t location = url.is_special() ? view.find_first_of(":[/?\\") : view.find_first_of(":[/?");
+ada_really_inline size_t get_host_delimiter_location(const ada::url& url, std::string_view& view, bool& inside_brackets) noexcept {
+    const size_t view_size = view.size();
+    size_t location = 0;
 
-    // Next while loop is almost never taken!
-    while((location != std::string_view::npos) && (view[location] == '[')) {
-      location = view.find(']',location);
-      if(location == std::string_view::npos) {
-        inside_brackets = true;
-        /**
-         * TODO: Ok. So if we arrive here then view has an unclosed [,
-         * Is the URL valid???
-         */
+    while (location < view_size) {
+      if (view[location] == '[') {
+        location = view.find(']', location);
+        if (location == std::string_view::npos) {
+          inside_brackets = true;
+          // TODO: Ok. So if we arrive here then view has an unclosed [,
+          // Is the URL valid???
+          break;
+        }
+      } else if (url.is_special()) {
+        if (view[location] == ':' || view[location] == '/' || view[location] == '?' || view[location] == '\\') {
+          break;
+        }
       } else {
-        location = url.is_special() ? view.find_first_of(":[/?\\#", location) : view.find_first_of(":[/?#", location);
+        if (view[location] == ':' || view[location] == '/' || view[location] == '?') {
+          break;
+        }
       }
+      ++location;
     }
 
     if (location != std::string_view::npos) {
-      view.remove_suffix(view.size() - location);
+      view.remove_suffix(view_size - location);
     }
+
     return location;
   }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -94,19 +94,20 @@ namespace ada::helpers {
     return pos > input.size() ? std::string_view() : input.substr(pos);
   }
 
-  ada_really_inline size_t get_host_delimiter_location(const bool is_special, std::string_view& view, bool& inside_brackets) noexcept {
+  ada_really_inline std::pair<size_t,bool> get_host_delimiter_location(const bool is_special, std::string_view& view) noexcept {
     const size_t view_size = view.size();
     size_t location = 0;
+    bool found_colon = false;
     // It is marginally better to have two loops.
     if(is_special) {
       for (;location < view_size; ++location) {
         if (view[location] == '[') {
           location = view.find(']', location);
           if (location == std::string_view::npos) {
-            inside_brackets = true;
             break;
           }
         } else if (view[location] == ':' || view[location] == '/' || view[location] == '?' || view[location] == '\\') {
+          found_colon = view[location] == ':';
           break;
         } 
       }
@@ -115,10 +116,10 @@ namespace ada::helpers {
         if (view[location] == '[') {
           location = view.find(']', location);
           if (location == std::string_view::npos) {
-            inside_brackets = true;
             break;
           }
         } else if (view[location] == ':' || view[location] == '/' || view[location] == '?') {
+          found_colon = view[location] == ':';
           break;
         }
       }
@@ -129,7 +130,7 @@ namespace ada::helpers {
       view.remove_suffix(view_size - location);
     }
 
-    return location;
+    return {location, found_colon};
   }
 
   ada_really_inline void trim_c0_whitespace(std::string_view& input) noexcept {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -378,7 +378,7 @@ namespace ada::parser {
 
           std::string_view host_view = helpers::substring(url_data, input_position);
           bool inside_brackets{false};
-          size_t location = helpers::get_host_delimiter_location(url, host_view, inside_brackets);
+          size_t location = helpers::get_host_delimiter_location(url.is_special(), host_view, inside_brackets);
           input_position = (location != std::string_view::npos) ? input_position + location : input_size;
           // Otherwise, if c is U+003A (:) and insideBrackets is false, then:
           if ((input_position != input_size) && (url_data[input_position] == ':') && !inside_brackets) {
@@ -394,7 +394,7 @@ namespace ada::parser {
           // Otherwise, if one of the following is true:
           // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
           // - url is special and c is U+005C (\)
-          else if (input_position == input_size || url_data[input_position] == '/' || url_data[input_position] == '?' || (url.is_special() && url_data[input_position] == '\\')) {
+          else {
 
             // If url is special and host_view is the empty string, validation error, return failure.
             if (url.is_special() && host_view.empty()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -377,11 +377,10 @@ namespace ada::parser {
           ada_log("HOST ", helpers::substring(url_data, input_position));
 
           std::string_view host_view = helpers::substring(url_data, input_position);
-          bool inside_brackets{false};
-          size_t location = helpers::get_host_delimiter_location(url.is_special(), host_view, inside_brackets);
+          auto [location, found_colon] = helpers::get_host_delimiter_location(url.is_special(), host_view);
           input_position = (location != std::string_view::npos) ? input_position + location : input_size;
           // Otherwise, if c is U+003A (:) and insideBrackets is false, then:
-          if ((input_position != input_size) && (url_data[input_position] == ':') && !inside_brackets) {
+          if (found_colon) {
             // If buffer is the empty string, validation error, return failure.
             // Let host be the result of host parsing buffer with url is not special.
             ada_log("HOST parsing ", host_view);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -380,6 +380,8 @@ namespace ada::parser {
           auto [location, found_colon] = helpers::get_host_delimiter_location(url.is_special(), host_view);
           input_position = (location != std::string_view::npos) ? input_position + location : input_size;
           // Otherwise, if c is U+003A (:) and insideBrackets is false, then:
+          // Note: the 'found_colon' value is true if and only if a colon was encountered
+          // while not inside brackets.
           if (found_colon) {
             // If buffer is the empty string, validation error, return failure.
             // Let host be the result of host parsing buffer with url is not special.
@@ -393,6 +395,8 @@ namespace ada::parser {
           // Otherwise, if one of the following is true:
           // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
           // - url is special and c is U+005C (\)
+          // The get_host_delimiter_location function either brings us to
+          // the colon outside of the bracket, or to one of those characters.
           else {
 
             // If url is special and host_view is the empty string, validation error, return failure.

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -85,15 +85,13 @@ namespace ada {
     // If url's scheme is "file", then set state to file host state, instead of host state.
     if (get_scheme_type() != ada::scheme::type::FILE) {
       std::string_view host_view(_host.data(), _host.length());
-      bool inside_brackets{false};
-      size_t location = helpers::get_host_delimiter_location(is_special(), host_view, inside_brackets);
-      std::string_view::iterator pointer = (location != std::string_view::npos) ? new_host.begin() + location : new_host.end();
+      auto [location,found_colon] = helpers::get_host_delimiter_location(is_special(), host_view);
 
       // Otherwise, if c is U+003A (:) and insideBrackets is false, then:
       // Note: we cannot access *pointer safely if (pointer == pointer_end).
-      if ((pointer != new_host.end()) && (*pointer == ':') && !inside_brackets) {
+      if (found_colon) {
         if (override_hostname) { return false; }
-        std::string_view buffer(&*(pointer + 1));
+        std::string_view  buffer = new_host.substr(location+1);
         if (!buffer.empty()) { set_port(buffer); }
       }
       // If url is special and host_view is the empty string, validation error, return failure.

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -88,7 +88,8 @@ namespace ada {
       auto [location,found_colon] = helpers::get_host_delimiter_location(is_special(), host_view);
 
       // Otherwise, if c is U+003A (:) and insideBrackets is false, then:
-      // Note: we cannot access *pointer safely if (pointer == pointer_end).
+      // Note: the 'found_colon' value is true if and only if a colon was encountered
+      // while not inside brackets.
       if (found_colon) {
         if (override_hostname) { return false; }
         std::string_view  buffer = new_host.substr(location+1);

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -77,8 +77,8 @@ namespace ada {
     std::optional<std::string> previous_host = host;
     std::optional<uint16_t> previous_port = port;
 
-    std::string_view::iterator _host_end = std::find(input.begin(), input.end(), '#');
-    std::string _host(input.data(), std::distance(input.begin(), _host_end));
+    size_t host_end_pos = input.find('#');
+    std::string _host(input.data(), host_end_pos != std::string_view::npos ? host_end_pos : input.size());
     helpers::remove_ascii_tab_or_newline(_host);
     std::string_view new_host(_host);
 

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -86,7 +86,7 @@ namespace ada {
     if (get_scheme_type() != ada::scheme::type::FILE) {
       std::string_view host_view(_host.data(), _host.length());
       bool inside_brackets{false};
-      size_t location = helpers::get_host_delimiter_location(*this, host_view, inside_brackets);
+      size_t location = helpers::get_host_delimiter_location(is_special(), host_view, inside_brackets);
       std::string_view::iterator pointer = (location != std::string_view::npos) ? new_host.begin() + location : new_host.end();
 
       // Otherwise, if c is U+003A (:) and insideBrackets is false, then:

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -110,6 +110,16 @@ size_t roller_fuzz(size_t N) {
 }
 
 int main() {
+#if ADA_HAS_ICU
+  std::cout << "We are using ICU."<< std::endl;
+#else
+  std::cout << "We are not using ICU."<< std::endl;
+#endif
+#if ADA_IS_BIG_ENDIAN
+  std::cout << "You have big-endian system."<< std::endl;
+#else
+  std::cout << "You have litte-endian system."<< std::endl;
+#endif
   std::cout << "Running basic fuzzer.\n";
   std::cout << "[fancy]  Executed " << fancy_fuzz(100000) << " mutations.\n";
 #if ADA_HAS_ICU

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -162,7 +162,17 @@ bool nodejs3() {
 }
 
 int main() {
-    bool success = set_host_should_return_false_sometimes()
+#if ADA_HAS_ICU
+  std::cout << "We are using ICU."<< std::endl;
+#else
+  std::cout << "We are not using ICU."<< std::endl;
+#endif
+#if ADA_IS_BIG_ENDIAN
+  std::cout << "You have big-endian system."<< std::endl;
+#else
+  std::cout << "You have litte-endian system."<< std::endl;
+#endif
+  bool success = set_host_should_return_false_sometimes()
      && set_host_should_return_true_sometimes()
      && set_hostname_should_return_false_sometimes()
      && set_hostname_should_return_true_sometimes()
@@ -170,6 +180,6 @@ int main() {
      && readme4() && readme5() && readme6()
      && readme7() && nodejs1() && nodejs2()
      && nodejs3();
-    if(success) { return EXIT_SUCCESS; }
-    return EXIT_FAILURE;
+  if(success) { return EXIT_SUCCESS; }
+  return EXIT_FAILURE;
 }

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -491,7 +491,12 @@ int main(int argc, char** argv) {
 #if ADA_HAS_ICU
   std::cout << "We are using ICU."<< std::endl;
 #else
-  std::cout << "ICU is unavailable and we have no feedback."<< std::endl;
+  std::cout << "We are not using ICU."<< std::endl;
+#endif
+#if ADA_IS_BIG_ENDIAN
+  std::cout << "You have big-endian system."<< std::endl;
+#else
+  std::cout << "You have litte-endian system."<< std::endl;
 #endif
   bool one_failed = false;
   for(auto [s,b] : results) {


### PR DESCRIPTION
This is an alternative to @miguelteixeiraa 's PR  https://github.com/ada-url/ada/pull/231

Miguel got most of the gains, but I am squeezing a few more and simplifying the code a bit...

Here are the results with the `bench` benchmark on an M2 processor (LLVM 14).

main branch
```
BasicBench_AdaURL_With_Move       2003 ns         2002 ns       350705 GHz=4.30689 cycle/byte=10.2129 cycles/url=750.182 instructions/byte=53.4653 instructions/cycle=5.23509 instructions/ns=22.547 instructions/url=3.92727k ns/url=174.182 speed=403.544M/s time/byte=2.47804ns time/url=182.023ns url/s=5.4938M/s
```

This PR:
```
BasicBench_AdaURL_With_Move       1854 ns         1854 ns       373606 GHz=4.4108 cycle/byte=10.0062 cycles/url=735 instructions/byte=50.5025 instructions/cycle=5.04712 instructions/ns=22.2619 instructions/url=3.70964k ns/url=166.636 speed=435.717M/s time/byte=2.29507ns time/url=168.583ns url/s=5.93179M/s
```

Miguel:
```
BasicBench_AdaURL_With_Move       2104 ns         2030 ns       342270 GHz=4.42335 cycle/byte=10.0347 cycles/url=737.091 instructions/byte=51.7475 instructions/cycle=5.15688 instructions/ns=22.8107 instructions/url=3.80109k ns/url=166.636 speed=397.999M/s time/byte=2.51257ns time/url=184.56ns url/s=5.41831M/s
```

The important measure for me is `instructions/url`. Or, if you prefer `instructions/byte`. It is amazing how much Miguel was able to trim out. This PR is a little bit better.

In total, it is reduction by 3% of the number of instructions per URL parsed. Wow. For such a small change...

Here are the results on an Zen 2 processor (x64) with GCC 11:

This PR:
```
BasicBench_AdaURL_With_Move       4527 ns         4527 ns       154928 GHz=3.4387 cycle/byte=19.9938 cycles/url=1.46864k instructions/byte=43.9542 instructions/cycle=2.19839 instructions/ns=7.5596 instructions/url=3.22864k ns/url=427.091 speed=178.499M/s time/byte=5.60226ns time/url=411.511ns url/s=2.43007M/s
```

Main branch:
```
BasicBench_AdaURL_With_Move       4959 ns         4959 ns       141184 GHz=3.43635 cycle/byte=22.1151 cycles/url=1.62445k instructions/byte=48.948 instructions/cycle=2.21333 instructions/ns=7.60577 instructions/url=3.59545k ns/url=472.727 speed=162.936M/s time/byte=6.13738ns time/url=450.818ns url/s=2.21819M/s
```

So a very nice gain again!!! A 9% reduction in the number of instructions.


One important code change is this...

```C++
std::string_view buffer(&*(pointer + 1));
```

to 

```C++
std::string_view buffer = new_host.substr(location+1);
```

I think that the latter is much nicer.

There is also another place where we had this crazy if clause that was entirely unnecessary because we it was rechecking the result of get_host_delimiter_location.

The updated code also uses SWAR to find the next matching character.