### PR TITLE
perf: improve authority state performance

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -88,6 +88,12 @@ namespace ada::helpers {
    * Reverse the order of the bytes but only if the system is big endian
    */
   ada_really_inline uint64_t swap_bytes_if_big_endian(uint64_t val) noexcept;
+  
+  /**
+   * Finds the delimiter of a view in authority state.
+   */
+  ada_really_inline size_t find_authority_delimiter(bool is_special, std::string_view view) noexcept;
+
 } // namespace ada::helpers
 
 #endif // ADA_HELPERS_H

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -90,9 +90,14 @@ namespace ada::helpers {
   ada_really_inline uint64_t swap_bytes_if_big_endian(uint64_t val) noexcept;
   
   /**
+  * Finds the delimiter of a view in authority state.
+  */
+  ada_really_inline size_t find_authority_delimiter_special(std::string_view view) noexcept;
+
+  /**
    * Finds the delimiter of a view in authority state.
    */
-  ada_really_inline size_t find_authority_delimiter(bool is_special, std::string_view view) noexcept;
+  ada_really_inline size_t find_authority_delimiter(std::string_view view) noexcept;
 
 } // namespace ada::helpers
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -436,6 +436,16 @@ namespace ada::helpers {
     if (url.query.has_value()) return;
     while (!url.path.empty() && url.path.back() == ' ') { url.path.resize(url.path.size()-1); }
   }
+
+  ada_really_inline size_t find_authority_delimiter(bool is_special, std::string_view view) noexcept {
+    size_t location = 0;
+    for (; location < view.size(); ++location) {
+      if (view[location] == '@' || view[location] == '/' || view[location] == '?' || (is_special && view[location] == '\\')) {
+        break;
+      }
+    }
+    return location < view.size() ? location : view.size();
+  }
 } // namespace ada::helpers
 
 namespace ada {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -172,7 +172,8 @@ namespace ada::parser {
           bool password_token_seen{false};
           do {
             std::string_view view = helpers::substring(url_data, input_position);
-            std::string_view authority_view(view.data(), helpers::find_authority_delimiter(url.is_special(), view));
+            size_t location = url.is_special() ? helpers::find_authority_delimiter_special(view) : helpers::find_authority_delimiter(view);
+            std::string_view authority_view(view.data(), location);
             size_t end_of_authority = input_position + authority_view.size();
             // If c is U+0040 (@), then:
             if ((end_of_authority != input_size) && (url_data[end_of_authority] == '@')) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -172,8 +172,7 @@ namespace ada::parser {
           bool password_token_seen{false};
           do {
             std::string_view view = helpers::substring(url_data, input_position);
-            size_t location = url.is_special() ? view.find_first_of("@/?\\") : view.find_first_of("@/?");
-            std::string_view authority_view(view.data(), (location != std::string_view::npos) ? location : view.size());
+            std::string_view authority_view(view.data(), helpers::find_authority_delimiter(url.is_special(), view));
             size_t end_of_authority = input_position + authority_view.size();
             // If c is U+0040 (@), then:
             if ((end_of_authority != input_size) && (url_data[end_of_authority] == '@')) {


### PR DESCRIPTION
Thanks to @miguelteixeiraa and @lemire 

Before

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations        GHz cycle/byte cycles/url instructions/byte instructions/cycle instructions/ns instructions/url     ns/url      speed  time/byte   time/url      url/s
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BasicBench_AdaURL_With_Copy       2342 ns         2341 ns       298997    4.81719    13.6646    1003.73            64.271            4.70347         22.6575           4.721k    208.364 345.132M/s  2.89744ns   212.83ns 4.69858M/s
BasicBench_AdaURL_With_Move       2028 ns         2027 ns       346784      5.063    12.5322    920.545           58.1597            4.64083         23.4965         4.27209k    181.818 398.596M/s  2.50881ns  184.283ns 5.42643M/s

```

After

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations        GHz cycle/byte cycles/url instructions/byte instructions/cycle instructions/ns instructions/url     ns/url      speed  time/byte   time/url      url/s
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BasicBench_AdaURL_With_Copy       2351 ns         2351 ns       300044    4.77282    13.7809    1012.27           64.1646            4.65604         22.2225         4.71318k    212.091 343.716M/s  2.90938ns  213.707ns 4.67931M/s
BasicBench_AdaURL_With_Move       2003 ns         2003 ns       349664     5.0045    12.3874    909.909           58.1361            4.69318          23.487         4.27036k    181.818 403.434M/s  2.47872ns  182.073ns  5.4923M/s
```