### PR TITLE
Checking that bench can run in CI.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         run: cmake --build build -j=2
 
       - name: Run default benchmark
-        run: sudo build/benchmarks/bench --benchmark_format=json | tee default_benchmark_result.json
+        run: cd build && sudo benchmarks/bench --benchmark_format=json | tee ../default_benchmark_result.json
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -46,7 +46,7 @@ jobs:
           alert-comment-cc-users: '@anonrig @lemire'
 
       - name: Run WPT benchmark
-        run: sudo build/benchmarks/wpt_bench tests/wpt/urltestdata.json --benchmark_format=json | tee wpt_benchmark_result.json
+        run: cd build && sudo benchmarks/wpt_bench tests/wpt/urltestdata.json --benchmark_format=json | tee ../wpt_benchmark_result.json
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -61,7 +61,7 @@ jobs:
           alert-comment-cc-users: '@anonrig @lemire'
 
       - name: Run BBC benchmark
-        run: sudo build/benchmarks/bbc_bench --benchmark_format=json | tee bbc_benchmark_result.json
+        run: cd build && sudo benchmarks/bbc_bench --benchmark_format=json | tee ../bbc_benchmark_result.json
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Display files
         run: find build
       - name: Run default benchmark
-        run: build/benchmarks/bench
+        run: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/benchmarks/ build/benchmarks/bench

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,5 +32,7 @@ jobs:
         run: cmake --build build -j=2
       - name: Test
         run: ctest --output-on-failure --test-dir build
+      - name: Display files
+        run: sudo find .
       - name: Run default benchmark
         run: sudo build/benchmarks/bench

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,3 +32,5 @@ jobs:
         run: cmake --build build -j=2
       - name: Test
         run: ctest --output-on-failure --test-dir build
+      - name: Run default benchmark
+        run: sudo build/benchmarks/bench

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Test
         run: ctest --output-on-failure --test-dir build
       - name: Display files
-        run: sudo find .
+        run: find build
       - name: Run default benchmark
-        run: sudo build/benchmarks/bench
+        run: build/benchmarks/bench

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,7 +32,5 @@ jobs:
         run: cmake --build build -j=2
       - name: Test
         run: ctest --output-on-failure --test-dir build
-      - name: Display files
-        run: find build
       - name: Run default benchmark
-        run: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/benchmarks/ build/benchmarks/bench
+        run: cd build && benchmarks/bench

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -170,6 +170,9 @@ if(RUST_FOUND)
   add_dependency(corrosion)
   # Important: we want to build in release mode!
   corrosion_import_crate(MANIFEST_PATH "competitors/servo-url/Cargo.toml" PROFILE release)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(CMAKE_BUILD_RPATH "${CMAKE_BINARY_DIR}")
+  endif()
 
   target_link_libraries(bench PRIVATE servo-url)
   target_compile_definitions(bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")


### PR DESCRIPTION
You have to run the benchmarks within the build directory otherwise the servo_url library might not be found, due to rpath is set.

Might help with https://github.com/ada-url/ada/issues/233

(We need to merge to find out!)