### PR TITLE
fix: quotes need to be percent encoded in paths.

### DIFF
--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -19,10 +19,10 @@ namespace ada::checkers {
   }
 
 
-  // for use with path_signature
+  // for use with path_signature, we include all characters that need percent encoding.
   static constexpr uint8_t path_signature_table[256] = {
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0,
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
       1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -32,8 +32,28 @@ namespace ada::checkers {
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  static_assert(path_signature_table[uint8_t('?')] == 1);
+  static_assert(path_signature_table[uint8_t('`')] == 1);
+  static_assert(path_signature_table[uint8_t('{')] == 1);
+  static_assert(path_signature_table[uint8_t('}')] == 1);
+  //
+  static_assert(path_signature_table[uint8_t(' ')] == 1);
+  static_assert(path_signature_table[uint8_t('?')] == 1);
+  static_assert(path_signature_table[uint8_t('"')] == 1);
+  static_assert(path_signature_table[uint8_t('#')] == 1);
+  static_assert(path_signature_table[uint8_t('<')] == 1);
+  static_assert(path_signature_table[uint8_t('>')] == 1);
+  //
+  static_assert(path_signature_table[0] == 1);
+  static_assert(path_signature_table[31] == 1);
+  static_assert(path_signature_table[127] == 1);
+  static_assert(path_signature_table[128] == 1);
+  static_assert(path_signature_table[255] == 1);
 
   ada_really_inline constexpr uint8_t path_signature(std::string_view input) noexcept {
+    // The path percent-encode set is the query percent-encode set and U+003F (?), U+0060 (`), U+007B ({), and U+007D (}).
+    // The query percent-encode set is the C0 control percent-encode set and U+0020 SPACE, U+0022 ("), U+0023 (#), U+003C (<), and U+003E (>).
+    // The C0 control percent-encode set are the C0 controls and all code points greater than U+007E (~).
     size_t i = 0;
     uint8_t accumulator{};
     for (; i + 7 < input.size(); i += 8) {

--- a/tests/wpt/ada_extra_urltestdata.json
+++ b/tests/wpt/ada_extra_urltestdata.json
@@ -226,5 +226,20 @@
     "input": "",
     "base": "about:blank",
     "failure": true
+  },
+  {
+    "input": "https://example.com/\"quoted\"",
+    "base": "about:blank",
+    "href": "https://example.com/%22quoted%22",
+    "origin": "https://example.com",
+    "protocol": "https:",
+    "username": "",
+    "password": "",
+    "host": "example.com",
+    "hostname": "example.com",
+    "port": "",
+    "pathname": "/%22quoted%22",
+    "search": "",
+    "hash": ""
   }
 ]


### PR DESCRIPTION
I don't know how this one slipped by.