### PR TITLE
Adding an optimization for dots.

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -332,7 +332,7 @@ namespace ada::helpers {
       // with '.' (easy to check), or we have the sequence './'.
       // Note: input cannot be empty, it must at least contain one character ('.')
       // Note: we know that '\' is not present.
-      if(input[0] != '.' || input.find("./") == std::string_view::npos) { trivial_path = true; }
+      if(input[0] != '.' && input.find("/.") == std::string_view::npos) { trivial_path = true; }
     }
     if (trivial_path) {
       ada_log("parse_path trivial");

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -324,6 +324,16 @@ namespace ada::helpers {
     bool trivial_path =
         (special ? (accumulator == 0) : ((accumulator & 0b11111101) == 0)) &&
         (type != ada::scheme::type::FILE);
+    if(accumulator == 4) {
+      // '4' means that we have at least one dot, but nothing that requires
+      // percent encoding or decoding. The only part that is not trivial is
+      // that we may have single dots and double dots path segments.
+      // If we have such segments, then we either have a path that begins
+      // with '.' (easy to check), or we have the sequence './'.
+      // Note: input cannot be empty, it must at least contain one character ('.')
+      // Note: we know that '\' is not present.
+      if(input[0] != '.' || input.find("./") == std::string_view::npos) { trivial_path = true; }
+    }
     if (trivial_path) {
       ada_log("parse_path trivial");
       path += '/';


### PR DESCRIPTION
This is nearly trivial but it helps in the common case where there is '.' in the path but there is neither a single-dot nor a double-dot path segment.

On x64 with GCC 11:


This PR:

```
BasicBench_AdaURL_With_Move       3788 ns         3787 ns       188401 GHz=3.45727 cycle/byte=15.6118 cycles/url=1.497k instructions/byte=32.1333 instructions/cycle=2.05826 instructions/ns=7.11599 instructions/url=3.08122k ns/url=433 speed=227.868M/s time/byte=4.38851ns time/url=420.809ns url/s=2.37637M/s
```

Main:

```
BasicBench_AdaURL_With_Move       5196 ns         5196 ns       132032 GHz=3.43774 cycle/byte=21.1124 cycles/url=2.02444k instructions/byte=42.9038 instructions/cycle=2.03216 instructions/ns=6.98604 instructions/url=4.114k ns/url=588.889 speed=166.103M/s time/byte=6.02035ns time/url=577.285ns url/s=1.73225M/s
```