### PR TITLE
Some proposed changes to feat: add url_components for start/end 

### DIFF
--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -105,8 +105,6 @@ namespace ada {
     if (port.has_value()) {
       out.port = out.host_end;
       out.pathname_start += std::to_string(port.value()).size();
-    } else {
-      out.port = ada::url_components::omitted;
     }
 
     if (query.has_value()) {

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -81,14 +81,14 @@ namespace ada {
     url_components out{};
 
     // protocol ends with ':'. for example: "https:"
-    out.protocol_end = get_scheme().size();
+    out.protocol_end = uint32_t(get_scheme().size());
 
     if (host.has_value()) {
 
       out.host_start = out.protocol_end + 2;
 
       if (includes_credentials()) {
-        out.username_end = out.protocol_end + 2 + username.size();
+        out.username_end = uint32_t(out.protocol_end + 2 + username.size());
 
         out.host_start += username.size();
 
@@ -97,25 +97,27 @@ namespace ada {
         }
       }
 
-      out.host_end = out.host_start + host.value().size() - 1;
+      out.host_end = uint32_t(out.host_start + host.value().size() - 1);
     }
 
-    out.port = port;
     out.pathname_start = out.host_end;
 
     if (port.has_value()) {
+      out.port = out.host_end;
       out.pathname_start += std::to_string(port.value()).size();
+    } else {
+      out.port = ada::url_components::omitted;
     }
 
     if (query.has_value()) {
-      out.search_start = out.pathname_start + get_pathname().size();
+      out.search_start = uint32_t(out.pathname_start + get_pathname().size());
     }
 
     if (fragment.has_value()) {
-      if (out.search_start.has_value()) {
-        out.hash_start = out.search_start.value() + get_search().size();
+      if (out.search_start != ada::url_components::omitted) {
+        out.hash_start = uint32_t(out.search_start + get_search().size());
       } else {
-        out.hash_start = out.pathname_start + get_pathname().size();
+        out.hash_start = uint32_t(out.pathname_start + get_pathname().size());
       }
     }
 

--- a/include/ada/url_components.h
+++ b/include/ada/url_components.h
@@ -12,23 +12,46 @@
 
 namespace ada {
 
+  /**
+   * We design the url_components struct so that it is as small
+   * and simple as possible. This version uses 32 bytes. A version with size_t
+   * and std::optional<size_t> might use 80 bytes or more.
+   */
   struct url_components {
+    constexpr static uint32_t omitted = uint32_t(-1);
 
     url_components() = default;
     url_components(const url_components &u) = default;
     url_components(url_components &&u) noexcept = default;
     url_components &operator=(url_components &&u) noexcept = default;
     url_components &operator=(const url_components &u) = default;
-    ADA_ATTRIBUTE_NOINLINE ~url_components() = default;
+    ~url_components() = default;
+    /*
+     * By using 32-bit integers, we implicitly assume that the URL string
+     * cannot exceed 4 GB.
+     */
+    uint32_t protocol_end{0};
+    uint32_t username_end{0};
+    uint32_t host_start{0};
+    uint32_t host_end{0};
+    uint32_t port{omitted};
+    uint32_t pathname_start{0};
+    uint32_t search_start{omitted};
+    uint32_t hash_start{omitted};
+     /**
+      *
+      * https://user@pass:example.com:1234/foo/bar?baz#quux
+      *      |      |    |          | ^^^^|       |   |
+      *      |      |    |          | |   |       |   `----- hash_start
+      *      |      |    |          | |   |       `--------- search_start
+      *      |      |    |          | |   `----------------- pathname_start
+      *      |      |    |          | `--------------------- port
+      *      |      |    |          `----------------------- host_end
+      *      |      |    `---------------------------------- host_start
+      *      |      `--------------------------------------- username_end
+      *      `---------------------------------------------- protocol_end
+      */
 
-    size_t protocol_end{0};
-    size_t username_end{0};
-    size_t host_start{0};
-    size_t host_end{0};
-    std::optional<uint32_t> port{};
-    size_t pathname_start{0};
-    std::optional<size_t> search_start{};
-    std::optional<size_t> hash_start{};
 
   }; // struct url_components
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -22,6 +22,10 @@ namespace ada::parser {
     ada::state state = ada::state::SCHEME_START;
     ada::url url = ada::url();
 
+    // We refuse to parse URL strings that exceed 4GB. Such strings are almost
+    // surely the result of a bug or are otherwise a security concern.
+    if(user_input.size()  >= std::string_view::size_type(std::numeric_limits<uint32_t>::max)) { url.is_valid = false; }
+
     // If we are provided with an invalid base, or the optional_url was invalid,
     // we must return.
     if(base_url != nullptr) { url.is_valid &= base_url->is_valid; }


### PR DESCRIPTION
This is a PR on top of https://github.com/ada-url/ada/pull/250, not the main branch.


Basically, I am proposing to make url_components a lightweight object that is very cheap to instantiate and copy. It would make it suitable for our users.