### PR TITLE
Add vs code dev container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:11-slim
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    gcc \
+    clang \
+    clang-tools \
+    cmake \
+    libicu-dev
+
+WORKDIR /repo
+
+CMD ["bash", "-c", "cmake -B build && cmake --build build && cd build && ctest --output-on-failure"]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Ada uses cmake as a build system. It's recommended you to run the following comm
 
 Windows users need additional flags to specify the build configuration, e.g. `--config Release`.
 
+Project can also be built via docker using default docker file of repository with following commands.
+
+`docker build -t ada-builder . && docker run --rm -it -v ${PWD}:/repo ada-builder`
+
 ### Installing ICU
 
 For macOS, you may install it with [brew](https://brew.sh) using `brew install icu4c`. Linux users may install ICU according to the their distribution: under Ubuntu, the command is `apt-get install -y libicu-dev`.


### PR DESCRIPTION
Addition dev container support can be good feature for developers who don't want to install c++ related build tools.

PS: CTEST did not work without change directory to build.