### PR TITLE
feat: add new data benchmark (100k URLs)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -11,6 +11,15 @@ target_link_libraries(bench PRIVATE ada)
 target_include_directories(bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 target_include_directories(bench PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
 
+# Benchdata
+import_dependency(url-dataset ada-url/url-dataset 9749b92c13e970e70409948fa862461191504ccc)
+add_executable(benchdata bench.cpp)
+target_link_libraries(benchdata PRIVATE ada)
+target_include_directories(benchdata PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(benchdata PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
+target_compile_definitions(benchdata PRIVATE ADA_URL_FILE="${url-dataset_SOURCE_DIR}/out.txt")
+
+
 # BBC Bench
 add_executable(bbc_bench bbc_bench.cpp)
 target_link_libraries(bbc_bench PRIVATE ada)
@@ -33,6 +42,7 @@ import_dependency(google_benchmarks google/benchmark f91b6b4)
 add_dependency(google_benchmarks)
 target_link_libraries(wpt_bench PRIVATE benchmark::benchmark)
 target_link_libraries(bench PRIVATE benchmark::benchmark)
+target_link_libraries(benchdata PRIVATE benchmark::benchmark)
 target_link_libraries(bbc_bench PRIVATE benchmark::benchmark)
 target_link_libraries(percent_encode PRIVATE benchmark::benchmark)
 
@@ -54,14 +64,17 @@ if(ICU_FOUND)
 
 
     target_link_libraries(bench PRIVATE url_whatwg_lib)
+    target_link_libraries(benchdata PRIVATE url_whatwg_lib)
     target_link_libraries(bbc_bench PRIVATE url_whatwg_lib)
     target_link_libraries(wpt_bench PRIVATE url_whatwg_lib)
 
     target_include_directories(bench PUBLIC "${url_whatwg_SOURCE_DIR}")
+    target_include_directories(benchdata PUBLIC "${url_whatwg_SOURCE_DIR}")
     target_include_directories(bbc_bench PUBLIC "${url_whatwg_SOURCE_DIR}")
     target_include_directories(wpt_bench PUBLIC "${url_whatwg_SOURCE_DIR}")
 
     target_compile_definitions(bench PRIVATE ADA_url_whatwg_ENABLED=1)
+    target_compile_definitions(benchdata PRIVATE ADA_url_whatwg_ENABLED=1)
     target_compile_definitions(bbc_bench PRIVATE ADA_url_whatwg_ENABLED=1)
     target_compile_definitions(wpt_bench PRIVATE ADA_url_whatwg_ENABLED=1)
 
@@ -106,12 +119,15 @@ if(CURL_FOUND)
         include_directories(${CURL_INCLUDE_DIRS})
         if(NOT CURL_LIBRARIES)
             target_link_libraries(bench PRIVATE CURL::libcurl)
+            target_link_libraries(benchdata PRIVATE CURL::libcurl)
             target_link_libraries(bbc_bench PRIVATE CURL::libcurl)
         else()
             target_link_libraries(bench PRIVATE ${CURL_LIBRARIES})
+            target_link_libraries(benchdata PRIVATE ${CURL_LIBRARIES})
             target_link_libraries(bbc_bench PRIVATE ${CURL_LIBRARIES})
         endif()
         target_compile_definitions(bench PRIVATE ADA_CURL_ENABLED=1)
+        target_compile_definitions(benchdata PRIVATE ADA_CURL_ENABLED=1)
         target_compile_definitions(bbc_bench PRIVATE ADA_CURL_ENABLED=1)
     endif()
 else(CURL_FOUND)
@@ -149,6 +165,10 @@ if(Boost_FOUND)
     target_link_libraries(bench PRIVATE boost_url)
     target_compile_definitions(bench PRIVATE ADA_BOOST_ENABLED=1)
 
+    target_link_libraries(benchdata PRIVATE Boost::system)
+    target_link_libraries(benchdata PRIVATE boost_url)
+    target_compile_definitions(benchdata PRIVATE ADA_BOOST_ENABLED=1)
+
     target_link_libraries(bbc_bench PRIVATE Boost::system)
     target_link_libraries(bbc_bench PRIVATE boost_url)
     target_compile_definitions(bbc_bench PRIVATE ADA_BOOST_ENABLED=1)
@@ -173,6 +193,9 @@ if(RUST_FOUND)
 
   target_link_libraries(bench PRIVATE servo-url)
   target_compile_definitions(bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
+
+  target_link_libraries(benchdata PRIVATE servo-url)
+  target_compile_definitions(benchdata PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
 
   target_link_libraries(bbc_bench PRIVATE servo-url)
   target_compile_definitions(bbc_bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")

--- a/benchmarks/bbc_bench.cpp
+++ b/benchmarks/bbc_bench.cpp
@@ -23,6 +23,8 @@ std::string url_examples[] = {
     "20220908-1153-091014d07889c842a7bdc06e00fa711c9e04f049/modules/vendor/"
     "bower/modernizr/modernizr.js"};
 
+void init_data() {}
+
 double url_examples_bytes = []() -> double  {
   size_t bytes{0};
   for (std::string &url_string : url_examples) {

--- a/benchmarks/bench.cpp
+++ b/benchmarks/bench.cpp
@@ -3,7 +3,7 @@
 /**
  * Realistic URL examples collected on the actual web.
  */
-std::string url_examples[] = {
+std::string url_examples_default[] = {
     "https://www.google.com/"
     "webhp?hl=en&amp;ictx=2&amp;sa=X&amp;ved=0ahUKEwil_"
     "oSxzJj8AhVtEFkFHTHnCGQQPQgI",
@@ -23,11 +23,40 @@ std::string url_examples[] = {
     "http://[2606:4700:4700::1111]", // ipv6
 };
 
+std::vector<std::string> url_examples;
+
 double url_examples_bytes =  []() -> double {
     size_t bytes{0};
     for(std::string& url_string : url_examples) { bytes += url_string.size(); }
     return double(bytes);
   }();
 
+size_t init_data() {
+  // compute the number of bytes.
+  auto compute =  []() -> double {
+    size_t bytes{0};
+    for(std::string& url_string : url_examples) { bytes += url_string.size(); }
+    return double(bytes);
+  };
+#ifndef ADA_URL_FILE
+  for(const std::string& s : url_examples_default) {
+    url_examples.emplace_back(s);
+  }
+  url_examples_bytes = compute();
+  return url_examples.size();
+#else
 
+  if (!file_exists(ADA_URL_FILE)) {
+    std::cout << "File not found !" << ADA_URL_FILE << std::endl;
+    for(const std::string& s : url_examples_default) {
+      url_examples.emplace_back(s);
+    }
+  } else {
+    std::cout << "Loading " << ADA_URL_FILE << std::endl;
+    url_examples = split_string(read_file(ADA_URL_FILE));
+  }
+  url_examples_bytes = compute();
+  return url_examples.size();
+#endif
+}
 #include "benchmark_template.cpp"

--- a/benchmarks/benchmark_header.h
+++ b/benchmarks/benchmark_header.h
@@ -1,6 +1,10 @@
 #include <iostream>
 #include <memory>
 #include <cstdlib>
+#include <sstream>
+#include <fstream>
+#include <filesystem>
+
 #if ADA_VARIOUS_COMPETITION_ENABLED
 #include <uriparser/Uri.h>
 #include <EdUrlParser.h>
@@ -16,3 +20,39 @@ event_collector collector;
 size_t N = 1000;
 
 #include <benchmark/benchmark.h>
+
+
+bool file_exists(const char *filename) {
+  namespace fs = std::filesystem;
+  std::filesystem::path f{filename};
+  if (std::filesystem::exists(filename)) {
+    return true;
+  } else {
+    std::cout << "  file missing: " << filename << std::endl;
+    return false;
+  }
+}
+
+
+
+std::string read_file(std::string filename) {
+  constexpr auto read_size = std::size_t(4096);
+  auto stream = std::ifstream(filename.c_str());
+  stream.exceptions(std::ios_base::badbit);
+  auto out = std::string();
+  auto buf = std::string(read_size, '\0');
+  while (stream.read(&buf[0], read_size)) {
+    out.append(buf, 0, size_t(stream.gcount()));
+  }
+  out.append(buf, 0, size_t(stream.gcount()));
+  return out;
+}
+
+std::vector<std::string> split_string(const std::string& str) {
+  auto result = std::vector<std::string>{};
+  auto ss = std::stringstream{str};
+  for (std::string line; std::getline(ss, line, '\n');) {
+    result.push_back(line);
+  }
+  return result;
+}

--- a/benchmarks/competitors/servo-url/lib.rs
+++ b/benchmarks/competitors/servo-url/lib.rs
@@ -8,8 +8,15 @@ extern crate libc;
 #[no_mangle]
 pub unsafe extern "C" fn parse_url(raw_input: *const c_char, raw_input_length: size_t) -> *mut Url {
   let input = std::str::from_utf8_unchecked(slice::from_raw_parts(raw_input as *const u8, raw_input_length));
-  let result = Url::parse(input).unwrap();
-  Box::into_raw(Box::new(result))
+  // This code would assume that the URL is parsed successfully:
+  // let result = Url::parse(input).unwrap();
+  // Box::into_raw(Box::new(result))
+  // But we might get an invalid input. So we want to return null in case of
+  // error. We can do it in such a manner:
+  match Url::parse(input) {
+    Ok(result) => Box::into_raw(Box::new(result)),
+    Err(_) => std::ptr::null_mut(),
+  }
 }
 
 #[no_mangle]

--- a/benchmarks/percent_encode.cpp
+++ b/benchmarks/percent_encode.cpp
@@ -16,6 +16,8 @@ std::string examples[] = {
     "connect_timeout=10&application_name=myapp"
 };
 
+void init_data() {}
+
 double examples_bytes = []() -> double {
   size_t bytes{0};
   for(std::string& url_string : examples) { bytes += url_string.size(); }

--- a/benchmarks/wpt_bench.cpp
+++ b/benchmarks/wpt_bench.cpp
@@ -1,20 +1,7 @@
 #include "benchmark_header.h"
-#include <filesystem>
-
 #include "simdjson.h"
 
 using namespace simdjson;
-
-bool file_exists(const char *filename) {
-  namespace fs = std::filesystem;
-  std::filesystem::path f{filename};
-  if (std::filesystem::exists(filename)) {
-    return true;
-  } else {
-    std::cout << "  file missing: " << filename << std::endl;
-    return false;
-  }
-}
 
 double url_examples_bytes{};
 


### PR DESCRIPTION
* New benchmark which benefits from the 100k URL dataset. It is named 'benchdata'. 
* I have also fixed curl to make our usage more compliant with the documentation.
* Importantly, the benchmark now prints the count of 'bad' URL. (A small number of URLs are invalid.)