### PR TITLE
 perf: improve href getter performance

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -182,7 +182,7 @@ endif(Boost_FOUND)
 
 # We want the check whether Rust is available before trying to build a crate.
 set(Rust_FIND_QUIETLY ON) # No need to alarm the user if rust is not available.
-import_dependency(corrosion corrosion-rs/corrosion v0.3.3)
+import_dependency(corrosion corrosion-rs/corrosion v0.3.4)
 include("${corrosion_SOURCE_DIR}/cmake/FindRust.cmake")
 
 if(RUST_FOUND)

--- a/src/url-getters.cpp
+++ b/src/url-getters.cpp
@@ -23,7 +23,7 @@ namespace ada {
       }
 
       output += get_host();
-    } else if (!has_opaque_path && path.find('/', 1) != std::string_view::npos && checkers::begins_with(path, "//")) {
+    } else if (!has_opaque_path && checkers::begins_with(path, "//")) {
       // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
       // and url’s path[0] is the empty string, then append U+002F (/) followed by U+002E (.) to output.
       output += "/.";

--- a/src/url-getters.cpp
+++ b/src/url-getters.cpp
@@ -11,26 +11,25 @@ namespace ada {
 
   [[nodiscard]] std::string url::get_href() const noexcept {
     std::string output = get_protocol();
-    size_t url_delimiter_count = std::count(path.begin(), path.end(), '/');
 
     if (host.has_value()) {
       output += "//";
       if (includes_credentials()) {
-        output += get_username();
-        if (!get_password().empty()) {
+        output += username;
+        if (!password.empty()) {
           output += ":" + get_password();
         }
         output += "@";
       }
 
       output += get_host();
-    } else if (!has_opaque_path && url_delimiter_count > 1 && path.length() >= 2 && path[0] == '/' && path[1] == '/') {
+    } else if (!has_opaque_path && path.find('/', 1) != std::string_view::npos && checkers::begins_with(path, "//")) {
       // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
       // and url’s path[0] is the empty string, then append U+002F (/) followed by U+002E (.) to output.
       output += "/.";
     }
 
-    output += get_pathname() 
+    output += path
            // If query is non-null, then set this’s query object’s list to the result of parsing query.
            + (query.has_value() ? "?" + query.value() : "")
            // If  url’s fragment is non-null, then append U+0023 (#), followed by url’s fragment, to output.


### PR DESCRIPTION
Before

```
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
BasicBench_AdaURL              32524681 ns     32480095 ns           21 GHz=3.22738 cycle/byte=12.0204 cycles/url=1044.08 instructions/byte=48.6195 instructions/cycle=4.04475 instructions/ns=13.054 instructions/url=4.22305k ns/url=323.507 speed=267.49M/s time/byte=3.73846ns time/url=324.72ns url/s=3.07958M/s
BasicBench_AdaURL_just_parse   17782300 ns     17774775 ns           40 GHz=3.22596 cycle/byte=6.52503 cycles/url=566.759 instructions/byte=26.3285 instructions/cycle=4.03501 instructions/ns=13.0168 instructions/url=2.28687k ns/url=175.687 speed=488.788M/s time/byte=2.04588ns time/url=177.703ns url/s=5.62736M/s
```

After

```
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
BasicBench_AdaURL              30952299 ns     30951273 ns           22 GHz=3.22836 cycle/byte=11.4879 cycles/url=997.83 instructions/byte=47.3469 instructions/cycle=4.12146 instructions/ns=13.3055 instructions/url=4.11252k ns/url=309.083 speed=280.702M/s time/byte=3.56249ns time/url=309.435ns url/s=3.23169M/s
BasicBench_AdaURL_just_parse   17426274 ns     17426275 ns           40 GHz=3.22926 cycle/byte=6.47108 cycles/url=562.073 instructions/byte=26.3955 instructions/cycle=4.07899 instructions/ns=13.1721 instructions/url=2.29269k ns/url=174.056 speed=498.563M/s time/byte=2.00577ns time/url=174.219ns url/s=5.7399M/s
```