### PR TITLE
Alternative design

### DIFF
--- a/include/ada/href_aggregator.h
+++ b/include/ada/href_aggregator.h
@@ -15,12 +15,29 @@
  * @brief Code for href_aggregator
  */
 namespace ada::parser {
+
 /**
  * Sometimes, you do not want to construct a full URL structure and you would
  * be satisfied with just a normalized href string.
+ *
+ * The href_aggregator contains a single string (buffer) along with a
+ * set of offsets (components). That is sufficient to qualified as a fully
+ * parsed URL. However, unlike ada/url, updates can be more difficult because
+ * the components are not separate. However, we should be able to map an
+ * ada/href_aggregator to an ada/url quickly and efficiently.
+ *
+ * In effect, we can view ada/url and ada/href_aggregator as equivalent.
+ * The ada/href_aggregator class is smaller and faster when processing essentially
+ * immutable URLs. The ada/url class is larger and has more overhead, but it would
+ * be well suited for URLs that are built by parts and modified. For many temporary
+ * or ephemeral instances, an href_aggregator would be more performant.
+ *
+ * TODO: both ada/url and ada/href_aggregator should have a common interface, 
+ * and it is an instance where using inheritance might be ease programming.
  */
 struct href_aggregator {
   bool is_valid;
+  url_components components;
   ada::scheme::type type{ada::scheme::type::NOT_SPECIAL};
 
   ada_really_inline bool is_special() const noexcept {
@@ -31,7 +48,10 @@ struct href_aggregator {
    * Put the specified value as the fragment of this URL.
    * Should be called last.
    */
-  ada_really_inline void set_fragment(std::string_view p) { buffer += p; }
+  ada_really_inline void set_fragment(std::string_view p) {
+    //TODO: update components
+    buffer += p;
+  }
 
   ada_really_inline bool parse_scheme(const std::string_view input) {
     auto parsed_type = ada::scheme::get_scheme_type(input);
@@ -39,11 +59,13 @@ struct href_aggregator {
     if (is_input_special) { // fast path!!!
       type = parsed_type;
       buffer += input;
+      //TODO: update components
     } else { // slow path
       std::string _buffer = std::string(input);
       unicode::to_lower_ascii(_buffer.data(), _buffer.size());
       type = ada::scheme::get_scheme_type(_buffer);
       buffer += _buffer;
+      //TODO: update components
     }
     return true;
   }

--- a/include/ada/href_aggregator.h
+++ b/include/ada/href_aggregator.h
@@ -76,5 +76,7 @@ struct href_aggregator {
 
   std::string buffer;
 };
+
 } // namespace ada::parser
+
 #endif // ADA_HREF_AGGREGATOR_H

--- a/include/ada/href_aggregator.h
+++ b/include/ada/href_aggregator.h
@@ -1,0 +1,58 @@
+/**
+ * @file href_aggreator.h
+ * @brief Definitions for the href_aggregator.
+ */
+#ifndef ADA_HREF_AGGREGATOR_H
+#define ADA_HREF_AGGREGATOR_H
+
+#include "ada/encoding_type.h"
+#include "ada/expected.h"
+#include <optional>
+#include <string_view>
+
+/**
+ * @namespace ada::parser
+ * @brief Code for href_aggregator
+ */
+namespace ada::parser {
+/**
+ * Sometimes, you do not want to construct a full URL structure and you would
+ * be satisfied with just a normalized href string.
+ */
+struct href_aggregator {
+  bool is_valid;
+  ada::scheme::type type{ada::scheme::type::NOT_SPECIAL};
+
+  ada_really_inline bool is_special() const noexcept {
+    return type != ada::scheme::NOT_SPECIAL;
+  }
+
+  /**
+   * Put the specified value as the fragment of this URL.
+   * Should be called last.
+   */
+  ada_really_inline void set_fragment(std::string_view p) { buffer += p; }
+
+  ada_really_inline bool parse_scheme(const std::string_view input) {
+    auto parsed_type = ada::scheme::get_scheme_type(input);
+    bool is_input_special = (parsed_type != ada::scheme::NOT_SPECIAL);
+    if (is_input_special) { // fast path!!!
+      type = parsed_type;
+      buffer += input;
+    } else { // slow path
+      std::string _buffer = std::string(input);
+      unicode::to_lower_ascii(_buffer.data(), _buffer.size());
+      type = ada::scheme::get_scheme_type(_buffer);
+      buffer += _buffer;
+    }
+    return true;
+  }
+
+  ada_really_inline ada::scheme::type get_scheme_type() const noexcept {
+    return type;
+  }
+
+  std::string buffer;
+};
+} // namespace ada::parser
+#endif // ADA_HREF_AGGREGATOR_H

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -9,6 +9,7 @@
 #include "ada/url.h"
 #include "ada/encoding_type.h"
 #include "ada/expected.h"
+#include "ada/href_aggregator.h"
 #include <optional>
 #include <string_view>
 
@@ -21,7 +22,15 @@ namespace ada::parser {
   /**
    * Parses a url.
    */
-  url parse_url(std::string_view user_input,
+  template <class result_type = url>
+  result_type parse_url(std::string_view user_input,
+                const ada::url* base_url = nullptr,
+                ada::encoding_type encoding = ada::encoding_type::UTF8);
+
+  extern template href_aggregator parse_url<href_aggregator>(std::string_view user_input,
+                const ada::url* base_url = nullptr,
+                ada::encoding_type encoding = ada::encoding_type::UTF8);
+  extern template url parse_url<url>(std::string_view user_input,
                 const ada::url* base_url = nullptr,
                 ada::encoding_type encoding = ada::encoding_type::UTF8);
 

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -19,6 +19,9 @@
  */
 namespace ada::parser {
 
+  // TODO: parse_url should not take a onst ada::url* base_url, instead it should take
+  // in a pointer to a more abstract class that can provide the basis for what we need.
+
   /**
    * Parses a url.
    */

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -368,6 +368,13 @@ namespace ada {
      * @see https://github.com/servo/rust-url/blob/b65a45515c10713f6d212e6726719a020203cc98/url/src/quirks.rs#L31
      */
     [[nodiscard]] ada_really_inline ada::url_components get_components() noexcept;
+    
+    /**
+     * Set the specified value as the fragment of this URL.
+     * The string is not processed, this is a direct assignment.
+     */
+    void set_fragment(std::string&& p) { fragment = p; }
+    void set_fragment(std::string_view p) { fragment = p; }
 
   private:
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -13,7 +13,7 @@ namespace ada {
     if(encoding != encoding_type::UTF8) {
       // @todo Add support for non UTF8 input
     }
-    ada::url u = ada::parser::parse_url(input, base_url, encoding);
+    ada::url u = ada::parser::parse_url<ada::url>(input, base_url, encoding);
     if(!u.is_valid) { return tl::unexpected(errors::generic_error); }
     return u;
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,8 +11,8 @@
 #include <string_view>
 
 namespace ada::parser {
-
-  url parse_url(std::string_view user_input,
+  template <class result_type>
+  result_type parse_url(std::string_view user_input,
                 const ada::url* base_url,
                 ada::encoding_type encoding) {
     ada_log("ada::parser::parse_url('", user_input,
@@ -20,7 +20,7 @@ namespace ada::parser {
      ",", ada::to_string(encoding), ")");
 
     ada::state state = ada::state::SCHEME_START;
-    ada::url url = ada::url();
+    result_type url{};
 
     // We refuse to parse URL strings that exceed 4GB. Such strings are almost
     // surely the result of a bug or are otherwise a security concern.
@@ -50,8 +50,8 @@ namespace ada::parser {
     // Optimization opportunity. Most websites do not have fragment.
     std::optional<std::string_view> fragment = helpers::prune_fragment(url_data);
     if(fragment.has_value()) {
-      url.fragment = unicode::percent_encode(*fragment,
-                                             ada::character_sets::FRAGMENT_PERCENT_ENCODE);
+      url.set_fragment(unicode::percent_encode(*fragment,
+                                             ada::character_sets::FRAGMENT_PERCENT_ENCODE));
     }
 
     // Here url_data no longer has its fragment.
@@ -644,5 +644,12 @@ namespace ada::parser {
     ada_log("returning ", url.to_string());
     return url;
   }
+
+  template url parse_url<url>(std::string_view user_input,
+                const ada::url* base_url = nullptr,
+                ada::encoding_type encoding = ada::encoding_type::UTF8);
+  template href_aggregator parse_url<href_aggregator>(std::string_view user_input,
+                const ada::url* base_url = nullptr,
+                ada::encoding_type encoding = ada::encoding_type::UTF8);
 
 } // namespace ada::parser


### PR DESCRIPTION
This PR is only for discussion and is not going to be completed (though it could be used as the basis for actual work).

It aims to show that the parser can produce different 'products' (instance types) depending on the need of the user. The ada/url class is rather sizeable, and just its constructor and destructor are non trivial. When most of its functionality is not used, it is probably wasted. This PR proposes a href_aggregator (though the name can be changed) that would be a lightweight equivalent. There is no need for much of the code logic to change, we just need to remove, in parse_url and related functions, the hardcoded assumptions about how the data is *stored* in the class instance. That's good in *any* case since it gives us more freedom to run further optimization.

Completing this is not difficult, it is mostly 'basic C++' and would require ~10 hours?