### PR TITLE
perf: improve url components getter

### DIFF
--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -145,9 +145,7 @@ namespace ada {
       out.host_start = out.protocol_end + 1;
       out.host_end = out.protocol_end + 1;
 
-      size_t url_delimiter_count = std::count(path.begin(), path.end(), '/');
-
-      if (!has_opaque_path && url_delimiter_count > 1 && path.length() >= 2 && path[0] == '/' && path[1] == '/') {
+      if (!has_opaque_path && checkers::begins_with(path, "//")) {
         // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
         // and url’s path[0] is the empty string, then append U+002F (/) followed by U+002E (.) to output.
         running_index = out.protocol_end + 3;


### PR DESCRIPTION
Before

```
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
BasicBench_AdaURL              31353288 ns     31351500 ns           22 GHz=3.22746 cycle/byte=11.5328 cycles/url=1001.73 instructions/byte=47.2392 instructions/cycle=4.09608 instructions/ns=13.2199 instructions/url=4.10316k ns/url=310.377 speed=277.119M/s time/byte=3.60856ns time/url=313.437ns url/s=3.19044M/s
BasicBench_AdaURL_just_parse   17773036 ns     17765025 ns           40 GHz=3.22812 cycle/byte=6.50058 cycles/url=564.635 instructions/byte=26.3988 instructions/cycle=4.06099 instructions/ns=13.1094 instructions/url=2.29298k ns/url=174.912 speed=489.056M/s time/byte=2.04476ns time/url=177.606ns url/s=5.63045M/s
```

After

```
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
BasicBench_AdaURL              31249888 ns     31249909 ns           22 GHz=3.22752 cycle/byte=11.4702 cycles/url=996.29 instructions/byte=47.3021 instructions/cycle=4.12392 instructions/ns=13.31 instructions/url=4.10862k ns/url=308.686 speed=278.02M/s time/byte=3.59687ns time/url=312.421ns url/s=3.20081M/s
BasicBench_AdaURL_just_parse   17491867 ns     17491875 ns           40 GHz=3.22866 cycle/byte=6.48159 cycles/url=562.985 instructions/byte=26.3987 instructions/cycle=4.07288 instructions/ns=13.1499 instructions/url=2.29297k ns/url=174.371 speed=496.693M/s time/byte=2.01332ns time/url=174.875ns url/s=5.71837M/s
```