### PR TITLE
Fix: compilation of proposal-aggregator

### DIFF
--- a/benchmarks/wpt_bench.cpp
+++ b/benchmarks/wpt_bench.cpp
@@ -36,7 +36,7 @@ static void BasicBench_AdaURL(benchmark::State &state) {
   for (auto _ : state) {
     for (const std::pair<std::string, std::string> &url_strings :
          url_examples) {
-      ada::result base;
+      ada::result<ada::url> base;
       ada::url* base_ptr = nullptr;
       if(!url_strings.second.empty()) {
         base = ada::parse(url_strings.second);
@@ -57,7 +57,7 @@ static void BasicBench_AdaURL(benchmark::State &state) {
       collector.start();
       for (const std::pair<std::string, std::string> &url_strings :
            url_examples) {
-        ada::result base;
+        ada::result<ada::url> base;
         ada::url* base_ptr = nullptr;
         if(!url_strings.second.empty()) {
             base = ada::parse(url_strings.second);

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -125,55 +125,55 @@ namespace ada {
     return out;
   }
 
-  void url::update_base_hash(std::string_view input) {
+  inline void url::update_base_hash(std::string_view input) {
     fragment = input;
   }
 
-  void url::update_base_search(std::optional<std::string> input) {
+  inline void url::update_base_search(std::optional<std::string> input) {
     query = input;
   }
 
-  void url::update_base_pathname(const std::string_view input) {
+  inline void url::update_base_pathname(const std::string_view input) {
     path = input;
   }
 
-  void url::update_base_username(const std::string_view input) {
+  inline void url::update_base_username(const std::string_view input) {
     username = input;
   }
 
-  void url::update_base_password(const std::string_view input) {
+  inline void url::update_base_password(const std::string_view input) {
     password = input;
   }
 
-  void url::update_base_port(std::optional<uint32_t> input) {
+  inline void url::update_base_port(std::optional<uint32_t> input) {
     port = input;
   }
 
-  std::optional<uint32_t> url::retrieve_base_port() {
+  inline std::optional<uint32_t> url::retrieve_base_port() {
     return port;
   }
 
-  std::string url::retrieve_base_pathname() {
+  inline std::string url::retrieve_base_pathname() {
     return path;
   }
 
-  void url::clear_base_hash() {
+  inline void url::clear_base_hash() {
     fragment = std::nullopt;
   }
 
-  bool url::base_fragment_has_value() const {
+  inline bool url::base_fragment_has_value() const {
     return fragment.has_value();
   }
 
-  bool url::base_search_has_value() const {
+  inline bool url::base_search_has_value() const {
     return query.has_value();
   }
 
-  bool url::base_port_has_value() const {
+  inline bool url::base_port_has_value() const {
     return port.has_value();
   }
 
-  bool url::base_hostname_has_value() const {
+  inline bool url::base_hostname_has_value() const {
     return host.has_value();
   }
 

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -110,31 +110,31 @@ namespace ada {
     bool set_host_or_hostname(std::string_view input, bool override_hostname);
 
     /** @private */
-    void update_base_hash(std::string_view input);
+    inline void update_base_hash(std::string_view input);
     /** @private */
-    void update_base_search(std::optional<std::string> input);
+    inline void update_base_search(std::optional<std::string> input);
     /** @private */
-    void update_base_pathname(const std::string_view input);
+    inline void update_base_pathname(const std::string_view input);
     /** @private */
-    void update_base_username(const std::string_view input);
+    inline void update_base_username(const std::string_view input);
     /** @private */
-    void update_base_password(const std::string_view input);
+    inline void update_base_password(const std::string_view input);
     /** @private */
-    void update_base_port(std::optional<uint32_t> input);
+    inline void update_base_port(std::optional<uint32_t> input);
     /** @private */
-    std::optional<uint32_t> retrieve_base_port();
+    inline std::optional<uint32_t> retrieve_base_port();
     /** @private */
-    std::string retrieve_base_pathname();
+    inline std::string retrieve_base_pathname();
     /** @private */
-    void clear_base_hash();
+    inline void clear_base_hash();
     /** @private */
-    bool base_hostname_has_value() const;
+    inline bool base_hostname_has_value() const;
     /** @private */
-    bool base_fragment_has_value() const;
+    inline bool base_fragment_has_value() const;
     /** @private */
-    bool base_search_has_value() const;
+    inline bool base_search_has_value() const;
     /** @private */
-    bool base_port_has_value() const;
+    inline bool base_port_has_value() const;
 
     /**
      * Returns true if this URL has a valid domain as per RFC 1034 and

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -36,7 +36,7 @@ namespace ada {
     url(url &&u) noexcept = default;
     url &operator=(url &&u) noexcept = default;
     url &operator=(const url &u) = default;
-    ADA_ATTRIBUTE_NOINLINE ~url() = default;
+    ~url() = default;
 
     /**
      * @private

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -13,14 +13,14 @@
 
 namespace ada {
 
-void url_aggregator::update_base_hash(std::string_view input) {
+inline void url_aggregator::update_base_hash(std::string_view input) {
   buffer.resize(components.hash_start);
   components.hash_start = uint32_t(buffer.size());
   buffer += "#";
   buffer.append(input);
 }
 
-void url_aggregator::update_base_search(std::optional<std::string> input) {
+inline void url_aggregator::update_base_search(std::optional<std::string> input) {
   bool has_hash = components.hash_start != url_components::omitted;
 
   if (has_hash) {
@@ -37,57 +37,57 @@ void url_aggregator::update_base_search(std::optional<std::string> input) {
   }
 }
 
-void url_aggregator::update_base_pathname(const std::string_view input) {
+inline void url_aggregator::update_base_pathname(const std::string_view input) {
   // TODO: Implement this
   void(input.size());
 }
 
-void url_aggregator::update_base_username(const std::string_view input) {
+inline void url_aggregator::update_base_username(const std::string_view input) {
   // TODO: Implement this
   void(input.size());
 }
 
-void url_aggregator::update_base_password(const std::string_view input) {
+inline void url_aggregator::update_base_password(const std::string_view input) {
   // TODO: Implement this
   void(input.size());
 }
 
-void url_aggregator::update_base_port(std::optional<uint32_t> input) {
+inline void url_aggregator::update_base_port(std::optional<uint32_t> input) {
   components.port = input.value_or(url_components::omitted);
 }
 
-std::optional<uint32_t> url_aggregator::retrieve_base_port() {
+inline std::optional<uint32_t> url_aggregator::retrieve_base_port() {
   if (components.port == url_components::omitted) {
     return std::nullopt;
   }
   return components.port;
 }
 
-std::string url_aggregator::retrieve_base_pathname() {
+inline std::string url_aggregator::retrieve_base_pathname() {
   size_t ending = std::string_view::npos;
   if (base_search_has_value()) { ending = components.search_start; }
   else if (base_fragment_has_value()) { ending = components.hash_start; }
   return buffer.substr(components.pathname_start, ending);
 }
 
-void url_aggregator::clear_base_hash() {
+inline void url_aggregator::clear_base_hash() {
   components.hash_start = url_components::omitted;
   buffer.resize(components.hash_start);
 }
 
-bool url_aggregator::base_fragment_has_value() const {
+inline bool url_aggregator::base_fragment_has_value() const {
   return components.hash_start != url_components::omitted;
 }
 
-bool url_aggregator::base_search_has_value() const {
+inline bool url_aggregator::base_search_has_value() const {
   return components.search_start != url_components::omitted;
 }
 
-bool url_aggregator::base_port_has_value() const {
+inline bool url_aggregator::base_port_has_value() const {
   return components.port != url_components::omitted;
 }
 
-bool url_aggregator::base_hostname_has_value() const {
+inline bool url_aggregator::base_hostname_has_value() const {
   return components.host_start != components.host_end;
 }
 

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -21,11 +21,11 @@ namespace ada {
     url_aggregator(url_aggregator &&u) noexcept = default;
     url_aggregator &operator=(url_aggregator &&u) noexcept = default;
     url_aggregator &operator=(const url_aggregator &u) = default;
-    ADA_ATTRIBUTE_NOINLINE ~url_aggregator() = default;
+    ~url_aggregator() = default;
 
     std::string buffer{};
 
-    url_components components;
+    url_components components{};
 
     bool set_href(const std::string_view input);
     bool set_host(const std::string_view input);

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -49,31 +49,31 @@ namespace ada {
     [[nodiscard]] inline bool cannot_have_credentials_or_port() const;
 
     /** @private */
-    void update_base_hash(std::string_view input);
+    inline void update_base_hash(std::string_view input);
     /** @private */
-    void update_base_search(std::optional<std::string> input);
+    inline void update_base_search(std::optional<std::string> input);
     /** @private */
-    void update_base_pathname(const std::string_view input);
+    inline void update_base_pathname(const std::string_view input);
     /** @private */
-    void update_base_username(const std::string_view input);
+    inline void update_base_username(const std::string_view input);
     /** @private */
-    void update_base_password(const std::string_view input);
+    inline void update_base_password(const std::string_view input);
     /** @private */
-    void update_base_port(std::optional<uint32_t> input);
+    inline void update_base_port(std::optional<uint32_t> input);
     /** @private */
-    std::optional<uint32_t> retrieve_base_port();
+    inline std::optional<uint32_t> retrieve_base_port();
     /** @private */
-    std::string retrieve_base_pathname();
+    inline std::string retrieve_base_pathname();
     /** @private */
-    void clear_base_hash();
+    inline void clear_base_hash();
     /** @private */
-    bool base_hostname_has_value() const;
+    inline bool base_hostname_has_value() const;
     /** @private */
-    bool base_fragment_has_value() const;
+    inline bool base_fragment_has_value() const;
     /** @private */
-    bool base_search_has_value() const;
+    inline bool base_search_has_value() const;
     /** @private */
-    bool base_port_has_value() const;
+    inline bool base_port_has_value() const;
 
   }; // url_aggregator
 

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -7,7 +7,7 @@
 
 #include "ada/common_defs.h"
 #include "ada/url_components.h"
-#include "scheme.h"
+#include "ada/scheme.h"
 
 #include <string_view>
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -19,6 +19,14 @@ namespace ada {
     return u;
   }
 
+  template ada::result<url> parse<url>(std::string_view input,
+                                              const ada::url* base_url = nullptr,
+                                              ada::encoding_type encoding = ada::encoding_type::UTF8);
+
+  template ada::result<url_aggregator> parse<url_aggregator>(std::string_view input,
+                                                                         const ada::url* base_url = nullptr,
+                                                                         ada::encoding_type encoding = ada::encoding_type::UTF8);
+
   std::string href_from_file(std::string_view input) {
     // This is going to be much faster than constructing a URL.
     std::string tmp_buffer;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -9,12 +9,23 @@
 #include <optional>
 #include <string_view>
 
+
+
 namespace ada::parser {
 
   template <class result_type>
   result_type parse_url(std::string_view user_input,
                         const ada::url* base_url,
                         ada::encoding_type encoding) {
+    // We can specialize the implementation per type.
+    // Important: result_type_is_ada_url is evaluated at *compile time*. This means
+    // that doing if constexpr(result_type_is_ada_url) { something } else { something else }
+    // is free (at runtime).
+    // This means that ada::url_aggregator and ada::url **do not have to support the exact same API**.
+    constexpr bool result_type_is_ada_url = std::is_same<ada::url, result_type>::value;
+    constexpr bool result_type_is_ada_url_aggregator = std::is_same<ada::url_aggregator, result_type>::value;
+    static_assert(result_type_is_ada_url || result_type_is_ada_url_aggregator); // We don't support anything else for now.
+
     ada_log("ada::parser::parse_url('", user_input,
      "' [", user_input.size()," bytes],", (base_url != nullptr ? base_url->to_string() : "null"),
      ",", ada::to_string(encoding), ")");
@@ -184,9 +195,9 @@ namespace ada::parser {
               // If atSignSeen is true, then prepend "%40" to buffer.
               if (at_sign_seen) {
                 if (password_token_seen) {
-                  url.password += "%40";
+                  if constexpr (result_type_is_ada_url) { url.password += "%40"; } else { /* TODO */}
                 } else {
-                  url.username += "%40";
+                  if constexpr (result_type_is_ada_url) { url.username += "%40"; } else { /* TODO */}
                 }
               }
 
@@ -197,14 +208,26 @@ namespace ada::parser {
                 password_token_seen = password_token_location != std::string_view::npos;
 
                 if (!password_token_seen) {
-                  url.username += unicode::percent_encode(authority_view, character_sets::USERINFO_PERCENT_ENCODE);
+                  if constexpr(result_type_is_ada_url) {
+                    url.username += unicode::percent_encode(authority_view, character_sets::USERINFO_PERCENT_ENCODE);
+                  } else {
+                    // TODO
+                  }
                 } else {
-                  url.username += unicode::percent_encode(authority_view.substr(0,password_token_location), character_sets::USERINFO_PERCENT_ENCODE);
-                  url.password += unicode::percent_encode(authority_view.substr(password_token_location+1), character_sets::USERINFO_PERCENT_ENCODE);
+                  if constexpr(result_type_is_ada_url) {
+                    url.username += unicode::percent_encode(authority_view.substr(0,password_token_location), character_sets::USERINFO_PERCENT_ENCODE);
+                    url.password += unicode::percent_encode(authority_view.substr(password_token_location+1), character_sets::USERINFO_PERCENT_ENCODE);
+                  } else {
+                    // TODO
+                  }
                 }
               }
               else {
-                url.password += unicode::percent_encode(authority_view, character_sets::USERINFO_PERCENT_ENCODE);
+                if constexpr (result_type_is_ada_url) {
+                  url.password += unicode::percent_encode(authority_view, character_sets::USERINFO_PERCENT_ENCODE);
+                } else {
+                  // TODO
+                }
               }
             }
             // Otherwise, if one of the following is true:
@@ -275,7 +298,11 @@ namespace ada::parser {
             // url’s port to base’s port, url’s path to a clone of base’s path, and url’s query to base’s query.
             url.update_base_username(base_url->username);
             url.update_base_password(base_url->password);
-            url.host = base_url->host;
+            if constexpr (result_type_is_ada_url) {
+              url.host = base_url->host;
+            } else  {
+              // TODO
+            }
             url.update_base_port(base_url->port);
             url.update_base_pathname(base_url->path);
             url.has_opaque_path = base_url->has_opaque_path;
@@ -289,10 +316,12 @@ namespace ada::parser {
             else if (input_position != input_size) {
               // Set url’s query to null.
               url.update_base_search(std::nullopt);
-
-              // Shorten url’s path.
-              helpers::shorten_path(url.path, url.type);
-
+              if constexpr (result_type_is_ada_url) {
+                // Shorten url’s path.
+                helpers::shorten_path(url.path, url.type);
+              } else {
+                // TODO
+              }
               // Set state to path state and decrease pointer by 1.
               state = ada::state::PATH;
               break;
@@ -322,7 +351,11 @@ namespace ada::parser {
           else {
             url.update_base_username(base_url->username);
             url.update_base_password(base_url->password);
-            url.host = base_url->host;
+            if constexpr (result_type_is_ada_url) {
+              url.host = base_url->host;
+            } else {
+              // TODO
+            }
             url.update_base_port(base_url->port);
             state = ada::state::PATH;
             break;
@@ -391,8 +424,12 @@ namespace ada::parser {
             // If buffer is the empty string, validation error, return failure.
             // Let host be the result of host parsing buffer with url is not special.
             ada_log("HOST parsing ", host_view);
-            if(!url.parse_host(host_view)) { return url; }
-            ada_log("HOST parsing results in ", url.base_hostname_has_value() ? "none" : url.host.value());
+            if constexpr (result_type_is_ada_url) {
+              if(!url.parse_host(host_view)) { return url; }
+              ada_log("HOST parsing results in ", url.base_hostname_has_value() ? "none" : url.host.value());
+            } else {
+              // TODO
+            }
             // Set url’s host to host, buffer to the empty string, and state to port state.
             state = ada::state::PORT;
             input_position++;
@@ -412,9 +449,17 @@ namespace ada::parser {
 
             // Let host be the result of host parsing host_view with url is not special.
             if (host_view.empty()) {
-              url.host = "";
+              if constexpr (result_type_is_ada_url) {
+                url.host = "";
+              } else {
+                // TODO
+              }
             } else {
-              if(!url.parse_host(host_view)) { return url; }
+              if constexpr(result_type_is_ada_url) {
+                if(!url.parse_host(host_view)) { return url; }
+              } else {
+                // TODO
+              }
             }
             // Set url’s host to host, and state to path start state.
             state = ada::state::PATH_START;
@@ -499,7 +544,11 @@ namespace ada::parser {
           } else {
             input_position = input_size + 1;
           }
-          if(!helpers::parse_prepared_path(view, url.type, url.path)) { return url; }
+          if constexpr (result_type_is_ada_url) {
+            if(!helpers::parse_prepared_path(view, url.type, url.path)) { return url; }
+          } else {
+            // TODO
+          }
           break;
         }
         case ada::state::FILE_SLASH: {
@@ -518,8 +567,11 @@ namespace ada::parser {
             // base_url_has_value() is true.
             if (base_url != nullptr && base_url->type == ada::scheme::type::FILE) {
               // Set url’s host to base’s host.
-              url.host = base_url->host;
-
+              if constexpr (result_type_is_ada_url) {
+                url.host = base_url->host;
+              } else {
+                // TODO
+              }
               // If the code point substring from pointer to the end of input does not start with
               // a Windows drive letter and base’s path[0] is a normalized Windows drive letter,
               // then append base’s path[0] to url’s path.
@@ -532,8 +584,12 @@ namespace ada::parser {
                     first_base_url_path.remove_suffix(first_base_url_path.size() - loc);
                   }
                   if (checkers::is_normalized_windows_drive_letter(first_base_url_path)) {
-                    url.path += '/';
-                    url.path += first_base_url_path;
+                    if constexpr (result_type_is_ada_url) {
+                      url.path += '/';
+                      url.path += first_base_url_path;
+                    } else {
+                      // TODO
+                    }
                   }
                 }
               }
@@ -556,18 +612,25 @@ namespace ada::parser {
             state = ada::state::PATH;
           } else if (file_host_buffer.empty()) {
             // Set url’s host to the empty string.
-            url.host = "";
+            if constexpr (result_type_is_ada_url) {
+              url.host = "";
+            } else {
+              // TODO
+            }
             // Set state to path start state.
             state = ada::state::PATH_START;
           } else {
             size_t consumed_bytes = file_host_buffer.size();
             input_position += consumed_bytes;
             // Let host be the result of host parsing buffer with url is not special.
-            if(!url.parse_host(file_host_buffer)) { return url; }
-
-            // If host is "localhost", then set host to the empty string.
-            if (url.base_hostname_has_value() && url.host.value() == "localhost") {
-              url.host = "";
+            if constexpr (result_type_is_ada_url) {
+              if(!url.parse_host(file_host_buffer)) { return url; }
+              // If host is "localhost", then set host to the empty string.
+              if (url.base_hostname_has_value() && url.host.value() == "localhost") {
+                url.host = "";
+              }
+            } else {
+              // TODO
             }
 
             // Set buffer to the empty string and state to path start state.
@@ -582,10 +645,12 @@ namespace ada::parser {
 
           // Set url’s scheme to "file".
           url.set_scheme("file");
-
-          // Set url’s host to the empty string.
-          url.host = "";
-
+          if constexpr (result_type_is_ada_url) {
+            // Set url’s host to the empty string.
+            url.host = "";
+          } else {
+            // TODO
+          }
           // If c is U+002F (/) or U+005C (\), then:
           if (input_position != input_size && (url_data[input_position] == '/' || url_data[input_position] == '\\')) {
             ada_log("FILE c is U+002F or U+005C");
@@ -596,7 +661,11 @@ namespace ada::parser {
           else if (base_url != nullptr && base_url->type == ada::scheme::type::FILE) {
             // Set url’s host to base’s host, url’s path to a clone of base’s path, and url’s query to base’s query.
             ada_log("FILE base non-null");
-            url.host = base_url->host;
+            if constexpr (result_type_is_ada_url) {
+              url.host = base_url->host;
+            } else {
+              // TODO
+            }
             url.update_base_pathname(base_url->path);
             url.has_opaque_path = base_url->has_opaque_path;
             url.update_base_search(base_url->query);
@@ -613,12 +682,20 @@ namespace ada::parser {
               // If the code point substring from pointer to the end of input does not start with a
               // Windows drive letter, then shorten url’s path.
               if (!checkers::is_windows_drive_letter(file_view)) {
-                helpers::shorten_path(url.path, url.type);
+                if constexpr (result_type_is_ada_url) {
+                  helpers::shorten_path(url.path, url.type);
+                } else {
+                  // TODO
+                }
               }
               // Otherwise:
               else {
                 // Set url’s path to an empty list.
-                url.path.clear();
+                if constexpr (result_type_is_ada_url) {
+                  url.path.clear();
+                } else {
+                  // TODO
+                }
                 url.has_opaque_path = true;
               }
 
@@ -641,7 +718,11 @@ namespace ada::parser {
           ada::unreachable();
       }
     }
-    ada_log("returning ", url.to_string());
+    if constexpr (result_type_is_ada_url) {
+      ada_log("returning ", url.to_string());
+    } else {
+      // TODO
+    }
     return url;
   }
 

--- a/src/url_base.cpp
+++ b/src/url_base.cpp
@@ -182,6 +182,7 @@ ada_really_inline bool url_base::parse_scheme(const std::string_view input) {
     // Next function is only valid if the input is ASCII and returns false
     // otherwise, but it seems that we always have ascii content so we do not need
     // to check the return value.
+    unicode::to_lower_ascii(_buffer.data(), _buffer.size());
 
     if (has_state_override) {
       // If url’s scheme is a special scheme and buffer is not a special scheme, then return.

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -44,7 +44,7 @@ std::string url_examples[] = {
 // This function copies your input onto a memory buffer that
 // has just the necessary size. This will entice tools to detect
 // an out-of-bound access.
-ada::result ada_parse(std::string_view view) {
+ada::result<ada::url> ada_parse(std::string_view view) {
   std::unique_ptr<char[]> buffer(new char[view.size()]);
   memcpy(buffer.get(), view.data(), view.size());
   return ada::parse(std::string_view(buffer.get(), view.size()));

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -33,7 +33,7 @@
 
 bool set_host_should_return_false_sometimes() {
     TEST_START()
-    ada::result r = ada::parse("mailto:a@b.com");
+    ada::result<ada::url> r = ada::parse("mailto:a@b.com");
     bool b = r->set_host("something");
     TEST_ASSERT(b, false, "set_host should return false")
     TEST_SUCCEED() 
@@ -41,7 +41,7 @@ bool set_host_should_return_false_sometimes() {
 
 bool set_host_should_return_true_sometimes() {
     TEST_START()
-    ada::result r = ada::parse("https://www.google.com");
+    ada::result<ada::url> r = ada::parse("https://www.google.com");
     bool b = r->set_host("something");
     TEST_ASSERT(b, true, "set_host should return true")
     TEST_SUCCEED() 
@@ -50,7 +50,7 @@ bool set_host_should_return_true_sometimes() {
 
 bool set_hostname_should_return_false_sometimes() {
     TEST_START()
-    ada::result r = ada::parse("mailto:a@b.com");
+    ada::result<ada::url> r = ada::parse("mailto:a@b.com");
     bool b = r->set_hostname("something");
     TEST_ASSERT(b, false, "set_hostname should return false")
     TEST_SUCCEED() 
@@ -58,7 +58,7 @@ bool set_hostname_should_return_false_sometimes() {
 
 bool set_hostname_should_return_true_sometimes() {
     TEST_START()
-    ada::result r = ada::parse("https://www.google.com");
+    ada::result<ada::url> r = ada::parse("https://www.google.com");
     bool b = r->set_hostname("something");
     TEST_ASSERT(b, true, "set_hostname should return true")
     TEST_SUCCEED() 
@@ -66,14 +66,14 @@ bool set_hostname_should_return_true_sometimes() {
 
 bool readme1() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     TEST_ASSERT(bool(url), true, "URL is valid")
     TEST_SUCCEED() 
 }
 
 bool readme2() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_username("username");
     url->set_password("password");
     TEST_ASSERT(url->get_href(), "https://username:password@www.google.com/", "href returned bad result")
@@ -82,7 +82,7 @@ bool readme2() {
 
 bool readme3() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_protocol("wss");
     TEST_ASSERT(url->get_protocol(), "wss:", "get_protocol returned bad result")
     TEST_ASSERT(url->get_href(), "wss://www.google.com/", "get_href returned bad result")
@@ -92,7 +92,7 @@ bool readme3() {
 
 bool readme4() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_host("github.com");
     TEST_ASSERT(url->get_host(), "github.com", "get_host returned bad result")
     TEST_SUCCEED() 
@@ -100,7 +100,7 @@ bool readme4() {
 
 bool readme5() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_port("8080");
     TEST_ASSERT(url->get_port(), "8080", "get_port returned bad result")
     TEST_SUCCEED() 
@@ -108,7 +108,7 @@ bool readme5() {
 
 bool readme6() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_pathname("/my-super-long-path");
     TEST_ASSERT(url->get_pathname(), "/my-super-long-path", "get_pathname returned bad result")
     TEST_SUCCEED() 
@@ -116,7 +116,7 @@ bool readme6() {
 
 bool readme7() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_search("target=self");
     TEST_ASSERT(url->get_search(), "?target=self", "get_pathname returned bad result");
     TEST_SUCCEED() 
@@ -124,7 +124,7 @@ bool readme7() {
 
 bool readme8() {
     TEST_START()
-    ada::result url = ada::parse("https://www.google.com");
+    ada::result<ada::url> url = ada::parse("https://www.google.com");
     url->set_hash("is-this-the-real-life");
     TEST_ASSERT(url->get_hash(), "#is-this-the-real-life", "get_hash returned bad result");
     TEST_SUCCEED() 

--- a/tests/from_file_tests.cpp
+++ b/tests/from_file_tests.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 std::string long_way(std::string path) {
-  ada::result base = ada::parse("file://");
+  ada::result<ada::url> base = ada::parse("file://");
   base->set_pathname(path);
   return base->get_href();
 }

--- a/tests/url_components.cpp
+++ b/tests/url_components.cpp
@@ -18,7 +18,7 @@ std::set<std::string> bad_domains = {"http://./", "http://../", "http://foo.09..
 // This function copies your input onto a memory buffer that
 // has just the necessary size. This will entice tools to detect
 // an out-of-bound access.
-ada::result ada_parse(std::string_view view,const ada::url* base = nullptr) {
+ada::result<ada::url> ada_parse(std::string_view view,const ada::url* base = nullptr) {
   std::cout << "about to parse '" << view << "' [" << view.size() << " bytes]" << std::endl;
   std::unique_ptr<char[]> buffer(new char[view.size()]);
   memcpy(buffer.get(), view.data(), view.size());
@@ -102,7 +102,7 @@ bool urltestdata_encoding(const char* source) {
       }
       std::cout << "input='" << input << "' [" << input.size() << " bytes]" << std::endl;
       std::string_view base;
-      ada::result  base_url;
+      ada::result<ada::url> base_url;
       if (!object["base"].get(base)) {
         std::cout << "base=" << base << std::endl;
         base_url = ada_parse(base);
@@ -117,7 +117,7 @@ bool urltestdata_encoding(const char* source) {
         }
       }
       bool failure = false;
-      ada::result input_url = (!object["base"].get(base)) ? ada_parse(input, &*base_url) : ada_parse(input);
+      ada::result<ada::url> input_url = (!object["base"].get(base)) ? ada_parse(input, &*base_url) : ada_parse(input);
 
       if (object["failure"].get(failure)) {
         auto url = input_url.value();


### PR DESCRIPTION
The PR https://github.com/ada-url/ada/pull/260 and the branch proposal-aggregator represents an excellent development branch allowing us to build the new url_aggregator support created by @anonrig.

However, up till now, it would not build nor pass our test. I find it difficult to work in such a context (it is a personal take), so what this PR does is fix the build. I have not checked the performance, but I assume that it is on par with our main branch.

This PR does not fix or test the new url_aggregator support, it only makes sure that the existing support for the production of ada::url instances is still operational.

Here are the fixes:

1. For some reason, one call to unicode::to_lower_ascii was deleted. I had to put it back. (???)
2. I had to inline a bunch of function. (Trivial issue.)
3. In our main parsing routine, I suggest we use 'if constexpr' expression: this ensures that we can support both ada::url and ada::url_aggregator in the same function while possibly allowing a divergent API. That's the beauty of C++ templates and C++17. Furthermore, this allows us to change the implementation just for ada::url_aggregator at times, without affecting at all ada::url.


It leaves *many* TODOs... however, at least as far as building the code goes, we can fill them in one by one... and progressively climb out way up.

I would suggest, as a next step, to include *some* tests for url_aggregator so we can progressively implement and test. I would discourage a long progress of implementation ending in a round of testing, as it could be discouraging.

Warning: this a PR on top of [proposal-aggregator](https://github.com/ada-url/ada/tree/proposal-aggregator).