### PR TITLE
Various comments on feat-add-protocol-setters

### DIFF
--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -144,9 +144,16 @@ url::get_components() const noexcept {
 }
 
 inline void url::update_base_hash(std::string_view input) {
+  fragment = input; // here we assume that the content was *already* percent encoded.
+}
+inline void url::update_unencoded_base_hash(std::string_view input) {
+  // We do the percent encoding
   fragment = unicode::percent_encode(input, ada::character_sets::FRAGMENT_PERCENT_ENCODE);
 }
 
+inline void url::update_base_search(std::string_view input, const uint8_t query_percent_encode_set[]) {
+  query = ada::unicode::percent_encode(input, query_percent_encode_set);
+}
 inline void url::update_base_search(std::optional<std::string> input) {
   query = input;
 }

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -94,6 +94,12 @@ struct url : url_base {
   /** @private */
   inline void update_base_hash(std::string_view input);
   /** @private */
+  inline void update_unencoded_base_hash(std::string_view input);
+  /** @private */
+  inline void update_base_search(std::string_view input);
+  /** @private */
+  inline void update_base_search(std::string_view input, const uint8_t query_percent_encode_set[]);
+  /** @private */
   inline void update_base_search(std::optional<std::string> input);
   /** @private */
   inline void update_base_pathname(const std::string_view input);

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -18,7 +18,36 @@ inline void url_aggregator::update_base_hash(std::string_view input) {
   buffer.resize(components.hash_start);
   components.hash_start = uint32_t(buffer.size());
   buffer += "#";
+  buffer += input; // assume already percent encoded
+}
+
+inline void url_aggregator::update_unencoded_base_hash(std::string_view input) {
+  buffer.resize(components.hash_start);
+  components.hash_start = uint32_t(buffer.size());
+  buffer += "#";
   unicode::percent_encode<true>(input,ada::character_sets::FRAGMENT_PERCENT_ENCODE, buffer);
+}
+
+inline void url_aggregator::update_base_search(std::string_view input) {
+  bool has_hash = components.hash_start != url_components::omitted;
+  if (has_hash) {
+    // TODO: Implement this.
+  } else {
+    buffer.resize(components.search_start);
+    buffer += "?";
+    buffer += input;
+  }
+}
+
+inline void url_aggregator::update_base_search(std::string_view input, const uint8_t query_percent_encode_set[]) {
+  bool has_hash = components.hash_start != url_components::omitted;
+  if (has_hash) {
+    // TODO: Implement this.
+  } else {
+    buffer.resize(components.search_start);
+    buffer += "?";
+    unicode::percent_encode<true>(input, query_percent_encode_set, buffer);
+  }
 }
 
 inline void url_aggregator::update_base_search(std::optional<std::string_view> input) {
@@ -31,7 +60,7 @@ inline void url_aggregator::update_base_search(std::optional<std::string_view> i
 
     if (input.has_value()) {
       buffer += "?";
-      buffer.append(input.value());
+      buffer += input.value();
     } else {
       components.search_start = url_components::omitted;
     }

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -148,6 +148,12 @@ namespace ada {
     /** @private */
     inline void update_base_hash(std::string_view input);
     /** @private */
+    inline void update_unencoded_base_hash(std::string_view input);
+    /** @private */
+    inline void update_base_search(std::string_view input);
+    /** @private */
+    inline void update_base_search(std::string_view input, const uint8_t query_percent_encode_set[]);
+    /** @private */
     inline void update_base_search(std::optional<std::string_view> input);
     /** @private */
     inline void update_base_pathname(const std::string_view input);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -61,7 +61,7 @@ namespace ada::parser {
       //                                       ada::character_sets::FRAGMENT_PERCENT_ENCODE));
       // This is much better as we pass a std::string_view, which opens up optimization
       // opportunities.
-      url.update_base_hash(*fragment);
+      url.update_unencoded_base_hash(*fragment);
     }
 
     // Here url_data no longer has its fragment.
@@ -327,7 +327,7 @@ namespace ada::parser {
             // Otherwise, if c is not the EOF code point:
             else if (input_position != input_size) {
               // Set url’s query to null.
-              url.update_base_search(std::nullopt);
+              url.update_base_search(std::nullopt); ///////// why don't we have a simple 'remove_search?', it would be faster and simpler!!!!!!
               if constexpr (result_type_is_ada_url) {
                 // Shorten url’s path.
                 helpers::shorten_path(url.path, url.type);
@@ -413,8 +413,10 @@ namespace ada::parser {
 
           // Percent-encode after encoding, with encoding, buffer, and queryPercentEncodeSet,
           // and append the result to url’s query.
-          url.update_base_search(ada::unicode::percent_encode(helpers::substring(url_data, input_position), query_percent_encode_set));
-
+          // The following is not good since we create a temporary string:
+          // url.update_base_search(ada::unicode::percent_encode(helpers::substring(url_data, input_position), query_percent_encode_set));
+          url.update_base_search(helpers::substring(url_data, input_position), query_percent_encode_set);
+          // passing a std::string_view opens up optimizations opportunities!!!
           return url;
         }
         case ada::state::HOST: {
@@ -486,6 +488,11 @@ namespace ada::parser {
             input_position = input_size + 1;
           }
           url.has_opaque_path = true;
+          /***
+          * This is not good. unicode::percent_encode(view, character_sets::C0_CONTROL_PERCENT_ENCODE) will
+          * create a temporary string, and then we pass a std::string_view to update_base_pathname which
+          * may then be converted back into a string.
+          ***/
           url.update_base_pathname(unicode::percent_encode(view, character_sets::C0_CONTROL_PERCENT_ENCODE));
           break;
         }
@@ -684,7 +691,7 @@ namespace ada::parser {
             // Otherwise, if c is not the EOF code point:
             else if (input_position != input_size) {
               // Set url’s query to null.
-              url.update_base_search(std::nullopt);
+              url.update_base_search(std::nullopt); // This is not good: we should have a simple function to remove the base
 
               // If the code point substring from pointer to the end of input does not start with a
               // Windows drive letter, then shorten url’s path.


### PR DESCRIPTION
1. Using std::string_view parameter is good, but it is not enough to ensure good perf and can actually trip you up and worsen the performance. If the caller creates a string, then and pass this string to a function that takes in a string_view, the string gets converted to a string_view. So far so good. But then, in some cases, we recreate a string from the string_view. This is likely worse that just moving the string. I fixed some of these cases, but not all of them.
2. As much as possible, we want to avoid temporary string creation. So creating a string, and then passing it as a string_view is something we should avoid. Instead, we should pass a string_view, pure and simple. If processing is needed, it should be done on the recipient side.
3. If we need to append a percent-encoded component  from a string_view to a buffer, it better to avoid the routine of creating a percent_encoded temporary string from the string_view, which we then append to the buffer. We want to append the percent-encoded characters directly to the buffer.
4. Using a std::optional<something> as a way to either pass the something or remove the value is probably not ideal. It is better to either pass the something, or have a different function just deletes the value. Indeed, in the worst case, the compiler might create a std::optional<std::string> with nothing in it, for naught. If you have an attribute  of type std::optional<std::string> on the receiving end, having a function that does 'reset()' on it, is surely efficient... as much so as doing std::optional<std::string> t = nullopt... But what if that's not what you have the receiving end... like you don't have a std::optional<std::string>, then passing a nullopt as way to communicate 'delete the value' is almost assuredly inefficient.


This PR can be merged to [feat-add-protocol-setters](https://github.com/ada-url/ada/tree/feat-add-protocol-setters)