### PR TITLE
optimization: This PR moves the insertion of the hash last

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -57,10 +57,9 @@ namespace ada::helpers {
   *
   * The input is expected to be UTF-8.
   *
-  * @return true on success.
   * @see https://url.spec.whatwg.org/
   */
-  ada_really_inline bool parse_prepared_path(const std::string_view input, ada::scheme::type type, std::string& path);
+  ada_really_inline void parse_prepared_path(const std::string_view input, ada::scheme::type type, std::string& path);
 
   /**
    * @private

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -139,7 +139,7 @@ struct url : url_base {
    *
    * @see https://url.spec.whatwg.org/
    */
-  [[nodiscard]] ada_really_inline bool parse_path(const std::string_view input);
+  ada_really_inline void parse_path(const std::string_view input);
 
   /**
    * Set the scheme for this URL. The provided scheme should be a valid

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -89,7 +89,7 @@ inline void url_aggregator::update_base_search(std::string_view input) {
   if(buffer.size() == components.search_start) { // common case
     buffer.append("?"); // TODO: in many instances, the '?' is part of the input and we could do as single append.
     buffer.append(input);
-  } else { // slowe case (uncommon)
+  } else { // slow case (uncommon)
     buffer.insert(components.search_start, "?");
     buffer.insert(components.search_start+1, input);
   }

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -135,7 +135,6 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   uint32_t difference = uint32_t(input.size()) - current_length;
   if(components.pathname_start == buffer.size()) { // common case
     buffer.append(input);
-    return;
   } else {
     buffer.erase(components.pathname_start, current_length);
     buffer.insert(components.pathname_start, input);

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -254,7 +254,7 @@ namespace ada {
       [[nodiscard]] bool parse_opaque_host(std::string_view input);
 
       /** @private */
-      ada_really_inline bool parse_path(std::string_view input);
+      ada_really_inline void parse_path(std::string_view input);
 
   }; // url_aggregator
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -321,7 +321,7 @@ namespace ada::helpers {
   }
 
 
-  ada_really_inline bool parse_prepared_path(std::string_view input, ada::scheme::type type, std::string& path) {
+  ada_really_inline void parse_prepared_path(std::string_view input, ada::scheme::type type, std::string& path) {
     ada_log("parse_prepared_path ", input);
     uint8_t accumulator = checkers::path_signature(input);
     // Let us first detect a trivial case.
@@ -346,7 +346,7 @@ namespace ada::helpers {
       ada_log("parse_path trivial");
       path += '/';
       path += input;
-      return true;
+      return;
     }
     // We are going to need to look a bit at the path, but let us see if we can
     // ignore percent encoding *and* backslashes *and* percent characters.
@@ -369,19 +369,19 @@ namespace ada::helpers {
           std::string_view path_view = input.substr(previous_location);
           if (path_view == "..") { // The path ends with ..
             // e.g., if you receive ".." with an empty path, you go to "/".
-            if(path.empty()) { path = '/'; return true; }
+            if(path.empty()) { path = '/'; return; }
             // Fast case where we have nothing to do:
-            if(path.back() == '/') { return true; }
+            if(path.back() == '/') { return; }
             // If you have the path "/joe/myfriend",
             // then you delete 'myfriend'.
             path.resize(path.rfind('/') + 1);
-            return true;
+            return;
           }
           path += '/';
           if (path_view != ".") {
             path.append(path_view);
           }
-          return true;
+          return;
         } else {
           // This is a non-final segment.
           std::string_view path_view = input.substr(previous_location, new_location - previous_location);
@@ -442,7 +442,7 @@ namespace ada::helpers {
           }
         }
         if (location == std::string_view::npos) {
-          return true;
+          return;
         }
       } while (true);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -56,7 +56,8 @@ namespace ada::parser {
 
     // Optimization opportunity. Most websites do not have fragment.
     std::optional<std::string_view> fragment = helpers::prune_fragment(url_data);
-    // We add it last.
+    // We add it last so that an implementation like ada::url_aggregator
+    // can append it last to its internal buffer, thus improving performance.
 
     // Here url_data no longer has its fragment.
     // We are going to access the data from url_data (it is immutable).

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -153,7 +153,8 @@ namespace ada {
   bool url::set_pathname(const std::string_view input) {
     if (has_opaque_path) { return false; }
     path = "";
-    return parse_path(input);
+    parse_path(input);
+    return true;
   }
 
   bool url::set_protocol(const std::string_view input) {

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -455,7 +455,7 @@ namespace ada {
     return true;
   }
 
-  ada_really_inline bool url::parse_path(std::string_view input) {
+  ada_really_inline void url::parse_path(std::string_view input) {
     ada_log("parse_path ", input);
     std::string tmp_buffer;
     std::string_view internal_input;
@@ -474,22 +474,26 @@ namespace ada {
       if(internal_input.empty()) {
         path = "/";
       } else if((internal_input[0] == '/') ||(internal_input[0] == '\\')){
-        return helpers::parse_prepared_path(internal_input.substr(1), type, path);
+        helpers::parse_prepared_path(internal_input.substr(1), type, path);
+        return;
       } else {
-        return helpers::parse_prepared_path(internal_input, type, path);
+        helpers::parse_prepared_path(internal_input, type, path);
+        return;
       }
     } else if (!internal_input.empty()) {
       if(internal_input[0] == '/') {
-        return helpers::parse_prepared_path(internal_input.substr(1), type, path);
+        helpers::parse_prepared_path(internal_input.substr(1), type, path);
+        return;
       } else {
-        return helpers::parse_prepared_path(internal_input, type, path);
+        helpers::parse_prepared_path(internal_input, type, path);
+        return;
       }
     } else {
       if(!host.has_value()) {
         path = "/";
       }
     }
-    return true;
+    return;
   }
 
   std::string url::to_string() const {


### PR DESCRIPTION
It enables some optimizations. Mostly it can make sure that we just append in the common case, never insert. Inserting in the middle of a string is not going to be cheap compared to an append.

I simplify a bit the code by removing unnecessary (and confusing) bool returns that I added earlier. It is a small thing but it bugged.

I fixed a bug with ipv4, but both ipv4 and ipv6 are likely buggy because after the parsing, we go back and put back the serialized string... effectively doubling the host.


I identified a few additional optimization opportunities. A major issue is that many times we do two appends or two insertions whereas just one would be needed. So if the input string contains '?something', we first locate 'something', and then we append '?' followed by an append of 'something'. This is likely running at half the speed. It seems very likely that we could avoid that.

It seems possible that we will or need to create our own backend string, maybe using `std::unique_ptr<char[]>` or maybe some pre-existing code.

