### PR TITLE
Testing empty and dash URLs (base-less).

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,30 @@ ada::result url = ada::parse("https://www.google.com");
 if(url) { /* URL is valid */ }
 ```
 
+After calling 'parse', you *must* check that the result is valid before
+accessing it when you are not sure that it will succeed. The following
+code is unsafe:
+
+```cpp
+ada::result url = ada::parse("some bad url");
+url->get_href();
+```
+
+You should do...
+
+```cpp
+ada::result url = ada::parse("some bad url");
+if(url) {
+  // next line is now safe:
+  url->get_href();
+} else {
+  // report a parsing failure
+}
+```
+
+For simplicity, in the examples below, we skip the check because
+we know that parsing succeeds.
+
 - Get/Update credentials
 
 ```cpp

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -171,6 +171,24 @@ bool nodejs4() {
   TEST_SUCCEED()
 }
 
+bool empty_url() {
+  TEST_START()
+  auto url = ada::parse("");
+  if(url) {
+    TEST_FAIL("Should not succeed on base-less empty URL.");
+  }
+  TEST_SUCCEED()
+}
+
+bool just_hash() {
+  TEST_START()
+  auto url = ada::parse("#x");
+  if(url) {
+    TEST_FAIL("Should not succeed on base-less hash url.");
+  }
+  TEST_SUCCEED()
+}
+
 int main() {
 #if ADA_HAS_ICU
   std::cout << "We are using ICU."<< std::endl;
@@ -182,7 +200,8 @@ int main() {
 #else
   std::cout << "You have litte-endian system."<< std::endl;
 #endif
-  bool success = set_host_should_return_false_sometimes()
+  bool success = just_hash() && empty_url()
+     && set_host_should_return_false_sometimes()
      && set_host_should_return_true_sometimes()
      && set_hostname_should_return_false_sometimes()
      && set_hostname_should_return_true_sometimes()

--- a/tests/wpt/ada_extra_urltestdata.json
+++ b/tests/wpt/ada_extra_urltestdata.json
@@ -20,11 +20,6 @@
     "hash":"#x"
   },
   {
-    "input": "",
-    "base": "about:blank",
-    "failure": true
-  },
-  {
     "input": "https://lemire.me/école",
     "base": "about:blank",
     "href": "https://lemire.me/%C3%A9cole",

--- a/tests/wpt/ada_extra_urltestdata.json
+++ b/tests/wpt/ada_extra_urltestdata.json
@@ -6,6 +6,25 @@
     "failure": true
   },
   {
+    "input": "#x",
+    "base": "about:blank",
+    "href": "about:blank#x",
+    "protocol":"about:",
+    "username": "",
+    "password": "",
+    "pathname":"blank",
+    "search": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "hash":"#x"
+  },
+  {
+    "input": "",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
     "input": "https://lemire.me/école",
     "base": "about:blank",
     "href": "https://lemire.me/%C3%A9cole",

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <map>
 #include <set>
+#include <sstream>
 
 #include "ada.h"
 #include "ada/character_sets-inl.h"
@@ -39,6 +40,8 @@ const char *URLTESTDATA_JSON = WPT_DATA_DIR "urltestdata.json";
 const char *ADA_URLTESTDATA_JSON = WPT_DATA_DIR "ada_extra_urltestdata.json";
 const char *VERIFYDNSLENGTH_TESTS_JSON = WPT_DATA_DIR "verifydnslength_tests.json";
 
+std::stringstream error_buffer;
+
 #define TEST_START()                                                           \
   do {                                                                         \
     std::cout << "> Running " << __func__ << " ..." << std::endl;              \
@@ -52,6 +55,7 @@ const char *VERIFYDNSLENGTH_TESTS_JSON = WPT_DATA_DIR "verifydnslength_tests.jso
 #define TEST_FAIL(MESSAGE)                                                     \
   do {                                                                         \
     std::cerr << "FAIL: " << (MESSAGE) << std::endl;                           \
+    error_buffer   << "FAIL: " << (MESSAGE) << std::endl;                      \
     return false;                                                              \
   } while (0);
 #define TEST_SUCCEED()                                                         \
@@ -62,6 +66,7 @@ const char *VERIFYDNSLENGTH_TESTS_JSON = WPT_DATA_DIR "verifydnslength_tests.jso
   do {                                                                         \
     if (LHS != RHS)  {                                                         \
       std::cerr << "Mismatch: '" << LHS << "' - '" << RHS << "'" << std::endl; \
+      error_buffer << "Mismatch: '" << LHS << "' - '" << RHS << "'" << std::endl; \
       TEST_FAIL(MESSAGE);                                                      \
     }                                                                          \
   } while (0);                                                                 \
@@ -73,7 +78,8 @@ bool file_exists(const char *filename) {
     std::cout << "  file found: " << filename << std::endl;
     return true;
   } else {
-    std::cout << "  file missing: " << filename << std::endl;
+    std::cerr << "  file missing: " << filename << std::endl;
+    error_buffer << "  file missing: " << filename << std::endl;
     return false;
   }
 }
@@ -303,10 +309,9 @@ bool urltestdata_encoding(const char* source) {
       std::string element_string = std::string(std::string_view(object.raw_json()));
       object.reset();
 
-      auto input_element = object["input"];
       std::string_view input{};
       bool allow_replacement_characters = true;
-      if (input_element.get_string(allow_replacement_characters).get(input)) {
+      if (object["input"].get_string(allow_replacement_characters).get(input)) {
         std::cout << "I could not parse " << element_string << std::endl;
         return false;
       }
@@ -322,7 +327,7 @@ bool urltestdata_encoding(const char* source) {
             // We are good. Failure was expected.
             continue; // We can't proceed any further.
           } else {
-            TEST_ASSERT(base_url.has_value(), true, "Based should not have failred " + element_string);
+            TEST_ASSERT(base_url.has_value(), true, "Based should not have failed " + element_string);
           }
         }
       }
@@ -334,25 +339,36 @@ bool urltestdata_encoding(const char* source) {
         TEST_ASSERT(input_url.has_value(), !failure, "Should not have succeeded " + element_string + input_url->to_string());
       } else {
         TEST_ASSERT(input_url.has_value(), true, "Should not have failed " + element_string + input_url->to_string());
+        std::string_view protocol;
+        if(!object["protocol"].get_string().get(protocol)) {
+          TEST_ASSERT(input_url->get_protocol(), protocol, "Protocol " + element_string + input_url->to_string());
+        }
 
-        std::string_view protocol = object["protocol"];
-        TEST_ASSERT(input_url->get_protocol(), protocol, "Protocol " + element_string + input_url->to_string());
+        std::string_view username;
+        if(!object["username"].get_string().get(username)) {
+          TEST_ASSERT(input_url->get_username(), username, "Username " + element_string + input_url->to_string());
+        }
 
-        std::string_view username = object["username"];
-        TEST_ASSERT(input_url->get_username(), username, "Username " + element_string + input_url->to_string());
+        std::string_view password;
+        if(!object["password"].get_string().get(password)) {
+          TEST_ASSERT(input_url->get_password(), password, "Password " + element_string + input_url->to_string());
+        }
 
-        std::string_view password = object["password"];
-        TEST_ASSERT(input_url->get_password(), password, "Password " + element_string + input_url->to_string());
+        std::string_view host;
+        if(!object["host"].get_string().get(host)) {
+          TEST_ASSERT(input_url->get_host(), host, "Hostname " + element_string + input_url->to_string());
+        }
 
-        std::string_view host = object["host"];
-        TEST_ASSERT(input_url->get_host(), host, "Hostname " + element_string + input_url->to_string());
+        std::string_view hostname;
+        if(!object["hostname"].get_string().get(hostname)){
+          TEST_ASSERT(input_url->get_hostname(), hostname, "Hostname " + element_string + input_url->to_string());
+        }
 
-        std::string_view hostname = object["hostname"];
-        TEST_ASSERT(input_url->get_hostname(), hostname, "Hostname " + element_string + input_url->to_string());
-
-        std::string_view port = object["port"];
-        std::string expected_port = (input_url->port.has_value()) ? std::to_string(input_url->port.value()) : "";
-        TEST_ASSERT(expected_port, port, "Port " + element_string);
+        std::string_view port;
+        if(!object["port"].get_string().get(port)) {
+          std::string expected_port = (input_url->port.has_value()) ? std::to_string(input_url->port.value()) : "";
+          TEST_ASSERT(expected_port, port, "Port " + element_string);
+        }
 
         std::string_view pathname{};
         if (!object["pathname"].get_string().get(pathname)) {
@@ -364,11 +380,15 @@ bool urltestdata_encoding(const char* source) {
           TEST_ASSERT(input_url->query.value_or(""), query, "Query " + element_string + input_url->to_string());
         }
 
-        std::string_view hash = object["hash"];
-        TEST_ASSERT(input_url->get_hash(), hash, "Hash/Fragment " + element_string + input_url->to_string());
+        std::string_view hash;
+        if(!object["hash"].get_string().get(hash)) {
+          TEST_ASSERT(input_url->get_hash(), hash, "Hash/Fragment " + element_string + input_url->to_string());
+        }
 
-        std::string_view href = object["href"];
-        TEST_ASSERT(input_url->get_href(), href, "href " + element_string + input_url->to_string());
+        std::string_view href;
+        if(!object["href"].get_string().get(href)) {
+          TEST_ASSERT(input_url->get_href(), href, "href " + element_string + input_url->to_string());
+        }
 
         std::string_view origin;
         if(!object["origin"].get(origin)) {
@@ -390,7 +410,6 @@ bool urltestdata_encoding(const char* source) {
         std::string_view json_recovered_scheme = parsed_object["scheme"];
         // We could test more fields.
         TEST_ASSERT(json_recovered_scheme, protocol.substr(0,protocol.size()-1), "JSON protocol " + element_string + parsed_url_json);
-
         TEST_ASSERT(json_recovered_path, pathname, "JSON Path " + element_string + parsed_url_json);
         counter++;
       }
@@ -507,6 +526,10 @@ int main(int argc, char** argv) {
     std::cout << "WPT tests are ok." << std::endl;
     return EXIT_SUCCESS;
   } else {
+    std::cerr << " ================== " << std::endl;
+    std::cerr << " Summary of errors: " << std::endl;
+    std::cerr << error_buffer.str() << std::endl;
+    std::cerr << " ================== " << std::endl;
     return EXIT_FAILURE;
   }
 }


### PR DESCRIPTION
@pthier  reported the following 

> This is indeed unsafe and causes OOB reads. E.g. for empty url or #x. This should probably be a check against url.fragment.has_value()?

See https://github.com/ada-url/ada/pull/225#discussion_r1140063705

This PR adds tests for empty URLs and hash-only URL. I do not find out-of-bound reads, but the URLs are invalid. The following... is indeed unsafe...

```C++
  auto url = ada::parse("#x");
  url->get_scheme();
```

But guarding the access, you find that the URL is not accessed.
```C++
  auto url = ada::parse("#x");
  if(url) {
    url->get_scheme();
  }
```

This PR adds some documentation in the README to encourage users to check the validity of the result.

I also make the wpt_tests slightly more robust and user-friendly: we now report a summary of the errors (if any) at the end of the console outputs.