### PR TITLE
Fixes clear path and adds many validate

### DIFF
--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -245,6 +245,9 @@ namespace ada {
 #endif // _MSC_VER
 #endif // SIMDJSON_DEVELOPMENT_CHECKS
 
+
+#define ADA_STR(x) #x
+
 #if ADA_DEVELOPMENT_CHECKS
 #define ADA_REQUIRE(EXPR) { if(!(EXPR) { abort(); }) }
 
@@ -260,15 +263,16 @@ namespace ada {
       ADA_FAIL(MESSAGE);                                                      \
     }                                                                          \
   } while (0);
-#define ADA_ASSERT_TRUE(COND, MESSAGE)                                         \
+#define ADA_ASSERT_TRUE(COND)                                                  \
   do {                                                                         \
     if (!(COND))  {                                                            \
-      ADA_FAIL(MESSAGE);                                              \
+      std::cerr << "Assert at " << __LINE__ << " of " << __FILE__ << std::endl; \
+      ADA_FAIL(ADA_STR(COND));                                                 \
     }                                                                          \
   } while (0);
 #else
 #define ADA_FAIL(MESSAGE)
 #define ADA_ASSERT_EQUAL(LHS, RHS, MESSAGE)
-#define ADA_ASSERT_TRUE(COND, MESSAGE)
+#define ADA_ASSERT_TRUE(COND)
 #endif
 #endif // ADA_COMMON_DEFS_H

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -368,15 +368,15 @@ struct url : url_base {
    * Useful for implementing efficient serialization for the URL.
    *
    * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *      |      |    |          | ^^^^|       |   |
-   *      |      |    |          | |   |       |   `----- hash_start
-   *      |      |    |          | |   |       `--------- search_start
-   *      |      |    |          | |   `----------------- pathname_start
-   *      |      |    |          | `--------------------- port
-   *      |      |    |          `----------------------- host_end
-   *      |      |    `---------------------------------- host_start
-   *      |      `--------------------------------------- username_end
-   *      `---------------------------------------------- protocol_end
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
    *
    * Inspired after servo/url
    *

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -21,21 +21,22 @@ namespace ada {
 
 inline void url_aggregator::update_unencoded_base_hash(std::string_view input) {
   ada_log("url_aggregator::update_unencoded_base_hash ", input, " [", input.size(), " bytes], buffer is '", buffer, "' [", buffer.size(), " bytes] components.hash_start = ", components.hash_start);
-
+  ADA_ASSERT_TRUE(validate());
   if (components.hash_start != url_components::omitted) {
     buffer.resize(components.hash_start);
   }
   components.hash_start = uint32_t(buffer.size());
   buffer += "#";
-  bool encoding_required = unicode::percent_encode<true>(input,ada::character_sets::FRAGMENT_PERCENT_ENCODE, buffer);
+  bool encoding_required = unicode::percent_encode<true>(input, ada::character_sets::FRAGMENT_PERCENT_ENCODE, buffer);
   // When encoding_required is false, then buffer is left unchanged, and percent encoding was not deemed required.
   if (!encoding_required) { buffer.append(input); }
   ada_log("url_aggregator::update_unencoded_base_hash final buffer is '", buffer, "' [", buffer.size(), " bytes]");
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::update_base_hostname(const std::string_view input) {
   ada_log("url_aggregator::update_base_hostname ", input, " [", input.size(), " bytes], buffer is '", buffer, "' [", buffer.size()," bytes]");
-
+  ADA_ASSERT_TRUE(validate());
   // This next line is required for when parsing a URL like `foo://`
   add_authority_slashes_if_needed();
 
@@ -57,6 +58,7 @@ inline void url_aggregator::update_base_hostname(const std::string_view input) {
   components.pathname_start += new_difference;
   if (components.search_start != url_components::omitted) { components.search_start += new_difference; }
   if (components.hash_start != url_components::omitted) { components.hash_start += new_difference; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 ada_really_inline uint32_t url_aggregator::get_pathname_length() const noexcept {
@@ -73,7 +75,7 @@ ada_really_inline uint32_t url_aggregator::get_pathname_length() const noexcept 
 
 inline void url_aggregator::update_base_search(std::string_view input) {
   ada_log("url_aggregator::update_base_search ", input);
-
+  ADA_ASSERT_TRUE(validate());
   if (input.empty()) {
     clear_base_search();
     return;
@@ -101,11 +103,12 @@ inline void url_aggregator::update_base_search(std::string_view input) {
     buffer.insert(components.search_start, input);
   }
   if (components.hash_start != url_components::omitted) { components.hash_start += input_size; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::update_base_search(std::string_view input, const uint8_t query_percent_encode_set[]) {
   ada_log("url_aggregator::update_base_search ", input, " with encoding parameter ", to_string());
-
+  ADA_ASSERT_TRUE(validate());
   // Make sure search is deleted and hash_start index is correct.
   if (components.search_start != url_components::omitted) { // uncommon path
     uint32_t search_end = uint32_t(buffer.size());
@@ -131,11 +134,12 @@ inline void url_aggregator::update_base_search(std::string_view input, const uin
     buffer.insert(components.search_start + 1, encoded);
     components.hash_start += uint32_t(encoded.size() + 1); // Do not forget `?`
   }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::update_base_pathname(const std::string_view input) {
   ada_log("url_aggregator::update_base_pathname ", input);
-
+  ADA_ASSERT_TRUE(validate());
   uint32_t ending_index = uint32_t(buffer.size());
   if (components.search_start != url_components::omitted) { ending_index = components.search_start; }
   else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
@@ -149,10 +153,12 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
 
   if (components.search_start != url_components::omitted) { components.search_start += difference; }
   if (components.hash_start != url_components::omitted) { components.hash_start += difference; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::append_base_pathname(const std::string_view input) {
   ada_log("url_aggregator::append_base_pathname ", input, " ", to_string());
+  ADA_ASSERT_TRUE(validate());
 #if ADA_DEVELOPMENT_CHECKS
   // computing the expected password.
   std::string path_expected = std::string(get_pathname());
@@ -170,11 +176,12 @@ inline void url_aggregator::append_base_pathname(const std::string_view input) {
   std::string path_after = std::string(get_pathname());
   ADA_ASSERT_EQUAL(path_expected, path_after, "append_base_pathname problem after inserting "+std::string(input));
 #endif // ADA_DEVELOPMENT_CHECKS
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::update_base_username(const std::string_view input) {
   ada_log("url_aggregator::update_base_username '", input, "' ", to_string());
-
+  ADA_ASSERT_TRUE(validate());
   add_authority_slashes_if_needed();
 
   uint32_t username_start = components.protocol_end + 2;
@@ -202,10 +209,12 @@ inline void url_aggregator::update_base_username(const std::string_view input) {
   components.pathname_start += diff;
   if (components.search_start != url_components::omitted) { components.search_start += diff; }
   if (components.hash_start != url_components::omitted) { components.hash_start += diff; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::append_base_username(const std::string_view input) {
   ada_log("url_aggregator::append_base_username ", input);
+  ADA_ASSERT_TRUE(validate());
 #if ADA_DEVELOPMENT_CHECKS
   // computing the expected password.
   std::string username_expected = std::string(get_username());
@@ -234,10 +243,12 @@ inline void url_aggregator::append_base_username(const std::string_view input) {
   std::string username_after = std::string(get_username());
   ADA_ASSERT_EQUAL(username_expected, username_after, "append_base_username problem after inserting "+std::string(input));
 #endif // ADA_DEVELOPMENT_CHECKS
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::clear_base_password() {
   ada_log("url_aggregator::clear_base_password ", to_string());
+  ADA_ASSERT_TRUE(validate());
   if (!has_password()) { return; }
 
   uint32_t diff = components.host_start - components.username_end;
@@ -287,10 +298,12 @@ inline void url_aggregator::update_base_password(const std::string_view input) {
   components.pathname_start += difference;
   if (components.search_start != url_components::omitted) { components.search_start += difference; }
   if (components.hash_start != url_components::omitted) { components.hash_start += difference; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::append_base_password(const std::string_view input) {
   ada_log("url_aggregator::append_base_password ", input, " ", to_string());
+  ADA_ASSERT_TRUE(validate());
 #if ADA_DEVELOPMENT_CHECKS
   // computing the expected password.
   std::string password_expected = std::string(get_password());
@@ -326,11 +339,12 @@ inline void url_aggregator::append_base_password(const std::string_view input) {
   std::string password_after = std::string(get_password());
   ADA_ASSERT_EQUAL(password_expected, password_after, "append_base_password problem after inserting "+std::string(input));
 #endif // ADA_DEVELOPMENT_CHECKS
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::update_base_port(uint32_t input) {
   ada_log("url_aggregator::update_base_port");
-
+  ADA_ASSERT_TRUE(validate());
   if (input == url_components::omitted) {
     clear_base_port();
     return;
@@ -350,11 +364,12 @@ inline void url_aggregator::update_base_port(uint32_t input) {
   if (components.search_start != url_components::omitted) { components.search_start += difference; }
   if (components.hash_start != url_components::omitted) { components.hash_start += difference; }
   components.port = input;
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::clear_base_port() {
   ada_log("url_aggregator::clear_base_port");
-
+  ADA_ASSERT_TRUE(validate());
   if (components.port == url_components::omitted) { return; }
   uint32_t length = components.pathname_start - components.host_end;
   buffer.erase(components.host_end, length);
@@ -362,6 +377,7 @@ inline void url_aggregator::clear_base_port() {
   if (components.search_start != url_components::omitted) { components.search_start -= length; }
   if (components.hash_start != url_components::omitted) { components.hash_start -= length; }
   components.port = url_components::omitted;
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline uint32_t url_aggregator::retrieve_base_port() const {
@@ -379,6 +395,7 @@ inline std::string_view url_aggregator::retrieve_base_pathname() const {
 
 inline void url_aggregator::clear_base_search() {
   ada_log("url_aggregator::clear_base_search");
+  ADA_ASSERT_TRUE(validate());
   if (components.search_start == url_components::omitted) { return; }
 
   if (components.hash_start == url_components::omitted) {
@@ -393,24 +410,30 @@ inline void url_aggregator::clear_base_search() {
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_search(), "", "search should have been cleared on buffer=" + buffer + " with " + components.to_string());
 #endif
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::clear_base_pathname() {
   ada_log("url_aggregator::clear_base_pathname");
+  ADA_ASSERT_TRUE(validate());
   uint32_t ending_index = uint32_t(buffer.size());
   if (components.search_start != url_components::omitted) { ending_index = components.search_start; }
   else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
   uint32_t pathname_length = ending_index - components.pathname_start;
   buffer.erase(components.pathname_start, pathname_length);
-  if (components.search_start != url_components::omitted) { components.search_start = components.pathname_start; }
-  if (components.hash_start != url_components::omitted) { components.hash_start = components.pathname_start; }
+  if (components.search_start != url_components::omitted) { components.search_start -= pathname_length; }
+  if (components.hash_start != url_components::omitted) { components.hash_start -= pathname_length; }
+  ada_log("url_aggregator::clear_base_pathname completed, running checks...");
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_pathname(), "", "pathname should have been cleared on buffer=" + buffer + " with " + components.to_string());
 #endif
+  ADA_ASSERT_TRUE(validate());
+  ada_log("url_aggregator::clear_base_pathname completed, running checks... ok");
 }
 
 inline void url_aggregator::clear_base_hostname() {
   ada_log("url_aggregator::clear_base_hostname");
+  ADA_ASSERT_TRUE(validate());
   uint32_t hostname_length = components.host_end - components.host_start;
   uint32_t start = components.host_start;
 
@@ -428,6 +451,7 @@ inline void url_aggregator::clear_base_hostname() {
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_hostname(), "", "hostname should have been cleared on buffer=" + buffer + " with " + components.to_string());
 #endif
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline bool url_aggregator::base_fragment_has_value() const {
@@ -461,6 +485,7 @@ inline bool ada::url_aggregator::has_authority() const noexcept {
 
 inline void ada::url_aggregator::add_authority_slashes_if_needed() noexcept {
   ada_log("url_aggregator::add_authority_slashes_if_needed");
+  ADA_ASSERT_TRUE(validate());
   // Protocol setter will insert `http:` to the URL. It is up to hostname setter to insert
   // `//` initially to the buffer, since it depends on the hostname existance.
   if (has_authority()) { return; }
@@ -474,6 +499,7 @@ inline void ada::url_aggregator::add_authority_slashes_if_needed() noexcept {
   components.pathname_start += 2;
   if (components.search_start != url_components::omitted) { components.search_start += 2; }
   if (components.hash_start != url_components::omitted) { components.hash_start += 2; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void ada::url_aggregator::reserve(uint32_t capacity) {
@@ -488,15 +514,15 @@ inline bool url_aggregator::has_non_empty_username() const {
   ada_log("url_aggregator::has_non_empty_username ");
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *      |      |    |          | ^^^^|       |   |
-   *      |      |    |          | |   |       |   `----- hash_start
-   *      |      |    |          | |   |       `--------- search_start
-   *      |      |    |          | |   `----------------- pathname_start
-   *      |      |    |          | `--------------------- port
-   *      |      |    |          `----------------------- host_end
-   *      |      |    `---------------------------------- host_start
-   *      |      `--------------------------------------- username_end
-   *      `---------------------------------------------- protocol_end
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
    */
   return components.protocol_end + 2 < components.username_end;
 }

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -223,16 +223,16 @@ namespace ada {
     /**
      * Useful for implementing efficient serialization for the URL.
      *
-     * https://user:pass@example.com:1234/foo/bar?baz#quux
-     *      |      |    |          | ^^^^|       |   |
-     *      |      |    |          | |   |       |   `----- hash_start
-     *      |      |    |          | |   |       `--------- search_start
-     *      |      |    |          | |   `----------------- pathname_start
-     *      |      |    |          | `--------------------- port
-     *      |      |    |          `----------------------- host_end
-     *      |      |    `---------------------------------- host_start
-     *      |      `--------------------------------------- username_end
-     *      `---------------------------------------------- protocol_end
+   * https://user:pass@example.com:1234/foo/bar?baz#quux
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
      *
      * Inspired after servo/url
      *

--- a/include/ada/url_components.h
+++ b/include/ada/url_components.h
@@ -33,15 +33,15 @@ namespace ada {
      * cannot exceed 4 GB.
      *
      * https://user:pass@example.com:1234/foo/bar?baz#quux
-     *      |      |    |          | ^^^^|       |   |
-     *      |      |    |          | |   |       |   `----- hash_start
-     *      |      |    |          | |   |       `--------- search_start
-     *      |      |    |          | |   `----------------- pathname_start
-     *      |      |    |          | `--------------------- port
-     *      |      |    |          `----------------------- host_end
-     *      |      |    `---------------------------------- host_start
-     *      |      `--------------------------------------- username_end
-     *      `---------------------------------------------- protocol_end
+     *       |     |    |          | ^^^^|       |   |
+     *       |     |    |          | |   |       |   `----- hash_start
+     *       |     |    |          | |   |       `--------- search_start
+     *       |     |    |          | |   `----------------- pathname_start
+     *       |     |    |          | `--------------------- port
+     *       |     |    |          `----------------------- host_end
+     *       |     |    `---------------------------------- host_start
+     *       |     `--------------------------------------- username_end
+     *       `--------------------------------------------- protocol_end
      */
     uint32_t protocol_end{0};
     /**
@@ -62,11 +62,10 @@ namespace ada {
      * expect when a value is omitted. It also computes
      * a lower bound on  the possible string length that may match these
      * offsets.
-     * @return true in the first component if the offset values are
-     *  consistent with a possible URL string, and if so return
-     *  a lower bound on the URL string length as the second component.
+     * @return true if the offset values are
+     *  consistent with a possible URL string
      */
-    std::pair<bool,uint32_t> check_offset_consistency() const noexcept;
+    bool check_offset_consistency() const noexcept;
 
     /**
      * @private

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -16,6 +16,7 @@ namespace ada {
 template <bool has_state_override>
 [[nodiscard]] ada_really_inline bool url_aggregator::parse_scheme(const std::string_view input) {
   ada_log("url_aggregator::parse_scheme ", input);
+  ADA_ASSERT_TRUE(validate());
   auto parsed_type = ada::scheme::get_scheme_type(input);
   bool is_input_special = (parsed_type != ada::scheme::NOT_SPECIAL);
   /**
@@ -79,11 +80,13 @@ template <bool has_state_override>
       }
     }
   }
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 inline void url_aggregator::copy_scheme(const url_aggregator& u) noexcept {
   ada_log("url_aggregator::copy_scheme ", u.buffer);
+  ADA_ASSERT_TRUE(validate());
   uint32_t new_difference = u.components.protocol_end - components.protocol_end;
   type = u.type;
   buffer.erase(0, components.protocol_end);
@@ -100,10 +103,12 @@ inline void url_aggregator::copy_scheme(const url_aggregator& u) noexcept {
   components.pathname_start += new_difference;
   if (components.search_start != url_components::omitted) { components.search_start += new_difference; }
   if (components.hash_start != url_components::omitted) { components.hash_start += new_difference; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 inline void url_aggregator::set_scheme(std::string_view new_scheme) noexcept {
   ada_log("url_aggregator::set_scheme ", new_scheme);
+  ADA_ASSERT_TRUE(validate());
   uint32_t new_difference = uint32_t(new_scheme.size()) - components.protocol_end;
 
   // Optimization opportunity: Get rid of this branch
@@ -124,6 +129,7 @@ inline void url_aggregator::set_scheme(std::string_view new_scheme) noexcept {
   components.pathname_start += new_difference;
   if (components.search_start != url_components::omitted) { components.search_start += new_difference; }
   if (components.hash_start != url_components::omitted) { components.hash_start += new_difference; }
+  ADA_ASSERT_TRUE(validate());
 }
 
 bool url_aggregator::set_protocol(const std::string_view input) {
@@ -147,24 +153,29 @@ bool url_aggregator::set_protocol(const std::string_view input) {
 
 bool url_aggregator::set_username(const std::string_view input) {
   ada_log("url_aggregator::set_username '", input, "' ");
+  ADA_ASSERT_TRUE(validate());
   if (cannot_have_credentials_or_port()) { return false; }
   // Optimization opportunity: Avoid temporary string creation
   std::string encoded_input = ada::unicode::percent_encode(input, character_sets::USERINFO_PERCENT_ENCODE);
   update_base_username(encoded_input);
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 bool url_aggregator::set_password(const std::string_view input) {
   ada_log("url_aggregator::set_password '", input, "'");
+  ADA_ASSERT_TRUE(validate());
   if (cannot_have_credentials_or_port()) { return false; }
   // Optimization opportunity: Avoid temporary string creation
   std::string encoded_input = ada::unicode::percent_encode(input, character_sets::USERINFO_PERCENT_ENCODE);
   update_base_password(encoded_input);
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 bool url_aggregator::set_port(const std::string_view input) {
   ada_log("url_aggregator::set_port ", input);
+  ADA_ASSERT_TRUE(validate());
   if (cannot_have_credentials_or_port()) { return false; }
   std::string trimmed(input);
   helpers::remove_ascii_tab_or_newline(trimmed);
@@ -180,20 +191,23 @@ bool url_aggregator::set_port(const std::string_view input) {
   if (is_valid) { return true; }
   update_base_port(previous_port);
   is_valid = true;
+  ADA_ASSERT_TRUE(validate());
   return false;
 }
 
 bool url_aggregator::set_pathname(const std::string_view input) {
   ada_log("url_aggregator::set_pathname ", input);
+  ADA_ASSERT_TRUE(validate());
   if (has_opaque_path) { return false; }
   clear_base_pathname();
   parse_path(input);
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 ada_really_inline void url_aggregator::parse_path(std::string_view input) {
   ada_log("url_aggregator::parse_path ", input);
-  
+  ADA_ASSERT_TRUE(validate());
   std::string tmp_buffer;
   std::string_view internal_input;
   if(unicode::has_tabs_or_newline(input)) {
@@ -239,11 +253,13 @@ ada_really_inline void url_aggregator::parse_path(std::string_view input) {
       update_base_pathname("/");
     }
   }
+  ADA_ASSERT_TRUE(validate());
   return;
 }
 
 void url_aggregator::set_search(const std::string_view input) {
   ada_log("url_aggregator::set_search ", input);
+  ADA_ASSERT_TRUE(validate());
   if (input.empty()) {
     clear_base_search();
     helpers::strip_trailing_spaces_from_opaque_path(*this);
@@ -259,10 +275,12 @@ void url_aggregator::set_search(const std::string_view input) {
     ada::character_sets::QUERY_PERCENT_ENCODE;
 
   update_base_search(new_value, query_percent_encode_set);
+  ADA_ASSERT_TRUE(validate());
 }
 
 void url_aggregator::set_hash(const std::string_view input) {
   ada_log("url_aggregator::set_hash ", input);
+  ADA_ASSERT_TRUE(validate());
   if (input.empty()) {
     if (components.hash_start != url_components::omitted) {
       buffer.resize(components.hash_start);
@@ -276,6 +294,7 @@ void url_aggregator::set_hash(const std::string_view input) {
   new_value = input[0] == '#' ? input.substr(1) : input;
   helpers::remove_ascii_tab_or_newline(new_value);
   update_unencoded_base_hash(new_value);
+  ADA_ASSERT_TRUE(validate());
 }
 
 bool url_aggregator::set_href(const std::string_view input) {
@@ -294,6 +313,7 @@ bool url_aggregator::set_href(const std::string_view input) {
 
 ada_really_inline bool url_aggregator::parse_host(std::string_view input) {
   ada_log("url_aggregator:parse_host ", input, "[", input.size(), " bytes]");
+  ADA_ASSERT_TRUE(validate());
   if(input.empty()) { return is_valid = false; } // technically unnecessary.
   // If input starts with U+005B ([), then:
   if (input[0] == '[') {
@@ -352,12 +372,14 @@ ada_really_inline bool url_aggregator::parse_host(std::string_view input) {
   }
 
   update_base_hostname(host.value());
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 template <bool override_hostname>
 bool url_aggregator::set_host_or_hostname(const std::string_view input) {
   ada_log("url_aggregator::set_host_or_hostname ", input);
+  ADA_ASSERT_TRUE(validate());
   if (has_opaque_path) { return false; }
 
   std::string previous_host = std::string(get_hostname());
@@ -422,16 +444,19 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
       clear_base_hostname();
     }
   }
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 bool url_aggregator::set_host(const std::string_view input) {
   ada_log("url_aggregator::set_host ", input);
+  ADA_ASSERT_TRUE(validate());
   return set_host_or_hostname<false>(input);
 }
 
 bool url_aggregator::set_hostname(const std::string_view input) {
   ada_log("url_aggregator::set_hostname ", input);
+  ADA_ASSERT_TRUE(validate());
   return set_host_or_hostname<true>(input);
 }
 
@@ -467,15 +492,15 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   ada_log("url_aggregator::get_username");
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *      |      |    |          | ^^^^|       |   |
-   *      |      |    |          | |   |       |   `----- hash_start
-   *      |      |    |          | |   |       `--------- search_start
-   *      |      |    |          | |   `----------------- pathname_start
-   *      |      |    |          | `--------------------- port
-   *      |      |    |          `----------------------- host_end
-   *      |      |    `---------------------------------- host_start
-   *      |      `--------------------------------------- username_end
-   *      `---------------------------------------------- protocol_end
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
    */
   if (components.protocol_end + 2 < components.username_end) {
     return helpers::substring(buffer, components.protocol_end + 2, components.username_end);
@@ -487,15 +512,15 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   ada_log("url_aggregator::get_password");
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *      |      |    |          | ^^^^|       |   |
-   *      |      |    |          | |   |       |   `----- hash_start
-   *      |      |    |          | |   |       `--------- search_start
-   *      |      |    |          | |   `----------------- pathname_start
-   *      |      |    |          | `--------------------- port
-   *      |      |    |          `----------------------- host_end
-   *      |      |    `---------------------------------- host_start
-   *      |      `--------------------------------------- username_end
-   *      `---------------------------------------------- protocol_end
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
    */
   if (buffer.size() > components.username_end && buffer[components.username_end] == ':') {
     size_t ending_index = components.host_start;
@@ -509,15 +534,15 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   ada_log("url_aggregator::get_password_length");
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *      |      |    |          | ^^^^|       |   |
-   *      |      |    |          | |   |       |   `----- hash_start
-   *      |      |    |          | |   |       `--------- search_start
-   *      |      |    |          | |   `----------------- pathname_start
-   *      |      |    |          | `--------------------- port
-   *      |      |    |          `----------------------- host_end
-   *      |      |    `---------------------------------- host_start
-   *      |      `--------------------------------------- username_end
-   *      `---------------------------------------------- protocol_end
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
    */
   if (components.username_end + 1 < components.host_start) {
     return components.host_start - components.username_end + 1;
@@ -544,15 +569,15 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   ada_log("url_aggregator::get_host");
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *      |      |    |          | ^^^^|       |   |
-   *      |      |    |          | |   |       |   `----- hash_start
-   *      |      |    |          | |   |       `--------- search_start
-   *      |      |    |          | |   `----------------- pathname_start
-   *      |      |    |          | `--------------------- port
-   *      |      |    |          `----------------------- host_end
-   *      |      |    `---------------------------------- host_start
-   *      |      `--------------------------------------- username_end
-   *      `---------------------------------------------- protocol_end
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
    */
   size_t start = components.host_start;
   if (buffer.size() > components.host_start && buffer[components.host_start] == '@') { start++; }
@@ -562,6 +587,7 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 [[nodiscard]] std::string_view url_aggregator::get_hostname() const noexcept {
   ada_log("url_aggregator::get_hostname");
   size_t start = components.host_start;
+  // So host_start is not where the host begins.
   if (buffer.size() > components.host_start && buffer[components.host_start] == '@') { start++; }
   return helpers::substring(buffer, start, components.host_end);
 }
@@ -686,6 +712,7 @@ std::string ada::url_aggregator::to_string() const {
 
 bool url_aggregator::parse_ipv4(std::string_view input) {
   ada_log("parse_ipv4 ", input, "[", input.size(), " bytes]");
+  ADA_ASSERT_TRUE(validate());
   if(input.back()=='.') {
     input.remove_suffix(1);
   }
@@ -742,12 +769,14 @@ final:
     // TODO: This is likely a bug because it goes back update_base_hostname, not what we want to do.
     update_base_hostname(ada::serializers::ipv4(ipv4)); // We have to reserialize the address.
   }
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 bool url_aggregator::parse_ipv6(std::string_view input) {
   // TODO: Find a way to merge parse_ipv6 with url.cpp implementation.
   ada_log("parse_ipv6 ", input, "[", input.size(), " bytes]");
+  ADA_ASSERT_TRUE(validate());
 
   if (input.empty()) { return is_valid = false; }
   // Let address be a new IPv6 address whose IPv6 pieces are all 0.
@@ -952,11 +981,13 @@ bool url_aggregator::parse_ipv6(std::string_view input) {
   // TODO: This is likely a bug because it goes back update_base_hostname, not what we want to do.
   update_base_hostname(ada::serializers::ipv6(address));
   ada_log("parse_ipv6 ", get_hostname());
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 bool url_aggregator::parse_opaque_host(std::string_view input) {
   ada_log("parse_opaque_host ", input, "[", input.size(), " bytes]");
+  ADA_ASSERT_TRUE(validate());
   if (std::any_of(input.begin(), input.end(), ada::unicode::is_forbidden_host_code_point)) {
     return is_valid = false;
   }
@@ -964,13 +995,132 @@ bool url_aggregator::parse_opaque_host(std::string_view input) {
   // Return the result of running UTF-8 percent-encode on input using the C0 control percent-encode set.
   // TODO: Optimization opportunity: Get rid of this string creation.
   update_base_hostname(ada::unicode::percent_encode(input, ada::character_sets::C0_CONTROL_PERCENT_ENCODE));
+  ADA_ASSERT_TRUE(validate());
   return true;
 }
 
 bool url_aggregator::validate() const noexcept {
   if(!is_valid) { return true; }
-  auto [ok, minlength] = components.check_offset_consistency();
-  return (ok && buffer.size() >= minlength);
+  if(!components.check_offset_consistency()) {
+    ada_log("url_aggregator::validate inconsistent components ", to_string());
+    return false;
+  }
+  // We have a credible components struct, but let us investivate more
+  // carefully:
+  /**
+   * https://user:pass@example.com:1234/foo/bar?baz#quux
+   *       |     |    |          | ^^^^|       |   |
+   *       |     |    |          | |   |       |   `----- hash_start
+   *       |     |    |          | |   |       `--------- search_start
+   *       |     |    |          | |   `----------------- pathname_start
+   *       |     |    |          | `--------------------- port
+   *       |     |    |          `----------------------- host_end
+   *       |     |    `---------------------------------- host_start
+   *       |     `--------------------------------------- username_end
+   *       `--------------------------------------------- protocol_end
+   */
+  if(components.protocol_end == url_components::omitted) {
+    ada_log("url_aggregator::validate omitted protocol_end ", to_string());
+    return false;
+  }
+  if(components.username_end == url_components::omitted) {
+    ada_log("url_aggregator::validate omitted username_end ", to_string());
+    return false;
+  }
+  if(components.host_start == url_components::omitted) {
+    ada_log("url_aggregator::validate omitted host_start ", to_string());
+    return false;
+  }
+  if(components.host_end == url_components::omitted) {
+    ada_log("url_aggregator::validate omitted host_end ", to_string());
+    return false;
+  }
+  if(components.pathname_start == url_components::omitted) {
+    ada_log("url_aggregator::validate omitted pathname_start ", to_string());
+    return false;
+  }
+
+  if(components.protocol_end > buffer.size()) {
+    ada_log("url_aggregator::validate protocol_end overflow ", to_string());
+    return false;
+  }
+  if(components.username_end > buffer.size()) {
+    ada_log("url_aggregator::validate username_end overflow ", to_string());
+    return false;
+  }
+  if(components.host_start > buffer.size()) {
+    ada_log("url_aggregator::validate host_start overflow ", to_string());
+    return false;
+  }
+  if(components.host_end > buffer.size()) {
+    ada_log("url_aggregator::validate host_end overflow ", to_string());
+    return false;
+  }
+  if(components.pathname_start > buffer.size()) {
+    ada_log("url_aggregator::validate pathname_start overflow ", to_string());
+    return false;
+  }
+
+  if(components.protocol_end > 0) {
+    if(buffer[components.protocol_end-1] != ':') {
+      ada_log("url_aggregator::validate missing : at the end of the protocol ", to_string());
+      return false;
+    }
+  }
+  if(components.username_end != buffer.size() && components.username_end > components.protocol_end + 2) {
+    if(buffer[components.username_end] != ':' && buffer[components.username_end] != '@') {
+      ada_log("url_aggregator::validate missing : or @ at the end of the username ", to_string());
+      return false;
+    }
+  }
+  if(components.host_start != buffer.size()) {
+    if(components.host_start > components.username_end) {
+      if(buffer[components.host_start] != '@') {
+        ada_log("url_aggregator::validate missing @ at the end of the password ", to_string());
+        return false;
+      }
+    } else if(components.host_start == components.username_end && components.host_end > components.host_start) {
+      // TODO:
+      // This would work if components.host_start was the start of the host, but it appears that it is not.
+      //if(buffer[components.host_start] != '/') {
+      //  ada_log("url_aggregator::validate missing / at host start ", to_string());
+      //  return false;
+      //}
+    } else {
+      if(components.host_end != components.host_start) {
+        ada_log("url_aggregator::validate expected omitted host ", to_string());
+        return false;
+      }
+    }
+  }
+  if(components.host_end != buffer.size() && components.pathname_start > components.host_end) {
+    if(buffer[components.host_end] != ':') {
+      ada_log("url_aggregator::validate missing : at the port ", to_string());
+      return false;
+    }
+  }
+  if(components.pathname_start != buffer.size() 
+      && components.pathname_start < components.search_start 
+      && components.pathname_start < components.hash_start 
+      && !has_opaque_path) {
+    if(buffer[components.pathname_start] != '/') {
+      ada_log("url_aggregator::validate missing / at the path ", to_string());
+      return false;
+    }
+  }
+  if(components.search_start != url_components::omitted) {
+    if(buffer[components.search_start] != '?') {
+      ada_log("url_aggregator::validate missing ? at the search ", to_string());
+      return false;
+    }
+  }
+  if(components.hash_start != url_components::omitted) {
+    if(buffer[components.hash_start] != '#') {
+      ada_log("url_aggregator::validate missing # at the hash ", to_string());
+      return false;
+    }
+  }
+  return true;
 }
 
 ada_really_inline size_t url_aggregator::parse_port(std::string_view view, bool check_trailing_content) noexcept {

--- a/src/url_components.cpp
+++ b/src/url_components.cpp
@@ -6,40 +6,52 @@
 
 namespace ada {
 
-  std::pair<bool,uint32_t> url_components::check_offset_consistency() const noexcept {
+  bool url_components::check_offset_consistency() const noexcept {
+   /**
+    * https://user:pass@example.com:1234/foo/bar?baz#quux
+    *       |     |    |          | ^^^^|       |   |
+    *       |     |    |          | |   |       |   `----- hash_start
+    *       |     |    |          | |   |       `--------- search_start
+    *       |     |    |          | |   `----------------- pathname_start
+    *       |     |    |          | `--------------------- port
+    *       |     |    |          `----------------------- host_end
+    *       |     |    `---------------------------------- host_start
+    *       |     `--------------------------------------- username_end
+    *       `--------------------------------------------- protocol_end
+    */
     // These conditions can be made more strict.
     uint32_t index = 0;
     if(protocol_end != url_components::omitted) {
-      if(protocol_end < index) { return {false,0}; }
+      if(protocol_end < index) { return false; }
       index = protocol_end;
     }
     if(username_end != url_components::omitted) {
-      if(username_end < index) { return {false,0}; }
+      if(username_end < index) { return false; }
       index = username_end;
     }
     if(host_start != url_components::omitted) {
-      if(host_start < index) { return {false,0}; }
+      if(host_start < index) { return false; }
       index = host_start;
     }
     if(port != url_components::omitted) {
-      if(port > 0xffff) { return {false,0}; }
+      if(port > 0xffff) { return false; }
       uint32_t port_length = helpers::fast_digit_count(port) + 1;
-      if(index + port_length < index) { return {false,0}; }
+      if(index + port_length < index) { return false; }
       index += port_length;
     }
     if(pathname_start != url_components::omitted) {
-      if(pathname_start < index) { return {false,0}; }
+      if(pathname_start < index) { return false; }
       index = pathname_start;
     }
     if(search_start != url_components::omitted) {
-      if(search_start < index) { return {false,0}; }
+      if(search_start < index) { return false; }
       index = search_start;
     }
     if(hash_start != url_components::omitted) {
-      if(hash_start < index) { return {false,0}; }
+      if(hash_start < index) { return false; }
       index = hash_start;
     }
-    return {true, index};
+    return true;
   }
 
   std::string url_components::to_string() const {


### PR DESCRIPTION
This PR fixes a bug in `clear_base_pathname()` (an obvious one, I think).

It also adds *many* asserts that are enabled when running tests with ADA_DEVELOPMENT_CHECKS.

While doing so, I found that the protocol_end seems to point *after* the ':', so I updated the diagrams.

However, I was not able to complete the validation because it not clear what `host_start` is. I recommend we clear this issue out and then add checks to the validate function so that we can be certain that the code obeys our conventions.

Note that while I did not change it, the `ADA_ASSERT_EQUAL` calls do not need to be guarded: they automatically compile to nothing when ADA_DEVELOPMENT_CHECKS is unset.