### PR TITLE
Various minor fixes to ada::url_aggregator

### DIFF
--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -549,6 +549,12 @@ inline bool url_aggregator::has_password() const {
   return buffer.size() > components.username_end && buffer[components.username_end] == ':';
 }
 
+inline bool url_aggregator::has_port() const noexcept {
+  ada_log("url_aggregator::has_port");
+  return components.pathname_start != components.host_end;
+}
+
+
 }
 
 #endif // ADA_URL_AGGREGATOR_INL_H

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -445,6 +445,7 @@ inline void url_aggregator::clear_base_pathname() {
 inline void url_aggregator::clear_base_hostname() {
   ada_log("url_aggregator::clear_base_hostname");
   ADA_ASSERT_TRUE(validate());
+  add_authority_slashes_if_needed();
   uint32_t hostname_length = components.host_end - components.host_start;
   uint32_t start = components.host_start;
 
@@ -458,7 +459,6 @@ inline void url_aggregator::clear_base_hostname() {
   components.pathname_start -= hostname_length;
   if (components.search_start != url_components::omitted) { components.search_start -= hostname_length; }
   if (components.hash_start != url_components::omitted) { components.hash_start -= hostname_length; }
-
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_hostname(), "", "hostname should have been cleared on buffer=" + buffer + " with " + components.to_string() + "\n" + to_diagram());
 #endif

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -216,6 +216,8 @@ namespace ada {
     inline bool has_non_empty_password() const;
     /** @private */
     inline bool has_password() const;
+    /** @return true if the URL has a (non default) port */
+    inline bool has_port() const noexcept;
     /** @private */
     inline void consume_prepared_path(std::string_view input);
     /** @private */
@@ -225,16 +227,16 @@ namespace ada {
     /**
      * Useful for implementing efficient serialization for the URL.
      *
-   * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *       |     |    |          | ^^^^|       |   |
-   *       |     |    |          | |   |       |   `----- hash_start
-   *       |     |    |          | |   |       `--------- search_start
-   *       |     |    |          | |   `----------------- pathname_start
-   *       |     |    |          | `--------------------- port
-   *       |     |    |          `----------------------- host_end
-   *       |     |    `---------------------------------- host_start
-   *       |     `--------------------------------------- username_end
-   *       `--------------------------------------------- protocol_end
+     * https://user:pass@example.com:1234/foo/bar?baz#quux
+     *       |     |    |          | ^^^^|       |   |
+     *       |     |    |          | |   |       |   `----- hash_start
+     *       |     |    |          | |   |       `--------- search_start
+     *       |     |    |          | |   `----------------- pathname_start
+     *       |     |    |          | `--------------------- port
+     *       |     |    |          `----------------------- host_end
+     *       |     |    `---------------------------------- host_start
+     *       |     `--------------------------------------- username_end
+     *       `--------------------------------------------- protocol_end
      *
      * Inspired after servo/url
      *

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -119,10 +119,14 @@ namespace ada::helpers {
   }
 
   ada_really_inline std::string_view substring(std::string_view input, size_t pos) noexcept {
-    return pos > input.size() ? std::string_view() : input.substr(pos);
+    ADA_ASSERT_TRUE(pos <= input.size());
+    // The following is safer but uneeded if we have the above line:
+    // return pos > input.size() ? std::string_view() : input.substr(pos);
+    return input.substr(pos);
   }
 
   ada_really_inline void resize(std::string_view& input, size_t pos) noexcept {
+    ADA_ASSERT_TRUE(pos <= input.size());
     input.remove_suffix(input.size() - pos);
   }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -322,14 +322,18 @@ namespace ada::parser {
               url.path = base_url->path;
               url.query = base_url->query;
             } else  {
-              // TODO: This is likely not correct. There is a difference between having an empty username
-              // and not having a username.
-              url.update_base_username(base_url->get_username());
-              // TODO: This is likely not correct. There is a difference between having an empty password
-              // and not having a password.
-              url.update_base_password(base_url->get_password());
-              url.set_hostname(base_url->get_hostname());
-  	          url.update_base_port(base_url->retrieve_base_port());
+              if(base_url->has_non_empty_username()) {
+                url.update_base_username(base_url->get_username());
+              }
+              if(base_url->has_non_empty_password()) {
+                url.update_base_password(base_url->get_password());
+              }
+              if(base_url->has_authority()) {
+                url.set_hostname(base_url->get_hostname());
+                if(base_url->has_port())  {
+                  url.update_base_port(base_url->retrieve_base_port());
+                }
+              }
               url.update_base_pathname(base_url->get_pathname());
               url.update_base_search(base_url->get_search());
             }
@@ -386,14 +390,18 @@ namespace ada::parser {
               url.host = base_url->host;
               url.port = base_url->port;
             } else {
-              // TODO: This is likely not correct. There is a difference between having an empty username
-              // and not having a username.
-              url.update_base_username(base_url->get_username());
-              // TODO: This is likely not correct. There is a difference between having an empty password
-              // and not having a password.
-              url.update_base_password(base_url->get_password());
-              url.set_hostname(base_url->get_hostname());
-              url.update_base_port(base_url->retrieve_base_port());
+              if(base_url->has_non_empty_username()) {
+                url.update_base_username(base_url->get_username());
+              }
+              if(base_url->has_non_empty_password()) {
+                url.update_base_password(base_url->get_password());
+              }
+              if(base_url->has_authority()) {
+                url.set_hostname(base_url->get_hostname());
+                if(base_url->has_port()) {
+                  url.update_base_port(base_url->retrieve_base_port());
+                }
+              }
             }
             state = ada::state::PATH;
             break;
@@ -594,7 +602,7 @@ namespace ada::parser {
                 url.host = base_url->host;
               } else {
                 // TODO: Optimization opportunity.
-                url.set_host(url.get_host());
+                url.set_host(base_url->get_host());
               }
               // If the code point substring from pointer to the end of input does not start with
               // a Windows drive letter and base’s path[0] is a normalized Windows drive letter,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -330,9 +330,7 @@ namespace ada::parser {
               }
               if(base_url->has_authority()) {
                 url.set_hostname(base_url->get_hostname());
-                if(base_url->has_port())  {
-                  url.update_base_port(base_url->retrieve_base_port());
-                }
+                url.update_base_port(base_url->retrieve_base_port());
               }
               url.update_base_pathname(base_url->get_pathname());
               url.update_base_search(base_url->get_search());
@@ -398,9 +396,7 @@ namespace ada::parser {
               }
               if(base_url->has_authority()) {
                 url.set_hostname(base_url->get_hostname());
-                if(base_url->has_port()) {
-                  url.update_base_port(base_url->retrieve_base_port());
-                }
+                url.update_base_port(base_url->retrieve_base_port());
               }
             }
             state = ada::state::PATH;

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -426,7 +426,6 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // Let host be the result of host parsing host_view with url is not special.
     if (host_view.empty()) {
       clear_base_hostname();
-      add_authority_slashes_if_needed();
       return true;
     }
 
@@ -444,8 +443,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
   if (new_host.empty()) {
     // Set url’s host to the empty string.
     clear_base_hostname();
-  }
-  else {
+  } else {
     // Let host be the result of host parsing buffer with url is not special.
     if (!parse_host(new_host)) {
       update_base_hostname(previous_host);

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -426,6 +426,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // Let host be the result of host parsing host_view with url is not special.
     if (host_view.empty()) {
       clear_base_hostname();
+      add_authority_slashes_if_needed();
       return true;
     }
 
@@ -462,14 +463,14 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
 }
 
 bool url_aggregator::set_host(const std::string_view input) {
-  ada_log("url_aggregator::set_host ", input);
+  ada_log("url_aggregator::set_host '", input, "'");
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   return set_host_or_hostname<false>(input);
 }
 
 bool url_aggregator::set_hostname(const std::string_view input) {
-  ada_log("url_aggregator::set_hostname ", input);
+  ada_log("url_aggregator::set_hostname '", input, "'");
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   return set_host_or_hostname<true>(input);
@@ -505,19 +506,7 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 [[nodiscard]] std::string_view url_aggregator::get_username() const noexcept {
   ada_log("url_aggregator::get_username");
-  /**
-   * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *       |     |    |          | ^^^^|       |   |
-   *       |     |    |          | |   |       |   `----- hash_start
-   *       |     |    |          | |   |       `--------- search_start
-   *       |     |    |          | |   `----------------- pathname_start
-   *       |     |    |          | `--------------------- port
-   *       |     |    |          `----------------------- host_end
-   *       |     |    `---------------------------------- host_start
-   *       |     `--------------------------------------- username_end
-   *       `--------------------------------------------- protocol_end
-   */
-  if (components.protocol_end + 2 < components.username_end) {
+  if (has_non_empty_username()) {
     return helpers::substring(buffer, components.protocol_end + 2, components.username_end);
   }
   return "";
@@ -525,21 +514,7 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 [[nodiscard]] std::string_view url_aggregator::get_password() const noexcept {
   ada_log("url_aggregator::get_password");
-  /**
-   * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *       |     |    |          | ^^^^|       |   |
-   *       |     |    |          | |   |       |   `----- hash_start
-   *       |     |    |          | |   |       `--------- search_start
-   *       |     |    |          | |   `----------------- pathname_start
-   *       |     |    |          | `--------------------- port
-   *       |     |    |          `----------------------- host_end
-   *       |     |    `---------------------------------- host_start
-   *       |     `--------------------------------------- username_end
-   *       `--------------------------------------------- protocol_end
-   */
-  if (buffer.size() > components.username_end && buffer[components.username_end] == ':') {
-    size_t ending_index = components.host_start;
-    if (buffer[ending_index] == '@') { ending_index--; }
+  if (has_non_empty_password()) {
     return helpers::substring(buffer, components.username_end + 1, components.host_start);
   }
   return "";
@@ -547,18 +522,7 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 [[nodiscard]] uint32_t url_aggregator::get_password_length() const noexcept {
   ada_log("url_aggregator::get_password_length");
-  /**
-   * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *       |     |    |          | ^^^^|       |   |
-   *       |     |    |          | |   |       |   `----- hash_start
-   *       |     |    |          | |   |       `--------- search_start
-   *       |     |    |          | |   `----------------- pathname_start
-   *       |     |    |          | `--------------------- port
-   *       |     |    |          `----------------------- host_end
-   *       |     |    `---------------------------------- host_start
-   *       |     `--------------------------------------- username_end
-   *       `--------------------------------------------- protocol_end
-   */
+  ADA_ASSERT_TRUE(has_password());
   if (components.username_end + 1 < components.host_start) {
     return components.host_start - components.username_end + 1;
   }
@@ -582,18 +546,6 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 [[nodiscard]] std::string_view url_aggregator::get_host() const noexcept {
   ada_log("url_aggregator::get_host");
-  /**
-   * https://user:pass@example.com:1234/foo/bar?baz#quux
-   *       |     |    |          | ^^^^|       |   |
-   *       |     |    |          | |   |       |   `----- hash_start
-   *       |     |    |          | |   |       `--------- search_start
-   *       |     |    |          | |   `----------------- pathname_start
-   *       |     |    |          | `--------------------- port
-   *       |     |    |          `----------------------- host_end
-   *       |     |    `---------------------------------- host_start
-   *       |     `--------------------------------------- username_end
-   *       `--------------------------------------------- protocol_end
-   */
   size_t start = components.host_start;
   if (buffer.size() > components.host_start && buffer[components.host_start] == '@') { start++; }
   return helpers::substring(buffer, start, components.pathname_start);
@@ -728,7 +680,8 @@ std::string ada::url_aggregator::to_string() const {
 bool url_aggregator::parse_ipv4(std::string_view input) {
   ada_log("parse_ipv4 ", input, "[", input.size(), " bytes], overlaps with buffer: ", helpers::overlaps(input, buffer) ? "yes" : "no");
   ADA_ASSERT_TRUE(validate());
-  if(input.back()=='.') {
+  const bool trailing_dot = (input.back() == '.');
+  if(trailing_dot) {
     input.remove_suffix(1);
   }
   size_t digit_count{0};
@@ -777,7 +730,7 @@ final:
   ada_log("url_aggregator::parse_ipv4 completed ", get_href(), " host: ", get_host());
 
   // We could also check r.ptr to see where the parsing ended.
-  if(pure_decimal_count == 4) {
+  if(pure_decimal_count == 4 && !trailing_dot) {
     // The original input was already all decimal and we validated it. So we don't need to do anything.
   } else {
     // Optimization opportunity: Get rid of unnecessary string return in ipv4 serializer.


### PR DESCRIPTION
1. adds `has_port`
2. speeds up ada::helpers::substring
3. guard `update_base_username` and `update_base_password`
4. fix silly typo `url.set_host(url.get_host());`.
5. fix `url_aggregator::parse_ipv4` in the case where we have a trailing dot.
6. simplifies `get_password()` and `get_username()`.