### PR TITLE
empty host slash dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Specification for URL parser can be found from the
 
 ## Usage
 
+Ada supports two types of URL instances, `ada:url` and `ada:url_aggregator`. The usage is
+the same in either case: we have an parsing function template `ada::parse` which can return
+either a result of type `ada::result<ada:url>` or of type `ada::result<ada:url_aggregator>`
+depending on your needs. The `ada:url_aggregator` class is smaller and it is backed by a precomputed
+serialized URL string. The `ada:url` class is made of several separate strings for the various
+components (path, host, and so forth).
+
 ### Examples
 
 - Parse and validate a URL

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -266,7 +266,7 @@ namespace ada {
 #define ADA_ASSERT_TRUE(COND)                                                  \
   do {                                                                         \
     if (!(COND))  {                                                            \
-      std::cerr << "Assert at " << __LINE__ << " of " << __FILE__ << std::endl; \
+      std::cerr << "Assert at line " << __LINE__ << " of file " << __FILE__ << std::endl; \
       ADA_FAIL(ADA_STR(COND));                                                 \
     }                                                                          \
   } while (0);

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -22,7 +22,13 @@ namespace ada {
 [[nodiscard]] inline bool url::cannot_have_credentials_or_port() const {
   return !host.has_value() || host.value().empty() || type == ada::scheme::type::FILE;
 }
-
+[[nodiscard]] inline bool url::has_hostname() const noexcept {
+  return host.has_value();
+}
+[[nodiscard]] inline bool url::has_empty_hostname() const noexcept {
+  if(!host.has_value()) { return false; }
+  return host.value().empty();
+}
 inline std::ostream &operator<<(std::ostream &out, const ada::url &u) {
   return out << u.to_string();
 }

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -120,7 +120,10 @@ struct url : url_base {
   inline bool base_fragment_has_value() const override;
   /** @private */
   inline bool base_search_has_value() const override;
-
+  /** @return true if the URL has host */
+  [[nodiscard]] inline bool has_hostname() const noexcept;
+  /** @return true if it has an host but it is the empty string */
+  [[nodiscard]] inline bool has_empty_hostname() const noexcept;
   [[nodiscard]] bool has_valid_domain() const noexcept override;
 
   /**
@@ -182,6 +185,8 @@ struct url : url_base {
   /**
    * Return url’s host, serialized, followed by U+003A (:) and url’s port,
    * serialized.
+   * When there is no host, this function returns the empty string.
+   * @see has_hostname()
    * @return a newly allocated string.
    * @see https://url.spec.whatwg.org/#dom-url-host
    */
@@ -189,6 +194,8 @@ struct url : url_base {
 
   /**
    * Return this’s URL’s host, serialized.
+   * When there is no host, this function returns the empty string.
+   * @see has_hostname()
    * @return a newly allocated string.
    * @see https://url.spec.whatwg.org/#dom-url-hostname
    */

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -212,8 +212,7 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
     // then append U+002F (/) followed by U+002E (.) to output.
     buffer.insert(components.pathname_start, "/.");
     components.pathname_start += 2;
-    if (components.search_start != url_components::omitted) { components.search_start += 2; }
-    if (components.hash_start != url_components::omitted) { components.hash_start += 2; }
+    difference += 2;
   }
   // The common case is components.pathname_start == buffer.size() so this is effectively an append.
   buffer.insert(components.pathname_start, input);

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -198,16 +198,19 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   ada_log("url_aggregator::update_base_pathname '", input, "' [", input.size(), " bytes] \n", to_diagram());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   ADA_ASSERT_TRUE(validate());
-  uint32_t ending_index = uint32_t(buffer.size());
-  if (components.search_start != url_components::omitted) { ending_index = components.search_start; }
-  else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
-
-  uint32_t current_length = ending_index - components.pathname_start;
+  const bool begins_with_dashdash = checkers::begins_with(input, "//");
+  // uncommon branch:
+  if(!begins_with_dashdash && has_dash_dot()) {
+    ada_log("url_aggregator::update_base_pathname has /.: \n", to_diagram());
+    // We must delete the ./
+    delete_dash_dot();
+  }
+  uint32_t current_length = get_pathname_length();
   uint32_t difference = uint32_t(input.size()) - current_length;
   // The common case is current_length == 0.
   buffer.erase(components.pathname_start, current_length);
   // next line is very uncommon and we should seek to optimize it accordingly.
-  if(has_empty_hostname() && !has_opaque_path && input.size()>1) {
+  if(begins_with_dashdash && !has_hostname() && !has_opaque_path) {
     // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
     // then append U+002F (/) followed by U+002E (.) to output.
     buffer.insert(components.pathname_start, "/.");
@@ -512,6 +515,8 @@ inline void url_aggregator::clear_base_pathname() {
 inline void url_aggregator::clear_base_hostname() {
   ada_log("url_aggregator::clear_base_hostname");
   ADA_ASSERT_TRUE(validate());
+  if(!has_hostname()) { return; }
+  ADA_ASSERT_TRUE(has_hostname());
 
   uint32_t hostname_length = components.host_end - components.host_start;
   uint32_t start = components.host_start;
@@ -529,6 +534,8 @@ inline void url_aggregator::clear_base_hostname() {
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_hostname(), "", "hostname should have been cleared on buffer=" + buffer + " with " + components.to_string() + "\n" + to_diagram());
 #endif
+  ADA_ASSERT_TRUE(has_hostname());
+  ADA_ASSERT_TRUE(has_empty_hostname());
   ADA_ASSERT_TRUE(validate());
 }
 
@@ -556,9 +563,16 @@ inline bool url_aggregator::cannot_have_credentials_or_port() const {
   return components;
 }
 
-inline bool ada::url_aggregator::has_authority() const noexcept {
+[[nodiscard]] inline bool ada::url_aggregator::has_authority() const noexcept {
   ada_log("url_aggregator::has_authority");
+  // Performance: instead of doing this potentially expensive check, we could have
+  // a boolean in the struct.
   return (components.protocol_end + 2 <= buffer.size()) && helpers::substring(buffer, components.protocol_end, components.protocol_end + 2) == "//";
+}
+
+[[nodiscard]] inline bool ada::url_aggregator::has_hostname() const noexcept {
+  ada_log("url_aggregator::has_hostname");
+  return has_authority(); // same concept
 }
 
 inline void ada::url_aggregator::add_authority_slashes_if_needed() noexcept {
@@ -613,6 +627,7 @@ inline bool url_aggregator::has_password() const {
 }
 
 inline bool url_aggregator::has_empty_hostname() const noexcept {
+  if(!has_hostname()) { return false; }
   if(components.host_start == components.host_end) { return true; }
   if (components.host_end > components.host_start + 1) { return false; }
   return buffer[components.host_start] == '@';
@@ -621,6 +636,21 @@ inline bool url_aggregator::has_empty_hostname() const noexcept {
 inline bool url_aggregator::has_port() const noexcept {
   ada_log("url_aggregator::has_port");
   return components.pathname_start != components.host_end;
+}
+
+inline bool url_aggregator::has_dash_dot() const noexcept  {
+  ada_log("url_aggregator::has_dash_dot");
+  // Performance: instead of doing this potentially expensive check, we could just
+  // have a boolean value in the structure.
+#if ADA_DEVELOPMENT_CHECKS
+  if(components.pathname_start + 1 < buffer.size() && components.pathname_start == components.host_end + 2) {
+    ADA_ASSERT_TRUE(buffer[components.host_end] == '/');
+    ADA_ASSERT_TRUE(buffer[components.host_end+1] == '.');
+    ADA_ASSERT_TRUE(buffer[components.pathname_start] == '/');
+    ADA_ASSERT_TRUE(buffer[components.pathname_start+1] == '/');
+  }
+#endif
+  return components.pathname_start + 1 < buffer.size() && components.pathname_start == components.host_end + 2;
 }
 
 inline std::string_view url_aggregator::get_href() const noexcept {

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -145,6 +145,7 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   ada_log("url_aggregator::update_base_pathname '", input, "' [", input.size(), " bytes] \n", to_diagram());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   ADA_ASSERT_TRUE(validate());
+
   uint32_t ending_index = uint32_t(buffer.size());
   if (components.search_start != url_components::omitted) { ending_index = components.search_start; }
   else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
@@ -153,6 +154,13 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   uint32_t difference = uint32_t(input.size()) - current_length;
   // The common case is current_length == 0.
   buffer.erase(components.pathname_start, current_length);
+  // next line is very uncommon.
+  if(has_empty_hostname() && !has_opaque_path && input.size()>1) {
+    // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
+    // then append U+002F (/) followed by U+002E (.) to output.
+    buffer.insert(components.pathname_start, "/.");
+    components.pathname_start += 2;
+  }
   // The common case is components.pathname_start == buffer.size() so this is effectively an append.
   buffer.insert(components.pathname_start, input);
   if (components.search_start != url_components::omitted) { components.search_start += difference; }
@@ -549,6 +557,13 @@ inline bool url_aggregator::has_password() const {
   return buffer.size() > components.username_end && buffer[components.username_end] == ':';
 }
 
+inline bool url_aggregator::has_empty_hostname() const noexcept {
+  if(buffer.size() == components.host_start) { return true; }
+  uint32_t start = components.host_start;
+  // So host_start is not where the host begins.
+  if (buffer[components.host_start] == '@') { start++; }
+  return start == components.host_end;
+}
 }
 
 #endif // ADA_URL_AGGREGATOR_INL_H

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -145,7 +145,6 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   ada_log("url_aggregator::update_base_pathname '", input, "' [", input.size(), " bytes] \n", to_diagram());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   ADA_ASSERT_TRUE(validate());
-
   uint32_t ending_index = uint32_t(buffer.size());
   if (components.search_start != url_components::omitted) { ending_index = components.search_start; }
   else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
@@ -154,12 +153,14 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   uint32_t difference = uint32_t(input.size()) - current_length;
   // The common case is current_length == 0.
   buffer.erase(components.pathname_start, current_length);
-  // next line is very uncommon.
+  // next line is very uncommon and we should seek to optimize it accordingly.
   if(has_empty_hostname() && !has_opaque_path && input.size()>1) {
     // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
     // then append U+002F (/) followed by U+002E (.) to output.
     buffer.insert(components.pathname_start, "/.");
     components.pathname_start += 2;
+    if (components.search_start != url_components::omitted) { components.search_start += 2; }
+    if (components.hash_start != url_components::omitted) { components.hash_start += 2; }
   }
   // The common case is components.pathname_start == buffer.size() so this is effectively an append.
   buffer.insert(components.pathname_start, input);
@@ -442,6 +443,12 @@ inline void url_aggregator::clear_base_pathname() {
   buffer.erase(components.pathname_start, pathname_length);
   if (components.search_start != url_components::omitted) { components.search_start -= pathname_length; }
   if (components.hash_start != url_components::omitted) { components.hash_start -= pathname_length; }
+  if(components.pathname_start == components.host_end + 2 && buffer[components.host_end] == '/' && buffer[components.host_end + 1] == '.') {
+    components.pathname_start -= 2;
+    buffer.erase(components.host_end, 2);
+    if (components.search_start != url_components::omitted) { components.search_start -= 2; }
+    if (components.hash_start != url_components::omitted) { components.hash_start -= 2; }
+  }
   ada_log("url_aggregator::clear_base_pathname completed, running checks...");
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_pathname(), "", "pathname should have been cleared on buffer=" + buffer + " with " + components.to_string() + "\n" + to_diagram());
@@ -558,6 +565,7 @@ inline bool url_aggregator::has_password() const {
 }
 
 inline bool url_aggregator::has_empty_hostname() const noexcept {
+  // This is sadly unreasonably expensive!!!
   if(buffer.size() == components.host_start) { return true; }
   uint32_t start = components.host_start;
   // So host_start is not where the host begins.

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -48,8 +48,8 @@ namespace ada {
 
     /** @private */
     inline bool has_authority() const noexcept;
-    /** @private */
-    inline bool has_empty_hostname() const noexcept;
+    /** @return true if it has an host but it is the empty string */
+    [[nodiscard]] inline bool has_empty_hostname() const noexcept;
     /**
      * The origin getter steps are to return the serialization of this’s URL’s
      * origin. [HTML]
@@ -98,6 +98,8 @@ namespace ada {
      * Return url’s host, serialized, followed by U+003A (:) and url’s port,
      * serialized.
      * This function does not allocate memory.
+     * When there is no host, this function returns the empty view.
+     * @see has_hostname()
      * @return a lightweight std::string_view.
      * @see https://url.spec.whatwg.org/#dom-url-host
      */
@@ -105,6 +107,8 @@ namespace ada {
     /**
      * Return this’s URL’s host, serialized.
      * This function does not allocate memory.
+     * When there is no host, this function returns the empty view.
+     * @see has_hostname()
      * @return a lightweight std::string_view.
      * @see https://url.spec.whatwg.org/#dom-url-hostname
      */
@@ -214,13 +218,19 @@ namespace ada {
     /** @private */
     inline bool base_search_has_value() const override;
     /** @private */
-    inline bool has_non_empty_username() const;
+    inline bool has_dash_dot() const noexcept;
     /** @private */
-    inline bool has_non_empty_password() const;
+    void delete_dash_dot();
     /** @private */
-    inline bool has_password() const;
+    [[nodiscard]] inline bool has_non_empty_username() const;
+    /** @private */
+    [[nodiscard]] inline bool has_non_empty_password() const;
+    /** @private */
+    [[nodiscard]] inline bool has_password() const;
     /** @return true if the URL has a (non default) port */
-    inline bool has_port() const noexcept;
+    [[nodiscard]] inline bool has_port() const noexcept;
+    /** @return true if the URL has host */
+    [[nodiscard]] inline bool has_hostname() const noexcept;
     /** @private */
     inline void consume_prepared_path(std::string_view input);
     /** @private */

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -48,7 +48,8 @@ namespace ada {
 
     /** @private */
     inline bool has_authority() const noexcept;
-
+    /** @private */
+    inline bool has_empty_hostname() const noexcept;
     /**
      * The origin getter steps are to return the serialization of this’s URL’s
      * origin. [HTML]

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -1221,9 +1221,8 @@ bool url_aggregator::validate() const noexcept {
   }
   if(components.host_end != buffer.size() && components.pathname_start > components.host_end) {
     if(components.pathname_start == components.host_end + 2 && buffer[components.host_end] == '/'  && buffer[components.host_end + 1] == '.') {
-      // if we have padding with /., then we need to have / and another character
-      if(components.pathname_start + 1 >= buffer.size() || buffer[components.pathname_start] != '/') {
-        ada_log("url_aggregator::validate expected the path to begin with / with something else after \n", to_diagram());
+      if(components.pathname_start + 1 >= buffer.size() || buffer[components.pathname_start] != '/' || buffer[components.pathname_start+1] != '/') {
+        ada_log("url_aggregator::validate expected the path to begin with // \n", to_diagram());
         return false;
       }
     } else if(buffer[components.host_end] != ':') {
@@ -1256,8 +1255,21 @@ bool url_aggregator::validate() const noexcept {
   return true;
 }
 
+void url_aggregator::delete_dash_dot() {
+  ada_log("url_aggregator::delete_dash_dot");
+  ADA_ASSERT_TRUE(validate());
+  ADA_ASSERT_TRUE(has_dash_dot());
+  buffer.erase(components.host_end, 2);
+  components.pathname_start -= 2;
+  if (components.search_start != url_components::omitted) { components.search_start -= 2; }
+  if (components.hash_start != url_components::omitted) { components.hash_start -= 2; }
+  ADA_ASSERT_TRUE(validate());
+  ADA_ASSERT_TRUE(!has_dash_dot());
+}
+
+
 ada_really_inline size_t url_aggregator::parse_port(std::string_view view, bool check_trailing_content) noexcept {
-  ada_log("parse_port('", view, "') ", view.size());
+  ada_log("url_aggregator::parse_port('", view, "') ", view.size());
   uint16_t parsed_port{};
   auto r = std::from_chars(view.data(), view.data() + view.size(), parsed_port);
   if(r.ec == std::errc::result_out_of_range) {

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -1272,7 +1272,13 @@ bool url_aggregator::validate() const noexcept {
     }
   }
   if(components.host_end != buffer.size() && components.pathname_start > components.host_end) {
-    if(buffer[components.host_end] != ':') {
+    if(components.pathname_start == components.host_end + 2 && buffer[components.host_end] == '/'  && buffer[components.host_end + 1] == '.') {
+      // if we have padding with /., then we need to have / and another character
+      if(components.pathname_start + 1 >= buffer.size() || buffer[components.pathname_start] != '/') {
+        ada_log("url_aggregator::validate expected the path to begin with / with something else after \n", to_diagram());
+        return false;
+      }
+    } else if(buffer[components.host_end] != ':') {
       ada_log("url_aggregator::validate missing : at the port \n", to_diagram());
       return false;
     }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -581,6 +581,9 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 std::string ada::url_aggregator::to_string() const {
   ada_log("url_aggregator::to_string buffer:", buffer, "[", buffer.size(), " bytes]");
+  if (!is_valid) {
+    return "null";
+  }
 
   std::string answer;
   auto back = std::back_insert_iterator(answer);
@@ -965,6 +968,9 @@ bool url_aggregator::parse_opaque_host(std::string_view input) {
 }
 
 std::string url_aggregator::to_diagram() const {
+  if (!is_valid) {
+    return "invalid";
+  }
   std::string answer;
   answer.append(buffer);
   answer.append(" [");

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -596,6 +596,9 @@ bool url_aggregator::set_hostname(const std::string_view input) {
    */
   size_t start = components.host_start;
   if (buffer.size() > components.host_start && buffer[components.host_start] == '@') { start++; }
+  // if we have an empty host, then the space between components.host_end and
+  // components.pathname_start may be occupied by /.
+  if(start == components.host_end) { return std::string_view(); }
   return helpers::substring(buffer, start, components.pathname_start);
 }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -189,17 +189,20 @@ bool just_hash() {
   TEST_SUCCEED()
 }
 
+template <class result>
 bool empty_host_dash_dash_path() {
   TEST_START()
-  auto url = ada::parse<ada::url_aggregator>("something:/.//");
+  auto url = ada::parse<result>("something:/.//");
   if(!url) {
     TEST_FAIL("Should succeed");
   }
+  TEST_ASSERT(url->has_opaque_path, false, "host is not opaque");
   TEST_ASSERT(url->get_href(), "something:/.//", "href should stay unchanged");
   TEST_ASSERT(url->get_pathname(), "//", "path name should be //")
   TEST_ASSERT(url->get_hostname(), "", "host should be empty")
   TEST_SUCCEED()
 }
+
 int main() {
 #if ADA_HAS_ICU
   std::cout << "We are using ICU."<< std::endl;
@@ -211,7 +214,8 @@ int main() {
 #else
   std::cout << "You have litte-endian system."<< std::endl;
 #endif
-  bool success = empty_host_dash_dash_path()
+  bool success = empty_host_dash_dash_path<ada::url_aggregator>()
+     && empty_host_dash_dash_path<ada::url>()
      && just_hash() && empty_url()
      && set_host_should_return_false_sometimes()
      && set_host_should_return_true_sometimes()

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -36,6 +36,15 @@ bool set_host_should_return_false_sometimes() {
     ada::result<ada::url> r = ada::parse("mailto:a@b.com");
     bool b = r->set_host("something");
     TEST_ASSERT(b, false, "set_host should return false")
+    //
+    auto r2 = ada::parse<ada::url>("mailto:a@b.com");
+    bool b2 = r2->set_host("something");
+    TEST_ASSERT(b2, false, "set_host should return false")
+    TEST_SUCCEED() 
+}
+
+bool set_host_should_return_false_sometimes2() {
+    TEST_START()
     TEST_SUCCEED() 
 }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -196,7 +196,7 @@ bool empty_host_dash_dash_path() {
   if(!url) {
     TEST_FAIL("Should succeed");
   }
-  TEST_ASSERT(url->has_opaque_path, false, "host is not opaque");
+  TEST_ASSERT(url->has_opaque_path, false, "path is not opaque");
   TEST_ASSERT(url->get_href(), "something:/.//", "href should stay unchanged");
   TEST_ASSERT(url->get_pathname(), "//", "path name should be //")
   TEST_ASSERT(url->get_hostname(), "", "host should be empty")

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -203,6 +203,50 @@ bool empty_host_dash_dash_path() {
   TEST_SUCCEED()
 }
 
+
+template <class result>
+bool confusing_mess() {
+  TEST_START()
+  auto base_url = ada::parse<result>("http://example.org/foo/bar");
+  if(!base_url) {
+    TEST_FAIL("Should succeed");
+  }
+  auto url = ada::parse<result>("http://::@c@d:2", &*base_url);
+  if(!url) {
+    TEST_FAIL("Should succeed");
+  }
+  TEST_ASSERT(url->has_opaque_path, false, "path is not opaque");
+  TEST_ASSERT(url->get_hostname(), "d", "bad hostname")
+  TEST_ASSERT(url->get_host(), "d:2", "bad host")
+  TEST_ASSERT(url->get_pathname(), "/", "bad path")
+  TEST_ASSERT(url->get_href(), "http://:%3A%40c@d:2/", "bad href");
+  TEST_ASSERT(url->get_origin(), "http://d:2", "bad origin")
+
+
+  TEST_SUCCEED()
+}
+
+template <class result>
+bool standard_file() {
+  TEST_START()
+  auto url = ada::parse<result>("file:///tmp/mock/path");
+  if(!url) {
+    TEST_FAIL("Should succeed");
+  }
+  std::cout << url->to_string() << std::endl;
+  TEST_ASSERT(url->has_hostname(), true, "path is not opaque");
+  TEST_ASSERT(url->has_empty_hostname(), true, "path is not opaque");
+  TEST_ASSERT(url->has_opaque_path, false, "path is not opaque");
+  TEST_ASSERT(url->get_pathname(), "/tmp/mock/path", "path name should be /tmp/mock/path")
+  TEST_ASSERT(url->get_hostname(), "", "host should be empty")
+  TEST_ASSERT(url->get_host(), "", "host should be empty")
+  TEST_ASSERT(url->get_href(), "file:///tmp/mock/path", "href should stay unchanged");
+  TEST_SUCCEED()
+}
+
+
+
+
 int main() {
 #if ADA_HAS_ICU
   std::cout << "We are using ICU."<< std::endl;
@@ -214,7 +258,11 @@ int main() {
 #else
   std::cout << "You have litte-endian system."<< std::endl;
 #endif
-  bool success = empty_host_dash_dash_path<ada::url_aggregator>()
+  bool success = confusing_mess<ada::url>()
+     && confusing_mess<ada::url_aggregator>()
+     && standard_file<ada::url_aggregator>()
+     && standard_file<ada::url>()
+     && empty_host_dash_dash_path<ada::url_aggregator>()
      && empty_host_dash_dash_path<ada::url>()
      && just_hash() && empty_url()
      && set_host_should_return_false_sometimes()

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -189,6 +189,17 @@ bool just_hash() {
   TEST_SUCCEED()
 }
 
+bool empty_host_dash_dash_path() {
+  TEST_START()
+  auto url = ada::parse<ada::url_aggregator>("something:/.//");
+  if(!url) {
+    TEST_FAIL("Should succeed");
+  }
+  TEST_ASSERT(url->get_href(), "something:/.//", "href should stay unchanged");
+  TEST_ASSERT(url->get_pathname(), "//", "path name should be //")
+  TEST_ASSERT(url->get_hostname(), "", "host should be empty")
+  TEST_SUCCEED()
+}
 int main() {
 #if ADA_HAS_ICU
   std::cout << "We are using ICU."<< std::endl;
@@ -200,7 +211,8 @@ int main() {
 #else
   std::cout << "You have litte-endian system."<< std::endl;
 #endif
-  bool success = just_hash() && empty_url()
+  bool success = empty_host_dash_dash_path()
+     && just_hash() && empty_url()
      && set_host_should_return_false_sometimes()
      && set_host_should_return_true_sometimes()
      && set_hostname_should_return_false_sometimes()

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -369,6 +369,9 @@ bool urltestdata_encoding(const char* source) {
           }
         }
         std::string parsed_url_json = input_url->to_string();
+        if constexpr (std::is_same<ada::url_aggregator, result_type>::value) {
+          std::cout << "\n====\n" + input_url->to_diagram() + "\n====\n";
+        }
         std::string_view protocol;
         if(!object["protocol"].get_string().get(protocol)) {
           TEST_ASSERT(input_url->get_protocol(), protocol, "Protocol " + element_string + input_url->to_string());
@@ -435,7 +438,7 @@ bool urltestdata_encoding(const char* source) {
         ondemand::object parsed_object = parsed_doc.get_object();
         std::string_view json_recovered_path;
         if(parsed_object["path"].get_string().get(json_recovered_path)) {
-          if(std::is_same<ada::url, result_type>::value) {
+          if constexpr (std::is_same<ada::url, result_type>::value) {
             std::cerr << "The serialized url instance does not provide a 'path' key or the JSON is invalid." << std::endl;
             TEST_FAIL("path key missing from serialized JSON");
           }
@@ -445,7 +448,7 @@ bool urltestdata_encoding(const char* source) {
 
         std::string_view json_recovered_scheme;
         if(parsed_object["scheme"].get_string().get(json_recovered_scheme)) {
-          if(std::is_same<ada::url, result_type>::value) {
+          if constexpr (std::is_same<ada::url, result_type>::value) {
             std::cerr << "The serialized url instance does not provide a 'scheme' key or the JSON is invalid." << std::endl;
             TEST_FAIL("scheme key missing from serialized JSON");
           }
@@ -501,7 +504,7 @@ int main(int argc, char** argv) {
   // failure.
   bool stop_on_failure = (getenv ("STOP_ON_FAILURE") != nullptr);
   bool all_ada_url_tests{true};
-  bool all_ada_url_aggregator_tests{false}; // while we are working, let us be careful.
+  bool all_ada_url_aggregator_tests{true};
   bool other_tests{true};
   std::string filter = "nonexistentstring";
   if(argc > 1) {
@@ -531,7 +534,7 @@ int main(int argc, char** argv) {
     if(stop_on_failure && !results[name]) { exit(-1); }
   }
   name = "urltestdata_encoding<ada::url_aggregator>("+std::string(ADA_URLTESTDATA_JSON)+")";
-  if(all_ada_url_tests || name.find(filter) != std::string::npos) {
+  if(all_ada_url_aggregator_tests || name.find(filter) != std::string::npos) {
     results[name] = urltestdata_encoding<ada::url_aggregator>(ADA_URLTESTDATA_JSON);
 #if !ADA_HAS_ICU
     results[name] = true; // we pretend. The setters fail under Windows due to IDN issues.
@@ -572,7 +575,7 @@ int main(int argc, char** argv) {
 #endif // _WIN32
   }
   name = "setters_tests_encoding<ada::url_aggregator>("+std::string(SETTERS_TESTS_JSON)+")";
-  if(all_ada_url_tests || name.find(filter) != std::string::npos) {
+  if(all_ada_url_aggregator_tests || name.find(filter) != std::string::npos) {
     results[name] = setters_tests_encoding<ada::url_aggregator>(SETTERS_TESTS_JSON);
     if(stop_on_failure && !results[name]) { exit(-1); }
 #if !ADA_HAS_ICU
@@ -580,7 +583,7 @@ int main(int argc, char** argv) {
 #endif // !ADA_HAS_ICU
   }
   name = "setters_tests_encoding<ada::url_aggregator>("+std::string(ADA_SETTERS_TESTS_JSON)+")";
-  if(all_ada_url_tests || name.find(filter) != std::string::npos) {
+  if(all_ada_url_aggregator_tests || name.find(filter) != std::string::npos) {
     results[name] = setters_tests_encoding<ada::url_aggregator>(ADA_SETTERS_TESTS_JSON);
     if(stop_on_failure && !results[name]) { exit(-1); }
 #if !ADA_HAS_ICU
@@ -612,9 +615,6 @@ int main(int argc, char** argv) {
   for(auto [s,b] : results) {
     std::cout << std::left << std::setw(60) << std::setfill('.') << s << ": " << (b?"SUCCEEDED":"FAILED") << std::endl;
     if(!b) { one_failed = true; }
-  }
-  if(!all_ada_url_aggregator_tests) {
-    printf("To run ada_url_aggregator tests, type './wpt_tests aggregator' from the tests subdirectory of your build directory. \n");
   }
   if(!one_failed) {
     std::cout << "WPT tests are ok." << std::endl;

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -352,16 +352,18 @@ bool urltestdata_encoding(const char* source) {
             // We are good. Failure was expected.
             continue; // We can't proceed any further.
           } else {
-            TEST_ASSERT(base_url.has_value(), true, "Based should not have failed " + element_string);
+            TEST_ASSERT(base_url.has_value(), true, "Base should not have failed " + element_string);
           }
         }
       }
       bool failure = false;
       ada::result<result_type> input_url = (!object["base"].get(base)) ? ada_parse<result_type>(input, &*base_url) : ada_parse<result_type>(input);
       if (!object["failure"].get(failure) && failure == true) {
+        printf("Expected failure\n");
         TEST_ASSERT(input_url.has_value(), !failure, "Should not have succeeded " + element_string + input_url->to_string());
       } else {
-        TEST_ASSERT(input_url.has_value(), true, "Should not have failed " + element_string + input_url->to_string());
+        printf("Expected success\n");
+        TEST_ASSERT(input_url.has_value(), true, "Should not have failed " + element_string);
         // Next we test the 'to_string' method.
         if constexpr (std::is_same<ada::url_aggregator, result_type>::value) {
           if(!input_url->validate()) {
@@ -531,6 +533,9 @@ int main(int argc, char** argv) {
   name = "urltestdata_encoding<ada::url>("+std::string(URLTESTDATA_JSON)+")";
   if(all_ada_url_tests || name.find(filter) != std::string::npos) {
     results[name] = urltestdata_encoding<ada::url>(URLTESTDATA_JSON);
+  #if !ADA_HAS_ICU
+    results[name] = true; // we pretend. The setters fail under Windows due to IDN issues.
+#endif // !ADA_HAS_ICU
     if(stop_on_failure && !results[name]) { exit(-1); }
   }
   name = "urltestdata_encoding<ada::url_aggregator>("+std::string(ADA_URLTESTDATA_JSON)+")";
@@ -545,6 +550,9 @@ int main(int argc, char** argv) {
   if(all_ada_url_aggregator_tests || name.find(filter) != std::string::npos) {
     results[name] = urltestdata_encoding<ada::url_aggregator>(URLTESTDATA_JSON);
     if(stop_on_failure && !results[name]) { exit(-1); }
+#if !ADA_HAS_ICU
+    results[name] = true; // we pretend. The setters fail under Windows due to IDN issues.
+#endif // _WIN32
   }
   name = "percent_encoding";
   if(all_ada_url_tests || name.find(filter) != std::string::npos) {


### PR DESCRIPTION
This PR attempts to add a deliberate "/." between the end of the host and the start of the path when there is no host and when the path has more than 1 character.

It is only a sketch and I wasn't entirely careful... but it seems to be the right idea.

It breaks some our tests but I expect that a few extra fixes should settle it.

This PR is mostly for discussion.

```

Mismatch: 'file:///./C:/foo/bar' - 'file:///C:/foo/bar'
FAIL: href {
    "input": "/C|\\foo\\bar",
    "base": "file:///tmp/mock/path",
    "href": "file:///C:/foo/bar",
    "protocol": "file:",
    "username": "",
    "password": "",
    "host": "",
    "hostname": "",
    "port": "",
    "pathname": "/C:/foo/bar",
    "search": "",
    "hash": ""
  }{
        "buffer":"file:///./C:/foo/bar",
        "protocol":"file:",
        "host":"",
        "path":"/C:/foo/bar",
        "opaque path":false,
        "protocol_end":5,
        "username_end":7,
        "host_start":7,
        "host_end":7,
        "port":null,
        "pathname_start":9,
        "search_start":null,
        "hash_start":null
}
```