### PR TITLE
various simplifications to dev branch

### DIFF
--- a/.github/workflows/ubuntu-sanitized.yml
+++ b/.github/workflows/ubuntu-sanitized.yml
@@ -1,12 +1,6 @@
 name: Ubuntu 22.04 (GCC 12 SANITIZED)
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 permissions:
   contents: read
@@ -27,7 +21,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -DADA_SANITIZE=ON  -DADA_DEVELOPMENT_CHECKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
+        run: cmake -DADA_SANITIZE=ON -DADA_DEVELOPMENT_CHECKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
         env:
           CXX: g++-12
       - name: Build

--- a/.github/workflows/ubuntu_old.yml
+++ b/.github/workflows/ubuntu_old.yml
@@ -1,12 +1,6 @@
 name: Ubuntu 20.04
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/ubuntu_pedantic.yml
+++ b/.github/workflows/ubuntu_pedantic.yml
@@ -1,12 +1,6 @@
 name: Ubuntu 22.04 (GCC 12) Fails On Compiler Warnings
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/visual_studio.yml
+++ b/.github/workflows/visual_studio.yml
@@ -22,14 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {gen: Visual Studio 17 2022, arch: x64}
+          - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON}
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -B build
+        cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -B build
     - name: Build Debug
       run: cmake --build build --config Debug --verbose
+    - name: Run Debug tests
+      working-directory: build
+      run: ctest -C Debug  --output-on-failure
     - name: Build Release
       run: cmake --build build --config Release --verbose
     - name: Run Release tests

--- a/.github/workflows/visual_studio.yml
+++ b/.github/workflows/visual_studio.yml
@@ -1,12 +1,6 @@
 name: VS17-CI
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/visual_studio_clang.yml
+++ b/.github/workflows/visual_studio_clang.yml
@@ -22,14 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {gen: Visual Studio 17 2022, arch: x64}
+          - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON}
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -T ClangCL  -B build
+        cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -T ClangCL  -B build
     - name: Build Debug
       run: cmake --build build --config Debug --verbose
+    - name: Run Debug tests
+      working-directory: build
+      run: ctest -C Debug  --output-on-failure
     - name: Build Release
       run: cmake --build build --config Release --verbose
     - name: Run Release tests

--- a/.github/workflows/visual_studio_clang.yml
+++ b/.github/workflows/visual_studio_clang.yml
@@ -1,12 +1,7 @@
 name: VS17-clang-CI
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
+
 
 permissions:
   contents: read

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -64,7 +64,7 @@ namespace ada {
      * @see https://url.spec.whatwg.org/#dom-url-href
      * @see https://url.spec.whatwg.org/#concept-url-serializer
      */
-    [[nodiscard]] const std::string& get_href() const noexcept;
+    inline std::string_view get_href() const noexcept;
     /**
      * The username getter steps are to return this’s URL’s username.
      * This function does not allocate memory.
@@ -270,9 +270,6 @@ namespace ada {
      * To optimize performance, you may indicate how much memory to allocate within this instance.
      */
     inline void reserve(uint32_t capacity);
-
-    /** @private */
-    inline const std::string& get_buffer() const noexcept;
 
     /** @private */
     ada_really_inline size_t parse_port(

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -94,7 +94,7 @@ namespace ada {
      * @see https://url.spec.whatwg.org/#host-parsing
      */
     virtual ada_really_inline size_t parse_port(
-      std::string_view view, bool check_trailing_content = false) noexcept = 0;;
+      std::string_view view, bool check_trailing_content = false) noexcept = 0;
 
     /**
     * Returns a JSON string representation of this URL.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -322,7 +322,7 @@ namespace ada::parser {
               url.path = base_url->path;
               url.query = base_url->query;
             } else  {
-              url.update_base_authority(base_url->get_buffer(), base_url->get_components());
+              url.update_base_authority(base_url->get_href(), base_url->get_components());
               url.set_hostname(base_url->get_hostname());
   	          url.update_base_port(base_url->retrieve_base_port());
               url.update_base_pathname(base_url->get_pathname());
@@ -381,7 +381,7 @@ namespace ada::parser {
               url.host = base_url->host;
               url.port = base_url->port;
             } else {
-              url.update_base_authority(base_url->get_buffer(), base_url->get_components());
+              url.update_base_authority(base_url->get_href(), base_url->get_components());
               url.set_hostname(base_url->get_hostname());
               url.update_base_port(base_url->retrieve_base_port());
             }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -7,29 +7,6 @@
 #include <string>
 
 namespace ada {
-
-  ada_really_inline size_t url::parse_port(std::string_view view, bool check_trailing_content) noexcept {
-    ada_log("parse_port('", view, "') ", view.size());
-    uint16_t parsed_port{};
-    auto r = std::from_chars(view.data(), view.data() + view.size(), parsed_port);
-    if(r.ec == std::errc::result_out_of_range) {
-      ada_log("parse_port: std::errc::result_out_of_range");
-      is_valid = false;
-      return 0;
-    }
-    ada_log("parse_port: ", parsed_port);
-    const size_t consumed = size_t(r.ptr - view.data());
-    ada_log("parse_port: consumed ", consumed);
-    if(check_trailing_content) {
-      is_valid &= (consumed == view.size() || view[consumed] == '/' || view[consumed] == '?' || (is_special() && view[consumed] == '\\'));
-    }
-    ada_log("parse_port: is_valid = ", is_valid);
-    if(is_valid) {
-      port = (r.ec == std::errc() && scheme_default_port() != parsed_port) ?
-        std::optional<uint16_t>(parsed_port) : std::nullopt;
-    }
-    return consumed;
-  }
   
   bool url::parse_opaque_host(std::string_view input) {
     ada_log("parse_opaque_host ", input, "[", input.size(), " bytes]");

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -474,11 +474,6 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   return set_host_or_hostname<true>(input);
 }
 
-[[nodiscard]] const std::string& url_aggregator::get_href() const noexcept {
-  ada_log("url_aggregator::get_href");
-  return buffer;
-}
-
 [[nodiscard]] std::string url_aggregator::get_origin() const noexcept {
   ada_log("url_aggregator::get_origin");
   if (is_special()) {


### PR DESCRIPTION
1. Inlining is of great importance for performance. In some instances, we include in the source file functions that ought to be inlined. Short functions that only include little code should almost always be inlined. In other cases we define inline functions in the source files... This is not consistent. A function that is inline should be in the header files. There are several cases where we fail to follow this convention... and I am not sure that I am concerned about it, but when it broke the build under Visual Studio.
2. We don't really need get_buffer(), we already have get_href() which is equivalent.
3. We should favor exposing std::string_view instead of returning a reference to an inner std::string instance to make future work easier: consider that we might want to change the inner implementation later.