### PR TITLE
perf: add multiple optimizations

### DIFF
--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -126,7 +126,6 @@ ada_really_inline uint32_t url_aggregator::get_pathname_length() const noexcept 
 }
 
 [[nodiscard]] ada_really_inline bool url_aggregator::is_at_path() const noexcept {
-  if (components.search_start != url_components::omitted || components.hash_start != url_components::omitted) { return false; }
   return buffer.size() == components.pathname_start;
 }
 
@@ -216,7 +215,7 @@ inline void url_aggregator::update_base_pathname(const std::string_view input) {
   // The common case is current_length == 0.
   buffer.erase(components.pathname_start, current_length);
   // next line is very uncommon and we should seek to optimize it accordingly.
-  if(begins_with_dashdash && !has_hostname() && !has_opaque_path) {
+  if (begins_with_dashdash && !has_opaque_path && !has_hostname()) {
     // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
     // then append U+002F (/) followed by U+002E (.) to output.
     buffer.insert(components.pathname_start, "/.");
@@ -245,9 +244,8 @@ inline void url_aggregator::append_base_pathname(const std::string_view input) {
   else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
   buffer.insert(ending_index, input);
 
-  uint32_t difference = uint32_t(input.size());
-  if (components.search_start != url_components::omitted) { components.search_start += difference; }
-  if (components.hash_start != url_components::omitted) { components.hash_start += difference; }
+  if (components.search_start != url_components::omitted) { components.search_start += uint32_t(input.size()); }
+  if (components.hash_start != url_components::omitted) { components.hash_start += uint32_t(input.size()); }
 #if ADA_DEVELOPMENT_CHECKS
   std::string path_after = std::string(get_pathname());
   ADA_ASSERT_EQUAL(path_expected, path_after, "append_base_pathname problem after inserting "+std::string(input));

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -632,6 +632,8 @@ inline bool url_aggregator::has_port() const noexcept {
 }
 
 inline bool url_aggregator::has_dash_dot() const noexcept  {
+  // If url’s host is null, url does not have an opaque path, url’s path’s size is greater than 1,
+  // and url’s path[0] is the empty string, then append U+002F (/) followed by U+002E (.) to output.
   ada_log("url_aggregator::has_dash_dot");
   // Performance: instead of doing this potentially expensive check, we could just
   // have a boolean value in the structure.
@@ -643,7 +645,7 @@ inline bool url_aggregator::has_dash_dot() const noexcept  {
     ADA_ASSERT_TRUE(buffer[components.pathname_start+1] == '/');
   }
 #endif
-  return components.pathname_start == components.host_end + 2 && components.pathname_start + 1 < buffer.size();
+  return !has_opaque_path && components.pathname_start == components.host_end + 2 && components.pathname_start + 1 < buffer.size();
 }
 
 inline std::string_view url_aggregator::get_href() const noexcept {

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -118,10 +118,9 @@ inline void url_aggregator::update_base_hostname(const std::string_view input) {
 
 ada_really_inline uint32_t url_aggregator::get_pathname_length() const noexcept {
   ada_log("url_aggregator::get_pathname_length");
-  uint32_t ending_index = 0;
+  uint32_t ending_index = uint32_t(buffer.size());
   if (components.search_start != url_components::omitted) { ending_index = components.search_start; }
   else if (components.hash_start != url_components::omitted) { ending_index = components.hash_start; }
-  else { ending_index = uint32_t(buffer.size()); }
   return ending_index - components.pathname_start;
 }
 

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -305,7 +305,7 @@ inline void url_aggregator::append_base_username(const std::string_view input) {
 
   uint32_t difference = uint32_t(input.size());
   buffer.insert(components.username_end, input);
-  components.username_end += uint32_t(input.size());
+  components.username_end += difference;
   components.host_start += difference;
 
   if (buffer[components.host_start] != '@' && components.host_start != components.host_end) {

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -147,12 +147,12 @@ inline void url_aggregator::update_base_search(std::string_view input) {
     } else {
       buffer.erase(components.search_start);
     }
+  } else {
+    components.search_start = components.pathname_start + get_pathname_length();
   }
 
-  uint32_t input_size = uint32_t(input.size());
-  components.search_start = components.pathname_start + get_pathname_length();
+  uint32_t input_size = 0;
   // The common case here is components.search_start == buffer.size().
-
   if (input[0] != '?') {
     // If input does not start with "?", we need to add it.
     buffer.insert(components.search_start, helpers::concat("?", input));
@@ -160,7 +160,7 @@ inline void url_aggregator::update_base_search(std::string_view input) {
   } else {
     buffer.insert(components.search_start, input);
   }
-  if (components.hash_start != url_components::omitted) { components.hash_start += input_size; }
+  if (components.hash_start != url_components::omitted) { components.hash_start += input_size + uint32_t(input.size()); }
   ADA_ASSERT_TRUE(validate());
 }
 

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -46,10 +46,6 @@ namespace ada {
 
     [[nodiscard]] bool has_valid_domain() const noexcept override;
 
-    /** @private */
-    inline bool has_authority() const noexcept;
-    /** @return true if it has an host but it is the empty string */
-    [[nodiscard]] inline bool has_empty_hostname() const noexcept;
     /**
      * The origin getter steps are to return the serialization of this’s URL’s
      * origin. [HTML]
@@ -221,12 +217,14 @@ namespace ada {
     inline bool has_dash_dot() const noexcept;
     /** @private */
     void delete_dash_dot();
+    /** @return true if it has an host but it is the empty string */
+    [[nodiscard]] inline bool has_empty_hostname() const noexcept;
     /** @private */
-    [[nodiscard]] inline bool has_non_empty_username() const;
+    [[nodiscard]] inline bool has_non_empty_username() const noexcept;
     /** @private */
-    [[nodiscard]] inline bool has_non_empty_password() const;
+    [[nodiscard]] inline bool has_non_empty_password() const noexcept;
     /** @private */
-    [[nodiscard]] inline bool has_password() const;
+    [[nodiscard]] inline bool has_password() const noexcept;
     /** @return true if the URL has a (non default) port */
     [[nodiscard]] inline bool has_port() const noexcept;
     /** @return true if the URL has host */
@@ -236,6 +234,8 @@ namespace ada {
     /** @private */
     template <bool has_state_override = false>
     [[nodiscard]] ada_really_inline bool parse_scheme(const std::string_view input);
+    /** @private */
+    inline bool has_authority() const noexcept;
 
     /**
      * Useful for implementing efficient serialization for the URL.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -37,12 +37,6 @@ namespace ada::parser {
     // we must return.
     if(base_url != nullptr) { url.is_valid &= base_url->is_valid; }
     if(!url.is_valid) { return url; }
-    if constexpr (result_type_is_ada_url_aggregator) {
-      // Most of the time, we just need user_input.size().
-      // In some instances, we may need more.
-      uint32_t reserve_capacity = uint32_t(user_input.size()) + 256;
-      url.reserve(reserve_capacity);
-    }
     std::string tmp_buffer;
     std::string_view internal_input;
     if(unicode::has_tabs_or_newline(user_input)) {

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -230,29 +230,18 @@ ada_really_inline void url_aggregator::parse_path(std::string_view input) {
 
   // If url is special, then:
   if (is_special()) {
-    std::string path{};
     if(internal_input.empty()) {
       update_base_pathname("/");
-      return;
     } else if((internal_input[0] == '/') || (internal_input[0] == '\\')) {
-      helpers::parse_prepared_path(internal_input.substr(1), type, path);
-      update_base_pathname(path);
-      return;
+      consume_prepared_path(internal_input.substr(1));
     } else {
-      helpers::parse_prepared_path(internal_input, type, path);
-      update_base_pathname(path);
-      return;
+      consume_prepared_path(internal_input);
     }
   } else if (!internal_input.empty()) {
-    std::string path{};
     if(internal_input[0] == '/') {
-      helpers::parse_prepared_path(internal_input.substr(1), type, path);
-      update_base_pathname(path);
-      return;
+      consume_prepared_path(internal_input.substr(1));
     } else {
-      helpers::parse_prepared_path(internal_input, type, path);
-      update_base_pathname(path);
-      return;
+      consume_prepared_path(internal_input);
     }
   } else {
     // Non-special URLs with an empty host can have their paths erased
@@ -262,7 +251,6 @@ ada_really_inline void url_aggregator::parse_path(std::string_view input) {
     }
   }
   ADA_ASSERT_TRUE(validate());
-  return;
 }
 
 void url_aggregator::set_search(const std::string_view input) {

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -424,12 +424,10 @@ bool urltestdata_encoding(const char *source) {
                 ? ada_parse<result_type>(input, &*base_url)
                 : ada_parse<result_type>(input);
         if (!object["failure"].get(failure) && failure == true) {
-          printf("Expected failure\n");
           TEST_ASSERT(input_url.has_value(), !failure,
                       "Should not have succeeded " + element_string +
                           input_url->to_string());
         } else {
-          printf("Expected success\n");
           TEST_ASSERT(input_url.has_value(), true,
                       "Should not have failed " + element_string);
           // Next we test the 'to_string' method.


### PR DESCRIPTION
Running: `sudo build/benchmarks/bench ./datasets/wikipedia/wikipedia_100k.txt`

Before

```
BasicBench_AdaURL_aggregator              21961383 ns     21959687 ns           32 GHz=3.21847 cycle/byte=13.6115 cycles/url=695.45 instructions/byte=62.6634 instructions/cycle=4.6037 instructions/ns=14.8169 instructions/url=3.20164k ns/url=216.081 speed=232.666M/s time/byte=4.29801ns time/url=219.597ns url/s=4.5538M/s
BasicBench_AdaURL_aggregator_just_parse   22256599 ns     22252937 ns           32 GHz=3.22738 cycle/byte=13.73 cycles/url=701.5 instructions/byte=63.6907 instructions/cycle=4.63881 instructions/ns=14.9712 instructions/url=3.25412k ns/url=217.359 speed=229.6M/s time/byte=4.35541ns time/url=222.529ns url/s=4.49379M/s
```

After

```
----------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations instructions/byte
----------------------------------------------------------------------------------------------------
BasicBench_AdaURL                         20176538 ns     20176514 ns           35           57.0265
BasicBench_AdaURL_just_parse              12578289 ns     12575679 ns           56           35.6931
BasicBench_AdaURL_aggregator              20621221 ns     20616647 ns           34           55.7308
BasicBench_AdaURL_aggregator_just_parse   20411587 ns     20410382 ns           34           55.5922
```