### PR TITLE
Various scheme-related optimizations.

### DIFF
--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -275,4 +275,12 @@ namespace ada {
 #define ADA_ASSERT_EQUAL(LHS, RHS, MESSAGE)
 #define ADA_ASSERT_TRUE(COND)
 #endif
+
+
+
+#ifdef ADA_VISUAL_STUDIO
+#define ADA_ASSUME(COND) __assume(COND)
+#else
+#define ADA_ASSUME(COND) do { if (!(COND)) __builtin_unreachable(); } while (0)
+#endif
 #endif // ADA_COMMON_DEFS_H

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -154,6 +154,8 @@ inline bool url::base_fragment_has_value() const { return fragment.has_value(); 
 
 inline bool url::base_search_has_value() const { return query.has_value(); }
 
+inline void url::set_file_protocol() { type =  ada::scheme::type::FILE; }
+
 inline void url::set_scheme(std::string &&new_scheme) noexcept {
   type = ada::scheme::get_scheme_type(new_scheme);
   // We only move the 'scheme' if it is non-special.

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -120,6 +120,8 @@ struct url : url_base {
   inline bool base_fragment_has_value() const override;
   /** @private */
   inline bool base_search_has_value() const override;
+  /** @private set this URL's type to file */
+  inline void set_file_protocol();
   /** @return true if the URL has host */
   [[nodiscard]] inline bool has_hostname() const noexcept;
   /** @return true if it has an host but it is the empty string */

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -685,6 +685,31 @@ ada_really_inline size_t url_aggregator::parse_port(std::string_view view, bool 
   return consumed;
 }
 
+inline void url_aggregator::set_file_protocol() {
+  ada_log("url_aggregator::set_file_protocol ");
+  ADA_ASSERT_TRUE(validate());
+  type =  ada::scheme::type::FILE;
+  uint32_t new_difference = 5 - components.protocol_end;
+
+  if(buffer.empty()) {
+    buffer.append("file:");
+  } else {
+    buffer.erase(0, components.protocol_end);
+    buffer.insert(0, "file:");
+  }
+  components.protocol_end = 5;
+
+  // Update the rest of the components.
+  components.username_end += new_difference;
+  components.host_start += new_difference;
+  components.host_end += new_difference;
+  components.pathname_start += new_difference;
+  if (components.search_start != url_components::omitted) { components.search_start += new_difference; }
+  if (components.hash_start != url_components::omitted) { components.hash_start += new_difference; }
+  ADA_ASSERT_TRUE(validate());
+}
+
+
 }
 
 #endif // ADA_URL_AGGREGATOR_INL_H

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -42,12 +42,17 @@ namespace ada {
     void set_search(const std::string_view input);
     void set_hash(const std::string_view input);
     inline void set_scheme(std::string_view new_scheme) noexcept;
+    /** @private */
+    inline void set_scheme_fast(std::string_view new_scheme_with_colon) noexcept;
+
     inline void copy_scheme(const url_aggregator& u) noexcept;
 
     [[nodiscard]] bool has_valid_domain() const noexcept override;
 
     /** @private */
     inline bool has_authority() const noexcept;
+    /** @private set this URL's type to file */
+    inline void set_file_protocol();
     /** @return true if it has an host but it is the empty string */
     [[nodiscard]] inline bool has_empty_hostname() const noexcept;
     /**
@@ -236,7 +241,8 @@ namespace ada {
     /** @private */
     template <bool has_state_override = false>
     [[nodiscard]] ada_really_inline bool parse_scheme(const std::string_view input);
-
+    template <bool has_state_override = false>
+    [[nodiscard]] ada_really_inline bool parse_scheme_with_colon(const std::string_view input);
     /**
      * Useful for implementing efficient serialization for the URL.
      *

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -99,7 +99,12 @@ namespace ada::parser {
           // Otherwise, if c is U+003A (:), then:
           if ((input_position != input_size) && (url_data[input_position] == ':')) {
             ada_log("SCHEME the scheme should be ", url_data.substr(0,input_position));
-            if(!url.parse_scheme(url_data.substr(0,input_position))) { return url; }
+            if constexpr (result_type_is_ada_url) {
+              if(!url.parse_scheme(url_data.substr(0,input_position))) { return url; }
+            } else {
+              // we pass the colon along instead of painfully adding it back.
+              if(!url.parse_scheme_with_colon(url_data.substr(0,input_position+1))) { return url; }
+            }
             ada_log("SCHEME the scheme is ", url.get_protocol());
 
             // If url’s scheme is "file", then:
@@ -659,8 +664,7 @@ namespace ada::parser {
           ada_log("FILE ", helpers::substring(url_data, input_position));
           std::string_view file_view = helpers::substring(url_data, input_position);
 
-          // Set url’s scheme to "file".
-          url.set_scheme("file");
+          url.set_file_protocol();
           if constexpr (result_type_is_ada_url) {
             // Set url’s host to the empty string.
             url.host = "";

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -37,6 +37,22 @@ namespace ada::parser {
     // we must return.
     if(base_url != nullptr) { url.is_valid &= base_url->is_valid; }
     if(!url.is_valid) { return url; }
+    if constexpr (result_type_is_ada_url_aggregator) {
+      // Most of the time, we just need user_input.size().
+      // In some instances, we may need a bit more.
+      ///////////////////////////
+      // This is *very* important. This line should be removed
+      // hastily. There are principled reasons why reserve is important
+      // for performance. If you have a benchmark with small inputs,
+      // it may not matter, but in other instances, it could.
+      ////
+      // This rounds up to the next power of two.
+      uint32_t reserve_capacity = (0xFFFFFFFF >> helpers::leading_zeroes(uint32_t(user_input.size()))) + 1;
+      url.reserve(reserve_capacity);
+      //
+      //
+      //
+    }
     std::string tmp_buffer;
     std::string_view internal_input;
     if(unicode::has_tabs_or_newline(user_input)) {


### PR DESCRIPTION
The main trick that this is using is that instead of, for example, passing the view "http" and then later creating the temporary "http:" which gets added to our buffer, we just pass straight up  "http:" and avoid the messy business entirely. Also, I created new methods to set the URL to file type, very fast (instead of passing the unnecessary string "file").

Apple M2, LLVM 14, benchdata.

Before:
```
Benchmark                                        Time             CPU   Iterations        GHz cycle/byte cycles/url instructions/byte instructions/cycle instructions/ns instructions/url     ns/url      speed  time/byte   time/url      url/s
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

BasicBench_AdaURL_aggregator              25379323 ns     25377464 ns           28    3.40142    9.73549    845.617            42.563            4.37194         14.8708         3.69699k    248.607 342.355M/s  2.92095ns  253.711ns 3.94149M/s
BasicBench_AdaURL_aggregator_just_parse   25524323 ns     25523074 ns           27    3.32936    9.76305    848.011            42.482            4.35131         14.4871         3.68996k    254.707 340.401M/s  2.93771ns  255.167ns   3.919M/s
```

After:
```
Benchmark                                        Time             CPU   Iterations        GHz cycle/byte cycles/url instructions/byte instructions/cycle instructions/ns instructions/url     ns/url      speed  time/byte   time/url      url/s
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BasicBench_AdaURL_aggregator              22431659 ns     22431677 ns           31    3.39537    8.73146    758.408           39.4446            4.51752         15.3387         3.42613k    223.365 387.314M/s  2.58189ns  224.261ns  4.4591M/s
BasicBench_AdaURL_aggregator_just_parse   22537055 ns     22537065 ns           31    3.40045    8.76141    761.009           39.4039            4.49744         15.2933         3.42259k    223.797 385.502M/s  2.59402ns  225.314ns 4.43824M/s
```