### PR TITLE
feat: add url_aggregator::replace_and_resize

### DIFF
--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -231,6 +231,9 @@ namespace ada {
     template <bool has_state_override = false>
     [[nodiscard]] ada_really_inline bool parse_scheme_with_colon(const std::string_view input);
 
+    /** @private */
+    ada_really_inline uint32_t replace_and_resize(uint32_t start, uint32_t end, std::string_view input);
+
     /**
      * Useful for implementing efficient serialization for the URL.
      *


### PR DESCRIPTION
Before

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations        GHz cycle/byte cycles/url instructions/byte instructions/cycle instructions/ns instructions/url     ns/url      speed  time/byte   time/url      url/s
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BasicBench_AdaURL                             3091 ns         3090 ns       226676    4.36423    16.4307   1.20691k           73.4208            4.46851         19.5016         5.39309k    276.545 261.454M/s  3.82476ns  280.946ns  3.5594M/s
BasicBench_AdaURL_just_parse                  1786 ns         1786 ns       391147    5.25279    11.6498    855.727           50.6225            4.34537         22.8253         3.71845k    162.909 452.463M/s  2.21013ns  162.344ns 6.15977M/s
BasicBench_AdaURL_aggregator                  2406 ns         2406 ns       291252    4.70737    14.0755    1033.91           59.6795            4.23995          19.959         4.38373k    219.636 335.869M/s  2.97735ns    218.7ns 4.57247M/s
BasicBench_AdaURL_aggregator_just_parse       2396 ns         2396 ns       293307    4.65728    13.9257    1022.91           59.4418            4.26849         19.8796         4.36627k    219.636 337.167M/s  2.96589ns  217.858ns 4.59015M/s
```


After

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations        GHz cycle/byte cycles/url instructions/byte instructions/cycle instructions/ns instructions/url     ns/url      speed  time/byte   time/url      url/s
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BasicBench_AdaURL                             2964 ns         2964 ns       235671     4.5096    16.2748   1.19545k           73.3775            4.50867         20.3323         5.38991k    265.091 272.572M/s  3.66876ns  269.487ns 3.71075M/s
BasicBench_AdaURL_just_parse                  1724 ns         1724 ns       405555    5.31429    11.5099    845.455           50.6126            4.39731         23.3686         3.71773k    159.091 468.793M/s  2.13314ns  156.689ns 6.38208M/s
BasicBench_AdaURL_aggregator                  2287 ns         2287 ns       303075    4.88267    13.5965    998.727           59.0829            4.34544         21.2173         4.33991k    204.545 353.325M/s  2.83025ns  207.895ns 4.81012M/s
BasicBench_AdaURL_aggregator_just_parse       2333 ns         2332 ns       302343    4.94889    13.7809    1012.27           58.9975             4.2811         21.1867         4.33364k    204.545 346.419M/s  2.88668ns   212.04ns  4.7161M/s
```