### PR TITLE
This PR reduces the number of some temporary strings.

### DIFF
--- a/include/ada/unicode-inl.h
+++ b/include/ada/unicode-inl.h
@@ -1,0 +1,25 @@
+/**
+ * @file unicode-inl.h
+ * @brief Definitions for unicode operations.
+ */
+#ifndef ADA_UNICODE_INL_H
+#define ADA_UNICODE_INL_H
+#include <algorithm>
+#include "ada/unicode.h"
+
+/**
+ * @namespace ada::unicode
+ * @brief Includes the declarations for unicode operations
+ */
+namespace ada::unicode {
+ada_really_inline size_t percent_encode_index(const std::string_view input,
+                                              const uint8_t character_set[]) {
+  return size_t(std::find_if(input.begin(), input.end(),
+                             [character_set](const char c) {
+                               return character_sets::bit_at(character_set, c);
+                             }) -
+                input.begin());
+}
+}  // namespace ada::unicode
+
+#endif  // ADA_UNICODE_INL_H

--- a/include/ada/unicode-inl.h
+++ b/include/ada/unicode-inl.h
@@ -14,11 +14,11 @@
 namespace ada::unicode {
 ada_really_inline size_t percent_encode_index(const std::string_view input,
                                               const uint8_t character_set[]) {
-  return size_t(std::find_if(input.begin(), input.end(),
-                             [character_set](const char c) {
-                               return character_sets::bit_at(character_set, c);
-                             }) -
-                input.begin());
+  return std::distance(
+      input.begin(),
+      std::find_if(input.begin(), input.end(), [character_set](const char c) {
+        return character_sets::bit_at(character_set, c);
+      }));
 }
 }  // namespace ada::unicode
 

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -164,7 +164,13 @@ std::string percent_decode(const std::string_view input, size_t first_percent);
  */
 std::string percent_encode(const std::string_view input,
                            const uint8_t character_set[]);
-
+/**
+ * Returns a percent-encoded string version of input, while starting the percent
+ * encoding at the provided index.
+ * @see https://github.com/nodejs/node/blob/main/src/node_url.cc#L226
+ */
+std::string percent_encode(const std::string_view input,
+                           const uint8_t character_set[], size_t index);
 /**
  * Returns true if percent encoding was needed, in which case, we store
  * the percent-encoded content in 'out'. If the boolean 'append' is set to
@@ -175,7 +181,12 @@ std::string percent_encode(const std::string_view input,
 template <bool append>
 bool percent_encode(const std::string_view input, const uint8_t character_set[],
                     std::string& out);
-
+/**
+ * Returns the index at which percent encoding should start, or (equivalently),
+ * the length of the prefix that does not require percent encoding.
+ */
+ada_really_inline size_t percent_encode_index(const std::string_view input,
+                                              const uint8_t character_set[]);
 /**
  * Lowers the string in-place, assuming that the content is ASCII.
  * Return true if the content was ASCII.

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -615,7 +615,6 @@ inline void url_aggregator::clear_base_search() {
   ADA_ASSERT_TRUE(validate());
 }
 
-
 inline void url_aggregator::clear_base_hash() {
   ada_log("url_aggregator::clear_base_hash");
   ADA_ASSERT_TRUE(validate());

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -205,6 +205,8 @@ struct url_aggregator : url_base {
   inline void clear_base_port();
   /** @private */
   inline void clear_base_hostname();
+/** @private */
+  inline void clear_base_hash();
   /** @private */
   inline void clear_base_pathname() override;
   /** @private */
@@ -293,7 +295,6 @@ struct url_aggregator : url_base {
   ada_really_inline size_t
   parse_port(std::string_view view,
              bool check_trailing_content = false) noexcept override;
-
  private:
   /** @private */
   std::string buffer{};

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -205,7 +205,7 @@ struct url_aggregator : url_base {
   inline void clear_base_port();
   /** @private */
   inline void clear_base_hostname();
-/** @private */
+  /** @private */
   inline void clear_base_hash();
   /** @private */
   inline void clear_base_pathname() override;
@@ -295,6 +295,7 @@ struct url_aggregator : url_base {
   ada_really_inline size_t
   parse_port(std::string_view view,
              bool check_trailing_content = false) noexcept override;
+
  private:
   /** @private */
   std::string buffer{};

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -391,6 +391,21 @@ bool to_ascii(std::optional<std::string>& out, const std::string_view plain,
   return true;
 }
 
+std::string percent_encode(const std::string_view input,
+                           const uint8_t character_set[], size_t index) {
+  std::string out;
+  out.append(input.data(), index);
+  auto pointer = input.begin() + index;
+  for (; pointer != input.end(); pointer++) {
+    if (character_sets::bit_at(character_set, *pointer)) {
+      out.append(character_sets::hex + uint8_t(*pointer) * 4, 3);
+    } else {
+      out += *pointer;
+    }
+  }
+  return out;
+}
+
 std::string to_unicode(std::string_view input) {
   return ada::idna::to_unicode(input);
 }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -4,6 +4,7 @@
 #include "ada/helpers.h"
 #include "ada/implementation.h"
 #include "ada/scheme.h"
+#include "ada/unicode-inl.h"
 #include "ada/url_components.h"
 #include "ada/url_aggregator.h"
 #include "ada/url_aggregator-inl.h"
@@ -242,10 +243,15 @@ bool url_aggregator::set_username(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
-  // Optimization opportunity: Avoid temporary string creation
-  std::string encoded_input = ada::unicode::percent_encode(
+  size_t idx = ada::unicode::percent_encode_index(
       input, character_sets::USERINFO_PERCENT_ENCODE);
-  update_base_username(encoded_input);
+  if (idx == input.size()) {
+    update_base_username(input);
+  } else {
+    // We only create a temporary string if we have to!
+    update_base_username(ada::unicode::percent_encode(
+        input, character_sets::USERINFO_PERCENT_ENCODE, idx));
+  }
   ADA_ASSERT_TRUE(validate());
   return true;
 }
@@ -257,10 +263,15 @@ bool url_aggregator::set_password(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
-  // Optimization opportunity: Avoid temporary string creation
-  std::string encoded_input = ada::unicode::percent_encode(
+  size_t idx = ada::unicode::percent_encode_index(
       input, character_sets::USERINFO_PERCENT_ENCODE);
-  update_base_password(encoded_input);
+  if (idx == input.size()) {
+    update_base_password(input);
+  } else {
+    // We only create a temporary string if we have to!
+    update_base_password(ada::unicode::percent_encode(
+        input, character_sets::USERINFO_PERCENT_ENCODE, idx));
+  }
   ADA_ASSERT_TRUE(validate());
   return true;
 }
@@ -1142,9 +1153,15 @@ bool url_aggregator::parse_opaque_host(std::string_view input) {
 
   // Return the result of running UTF-8 percent-encode on input using the C0
   // control percent-encode set.
-  // TODO: Optimization opportunity: Get rid of this string creation.
-  update_base_hostname(ada::unicode::percent_encode(
-      input, ada::character_sets::C0_CONTROL_PERCENT_ENCODE));
+  size_t idx = ada::unicode::percent_encode_index(
+      input, character_sets::C0_CONTROL_PERCENT_ENCODE);
+  if (idx == input.size()) {
+    update_base_hostname(input);
+  } else {
+    // We only create a temporary string if we need to.
+    update_base_hostname(ada::unicode::percent_encode(
+        input, character_sets::C0_CONTROL_PERCENT_ENCODE, idx));
+  }
   ADA_ASSERT_TRUE(validate());
   return true;
 }
@@ -1622,7 +1639,7 @@ inline void url_aggregator::consume_prepared_path(std::string_view input) {
         input.remove_prefix(location + 1);
       }
       // path_buffer is either path_view or it might point at a percent encoded
-      // temporary file.
+      // temporary string.
       std::string_view path_buffer =
           (needs_percent_encoding &&
            ada::unicode::percent_encode<false>(

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -770,7 +770,7 @@ int main(int argc, char **argv) {
 #endif
   bool one_failed = false;
   for (auto [s, b] : results) {
-    std::cout << std::left << std::setw(60) << std::setfill('.') << s << ": "
+    std::cout << std::left << std::setw(80) << std::setfill('.') << s << ": "
               << (b ? "SUCCEEDED" : "FAILED") << std::endl;
     if (!b) {
       one_failed = true;


### PR DESCRIPTION
It is not expect to impact the performance much because we still end up creating temporary strings. To get rid of them in more significant numbers, we would need push the encoding further and write directly on the buffer. This PR moves us slightly closer to this goal.

This PR also...

1. adds clear_base_hash() (because we can clear everything else!!!)
2. fix the ugly formatting in wpt_tests