### PR TITLE
Optimize domain processing.

### DIFF
--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -82,10 +82,19 @@ ada_really_inline constexpr bool is_forbidden_host_code_point(
     const char c) noexcept;
 
 /**
- * Checks if the input is a forbidden domain code point.
+ * Checks if the input contains a forbidden domain code point.
  * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
  */
 ada_really_inline constexpr bool contains_forbidden_domain_code_point(
+    const char* input, size_t length) noexcept;
+
+/**
+ * Checks if the input contains a forbidden domain code point in which case
+ * the first bit is set to 1. If the input contains an upper case ASCII letter,
+ * then the second bit is set to 1.
+ * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
+ */
+ada_really_inline constexpr bool contains_forbidden_domain_code_point_or_upper(
     const char* input, size_t length) noexcept;
 
 /**

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -146,6 +146,44 @@ ada_really_inline constexpr bool contains_forbidden_domain_code_point(
   return accumulator;
 }
 
+constexpr static uint8_t is_forbidden_domain_code_point_table_or_upper[] = {
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+static_assert(sizeof(is_forbidden_domain_code_point_table_or_upper) == 256);
+static_assert(is_forbidden_domain_code_point_table_or_upper[uint8_t('A')] == 2);
+static_assert(is_forbidden_domain_code_point_table_or_upper[uint8_t('Z')] == 2);
+
+ada_really_inline constexpr bool contains_forbidden_domain_code_point_or_upper(
+    const char* input, size_t length) noexcept {
+  size_t i = 0;
+  uint8_t accumulator{};
+  for (; i + 4 <= length; i += 4) {
+    accumulator |=
+        is_forbidden_domain_code_point_table_or_upper[uint8_t(input[i])];
+    accumulator |=
+        is_forbidden_domain_code_point_table_or_upper[uint8_t(input[i + 1])];
+    accumulator |=
+        is_forbidden_domain_code_point_table_or_upper[uint8_t(input[i + 2])];
+    accumulator |=
+        is_forbidden_domain_code_point_table_or_upper[uint8_t(input[i + 3])];
+  }
+  for (; i < length; i++) {
+    accumulator |=
+        is_forbidden_domain_code_point_table_or_upper[uint8_t(input[i])];
+  }
+  return accumulator;
+}
+
 static_assert(unicode::is_forbidden_domain_code_point('%'));
 static_assert(unicode::is_forbidden_domain_code_point('\x7f'));
 static_assert(unicode::is_forbidden_domain_code_point('\0'));

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -458,23 +458,50 @@ ada_really_inline bool url_aggregator::parse_host(std::string_view input) {
   // to ASCII with domain and false. The most common case is an ASCII input, in
   // which case we do not need to call the expensive 'to_ascii' if a few
   // conditions are met: no '%' and no 'xn-' subsequence.
-  std::string _buffer = std::string(input);
-  // This next function checks that the result is ascii, but we are going to
-  // to check anyhow with is_forbidden.
-  // bool is_ascii =
-  unicode::to_lower_ascii(_buffer.data(), _buffer.size());
-  bool is_forbidden = unicode::contains_forbidden_domain_code_point(
-      _buffer.data(), _buffer.size());
-  if (is_forbidden == 0 && _buffer.find("xn-") == std::string_view::npos) {
+
+  // Often, the input does not contain any forbidden code points, and no upper
+  // case ASCII letter, then we can just copy it to the buffer. We want to
+  // optimize for such a common case.
+  uint8_t is_forbidden_or_upper =
+      unicode::contains_forbidden_domain_code_point_or_upper(input.data(),
+                                                             input.size());
+  // Minor optimization opportunity:
+  // contains_forbidden_domain_code_point_or_upper could be extend to check for
+  // the presence of characters that cannot appear in the ipv4 address and we
+  // could also check whether x and n and - are present, and so we could skip
+  // some of the checks below. However, the gains are likely to be small, and
+  // the code would be more complex.
+  if (is_forbidden_or_upper == 0 &&
+      input.find("xn-") == std::string_view::npos) {
     // fast path
-    update_base_hostname(_buffer);
+    update_base_hostname(input);
     if (checkers::is_ipv4(get_hostname())) {
       ada_log("parse_host fast path ipv4");
       return parse_ipv4(get_hostname());
     }
     ada_log("parse_host fast path ", get_hostname());
     return true;
+  } else if (is_forbidden_or_upper == 2) {
+    // We have encountered at least one upper case ASCII letter, let us
+    // try to convert it to lower case. If there is no 'xn-' in the result,
+    // we can then use a secondary fast path.
+    std::string _buffer = std::string(input);
+    unicode::to_lower_ascii(_buffer.data(), _buffer.size());
+    if (input.find("xn-") == std::string_view::npos) {
+      // secondary fast path when input is not all lower case
+      update_base_hostname(input);
+      if (checkers::is_ipv4(get_hostname())) {
+        ada_log("parse_host fast path ipv4");
+        return parse_ipv4(get_hostname());
+      }
+      ada_log("parse_host fast path ", get_hostname());
+      return true;
+    }
   }
+  // We have encountered at least one forbidden code point or the input contains
+  // 'xn-' (case insensitive), so we need to call 'to_ascii' to perform the full
+  // conversion.
+
   ada_log("parse_host calling to_ascii");
   std::optional<std::string> host = std::string(get_hostname());
   is_valid = ada::unicode::to_ascii(host, input, input.find('%'));


### PR DESCRIPTION
Currently, ada::url_aggregator will always copy the domain string to a temporary `std::string` which is the processed and finally copied on our buffer. This processing turns out to have an overhead of nearly 10% in some realistic cases.

This PR optimizes the case when the input domain is all lowercase, which is the common case. We could get smarter, but it seems to be good enough.

Using `benchdata` which defaults on @anonrig 's large URL file.

Before

```
BasicBench_AdaURL_aggregator_href             2394 ns         2390 ns       293043 speed=338.136M/s time/byte=2.95739ns time/url=217.234ns url/s=4.60334M/s
```

After


```
BasicBench_AdaURL_aggregator_href             2184 ns         2180 ns       315622 speed=370.673M/s time/byte=2.69779ns time/url=198.165ns url/s=5.0463M/s
```

So a 10% boost on this test, with an M2/LLVM14. I know how to achieve an extra 2% but it would result in more complicated code (it is described in the comments).