### PR TITLE
fix: `libc++` buffer overflow in `string_view` ctor

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -105,10 +105,10 @@ ada_really_inline bool shorten_path(std::string& path,
   // Let path be url’s path.
   // If url’s scheme is "file", path’s size is 1, and path[0] is a normalized
   // Windows drive letter, then return.
-  if (type == ada::scheme::type::FILE &&
+  if (!path.empty() && type == ada::scheme::type::FILE &&
       first_delimiter == std::string_view::npos) {
     if (checkers::is_normalized_windows_drive_letter(
-            std::string_view(path.data() + 1, first_delimiter - 1))) {
+            std::string_view(path.data() + 1, path.length() - 1))) {
       return false;
     }
   }

--- a/tests/wpt/ada_extra_urltestdata.json
+++ b/tests/wpt/ada_extra_urltestdata.json
@@ -255,5 +255,19 @@
     "pathname": "/%22quoted%22",
     "search": "",
     "hash": ""
+  },
+  {
+    "input": "../package.json",
+    "base": "file:///Users/package.json",
+    "href": "file:///",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
   }
 ]


### PR DESCRIPTION
Refs https://github.com/llvm/llvm-project/issues/61100.

Fixes a buffer overflow crash in `std::string` view constructor. This happens as a result of a limitation of libc++'s implementation of the `string_view` constructor. If `string_view` receives a pointer to a string start point, and then a length as a `size_t`, the spec says that a `size_t` that exceeds the length of the null terminated string found at pointer should only be read up until the null terminator.

However, Chromium's implementation however does a hard check that this length is less than or equal to [`static_cast<size_t>(std::numeric_limits<std::ptrdiff_t>::max())`]( https://source.chromium.org/chromium/chromium/src/+/main:buildtools/third_party/libc++/trunk/include/string_view;drc=1718a75513d114e6b9aa4474e5c55d8dabee92fb;l=309)

This doesn't break in Node.js right now because that hard assert is missing, but will break in the next version of Xcode that's shipped because it will include the above LLVM PR and thus Node.js too.