### PR TITLE
refactor base prefix and rename fragment to hash

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -31,7 +31,7 @@ void encode_json(std::string_view view, out_iter out);
  * This function is used to prune a fragment from a url, and returning the
  * removed string if input has fragment.
  *
- * @details prune_fragment seeks the first '#' and returns everything after it
+ * @details prune_hash seeks the first '#' and returns everything after it
  * as a string_view, and modifies (in place) the input so that it points at
  * everything before the '#'. If no '#' is found, the input is left unchanged
  * and std::nullopt is returned.
@@ -39,7 +39,7 @@ void encode_json(std::string_view view, out_iter out);
  * @attention The function is non-allocating and it does not throw.
  * @returns Note that the returned string_view might be empty!
  */
-ada_really_inline std::optional<std::string_view> prune_fragment(
+ada_really_inline std::optional<std::string_view> prune_hash(
     std::string_view& input) noexcept;
 
 /**

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -106,7 +106,7 @@ size_t url::get_pathname_length() const noexcept { return path.size(); }
     }
   }
 
-  if (fragment.has_value()) {
+  if (hash.has_value()) {
     out.hash_start = uint32_t(running_index);
   }
 
@@ -117,8 +117,8 @@ inline void url::update_base_hostname(std::string_view input) { host = input; }
 
 inline void url::update_unencoded_base_hash(std::string_view input) {
   // We do the percent encoding
-  fragment = unicode::percent_encode(
-      input, ada::character_sets::FRAGMENT_PERCENT_ENCODE);
+  hash = unicode::percent_encode(input,
+                                 ada::character_sets::FRAGMENT_PERCENT_ENCODE);
 }
 
 inline void url::update_base_search(std::string_view input,
@@ -150,7 +150,7 @@ inline void url::clear_pathname() { path.clear(); }
 
 inline void url::clear_search() { query = std::nullopt; }
 
-inline bool url::has_hash() const { return fragment.has_value(); }
+inline bool url::has_hash() const { return hash.has_value(); }
 
 inline bool url::has_search() const { return query.has_value(); }
 
@@ -200,8 +200,8 @@ inline void url::copy_scheme(const ada::url &u) {
   if (query.has_value()) {
     output += "?" + query.value();
   }
-  if (fragment.has_value()) {
-    output += "#" + fragment.value();
+  if (hash.has_value()) {
+    output += "#" + hash.value();
   }
   return output;
 }

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -146,15 +146,13 @@ inline void url::update_base_port(std::optional<uint16_t> input) {
   port = input;
 }
 
-inline void url::clear_base_pathname() { path = ""; }
+inline void url::clear_pathname() { path.clear(); }
 
-inline void url::clear_base_search() { query = std::nullopt; }
+inline void url::clear_search() { query = std::nullopt; }
 
-inline bool url::base_fragment_has_value() const {
-  return fragment.has_value();
-}
+inline bool url::has_hash() const { return fragment.has_value(); }
 
-inline bool url::base_search_has_value() const { return query.has_value(); }
+inline bool url::has_search() const { return query.has_value(); }
 
 inline void url::set_protocol_as_file() { type = ada::scheme::type::FILE; }
 

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -89,7 +89,7 @@ struct url : url_base {
    * further processing on the resource the URL’s other components identify. It
    * is initially null.
    */
-  std::optional<std::string> fragment{};
+  std::optional<std::string> hash{};
 
   /** @private */
   inline void update_unencoded_base_hash(std::string_view input);

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -111,13 +111,13 @@ struct url : url_base {
   /** @private */
   inline void update_base_port(std::optional<uint16_t> input);
   /** @private */
-  inline void clear_base_pathname() override;
+  inline void clear_pathname() override;
   /** @private */
-  inline void clear_base_search() override;
+  inline void clear_search() override;
   /** @private */
-  inline bool base_fragment_has_value() const override;
+  inline bool has_hash() const override;
   /** @private */
-  inline bool base_search_has_value() const override;
+  inline bool has_search() const override;
   /** @private set this URL's type to file */
   inline void set_protocol_as_file();
   /** @return true if it has an host but it is the empty string */

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -174,7 +174,7 @@ inline void url_aggregator::update_base_search(std::string_view input) {
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   if (input.empty()) {
-    clear_base_search();
+    clear_search();
     return;
   }
 
@@ -412,9 +412,8 @@ inline void url_aggregator::append_base_username(const std::string_view input) {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void url_aggregator::clear_base_password() {
-  ada_log("url_aggregator::clear_base_password ", to_string(), "\n",
-          to_diagram());
+inline void url_aggregator::clear_password() {
+  ada_log("url_aggregator::clear_password ", to_string(), "\n", to_diagram());
   ADA_ASSERT_TRUE(validate());
   if (!has_password()) {
     return;
@@ -442,7 +441,7 @@ inline void url_aggregator::update_base_password(const std::string_view input) {
 
   // TODO: Optimization opportunity. Merge the following removal functions.
   if (input.empty()) {
-    clear_base_password();
+    clear_password();
 
     // Remove username too, if it is empty.
     if (!has_non_empty_username()) {
@@ -543,7 +542,7 @@ inline void url_aggregator::update_base_port(uint32_t input) {
   ada_log("url_aggregator::update_base_port");
   ADA_ASSERT_TRUE(validate());
   if (input == url_components::omitted) {
-    clear_base_port();
+    clear_port();
     return;
   }
   // calling std::to_string(input.value()) is unfortunate given that the port
@@ -569,8 +568,8 @@ inline void url_aggregator::update_base_port(uint32_t input) {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void url_aggregator::clear_base_port() {
-  ada_log("url_aggregator::clear_base_port");
+inline void url_aggregator::clear_port() {
+  ada_log("url_aggregator::clear_port");
   ADA_ASSERT_TRUE(validate());
   if (components.port == url_components::omitted) {
     return;
@@ -593,8 +592,8 @@ inline uint32_t url_aggregator::retrieve_base_port() const {
   return components.port;
 }
 
-inline void url_aggregator::clear_base_search() {
-  ada_log("url_aggregator::clear_base_search");
+inline void url_aggregator::clear_search() {
+  ada_log("url_aggregator::clear_search");
   ADA_ASSERT_TRUE(validate());
   if (components.search_start == url_components::omitted) {
     return;
@@ -618,8 +617,8 @@ inline void url_aggregator::clear_base_search() {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void url_aggregator::clear_base_hash() {
-  ada_log("url_aggregator::clear_base_hash");
+inline void url_aggregator::clear_hash() {
+  ada_log("url_aggregator::clear_hash");
   ADA_ASSERT_TRUE(validate());
   if (components.hash_start == url_components::omitted) {
     return;
@@ -635,8 +634,8 @@ inline void url_aggregator::clear_base_hash() {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void url_aggregator::clear_base_pathname() {
-  ada_log("url_aggregator::clear_base_pathname");
+inline void url_aggregator::clear_pathname() {
+  ada_log("url_aggregator::clear_pathname");
   ADA_ASSERT_TRUE(validate());
   uint32_t ending_index = uint32_t(buffer.size());
   if (components.search_start != url_components::omitted) {
@@ -660,19 +659,18 @@ inline void url_aggregator::clear_base_pathname() {
   if (components.hash_start != url_components::omitted) {
     components.hash_start -= difference;
   }
-  ada_log("url_aggregator::clear_base_pathname completed, running checks...");
+  ada_log("url_aggregator::clear_pathname completed, running checks...");
 #if ADA_DEVELOPMENT_CHECKS
   ADA_ASSERT_EQUAL(get_pathname(), "",
                    "pathname should have been cleared on buffer=" + buffer +
                        " with " + components.to_string() + "\n" + to_diagram());
 #endif
   ADA_ASSERT_TRUE(validate());
-  ada_log(
-      "url_aggregator::clear_base_pathname completed, running checks... ok");
+  ada_log("url_aggregator::clear_pathname completed, running checks... ok");
 }
 
-inline void url_aggregator::clear_base_hostname() {
-  ada_log("url_aggregator::clear_base_hostname");
+inline void url_aggregator::clear_hostname() {
+  ada_log("url_aggregator::clear_hostname");
   ADA_ASSERT_TRUE(validate());
   if (!has_authority()) {
     return;
@@ -706,13 +704,13 @@ inline void url_aggregator::clear_base_hostname() {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline bool url_aggregator::base_fragment_has_value() const {
-  ada_log("url_aggregator::base_fragment_has_value");
+inline bool url_aggregator::has_hash() const {
+  ada_log("url_aggregator::has_hash");
   return components.hash_start != url_components::omitted;
 }
 
-inline bool url_aggregator::base_search_has_value() const {
-  ada_log("url_aggregator::base_search_has_value");
+inline bool url_aggregator::has_search() const {
+  ada_log("url_aggregator::has_search");
   return components.search_start != url_components::omitted;
 }
 
@@ -859,7 +857,7 @@ ada_really_inline size_t url_aggregator::parse_port(
     if (r.ec == std::errc() && scheme_default_port() != parsed_port) {
       update_base_port(parsed_port);
     } else {
-      clear_base_port();
+      clear_port();
     }
   }
   return consumed;

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -202,22 +202,22 @@ struct url_aggregator : url_base {
   /** @private */
   inline uint32_t retrieve_base_port() const;
   /** @private */
-  inline void clear_base_port();
+  inline void clear_port();
   /** @private if there is no hostname, then this function does nothing, if
    * there is, we make it empty */
-  inline void clear_base_hostname();
+  inline void clear_hostname();
   /** @private */
-  inline void clear_base_hash();
+  inline void clear_hash();
   /** @private */
-  inline void clear_base_pathname() override;
+  inline void clear_pathname() override;
   /** @private */
-  inline void clear_base_search() override;
+  inline void clear_search() override;
   /** @private */
-  inline void clear_base_password();
+  inline void clear_password();
   /** @private */
-  inline bool base_fragment_has_value() const override;
+  inline bool has_hash() const override;
   /** @private */
-  inline bool base_search_has_value() const override;
+  inline bool has_search() const override;
   /** @private */
   inline bool has_dash_dot() const noexcept;
   /** @private */

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -96,16 +96,16 @@ struct url_base {
   virtual std::string to_string() const = 0;
 
   /** @private */
-  virtual inline void clear_base_pathname() = 0;
+  virtual inline void clear_pathname() = 0;
 
   /** @private */
-  virtual inline void clear_base_search() = 0;
+  virtual inline void clear_search() = 0;
 
   /** @private */
-  virtual inline bool base_fragment_has_value() const = 0;
+  virtual inline bool has_hash() const = 0;
 
   /** @private */
-  virtual inline bool base_search_has_value() const = 0;
+  virtual inline bool has_search() const = 0;
 
 };  // url_base
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -581,8 +581,8 @@ ada_really_inline void strip_trailing_spaces_from_opaque_path(
     url_type& url) noexcept {
   ada_log("helpers::strip_trailing_spaces_from_opaque_path");
   if (!url.has_opaque_path) return;
-  if (url.base_fragment_has_value()) return;
-  if (url.base_search_has_value()) return;
+  if (url.has_hash()) return;
+  if (url.has_search()) return;
 
   auto path = std::string(url.get_pathname());
   while (!path.empty() && path.back() == ' ') {

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -84,7 +84,7 @@ ada_unused std::string get_state(ada::state s) {
   }
 }
 
-ada_really_inline std::optional<std::string_view> prune_fragment(
+ada_really_inline std::optional<std::string_view> prune_hash(
     std::string_view& input) noexcept {
   // compiles down to 20--30 instructions including a class to memchr (C
   // function). this function should be quite fast.
@@ -92,10 +92,10 @@ ada_really_inline std::optional<std::string_view> prune_fragment(
   if (location_of_first == std::string_view::npos) {
     return std::nullopt;
   }
-  std::string_view fragment = input;
-  fragment.remove_prefix(location_of_first + 1);
+  std::string_view hash = input;
+  hash.remove_prefix(location_of_first + 1);
   input.remove_suffix(input.size() - location_of_first);
-  return fragment;
+  return hash;
 }
 
 ada_really_inline bool shorten_path(std::string& path,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -442,7 +442,7 @@ result_type parse_url(std::string_view user_input,
           // Otherwise, if c is not the EOF code point:
           else if (input_position != input_size) {
             // Set url’s query to null.
-            url.clear_base_search();
+            url.clear_search();
             if constexpr (result_type_is_ada_url) {
               // Shorten url’s path.
               helpers::shorten_path(url.path, url.type);
@@ -857,7 +857,7 @@ result_type parse_url(std::string_view user_input,
           // Otherwise, if c is not the EOF code point:
           else if (input_position != input_size) {
             // Set url’s query to null.
-            url.clear_base_search();
+            url.clear_search();
 
             // If the code point substring from pointer to the end of input does
             // not start with a Windows drive letter, then shorten url’s path.
@@ -874,11 +874,7 @@ result_type parse_url(std::string_view user_input,
             // Otherwise:
             else {
               // Set url’s path to an empty list.
-              if constexpr (result_type_is_ada_url) {
-                url.path.clear();
-              } else {
-                url.clear_base_pathname();
-              }
+              url.clear_pathname();
               url.has_opaque_path = true;
             }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -85,7 +85,7 @@ result_type parse_url(std::string_view user_input,
   helpers::trim_c0_whitespace(url_data);
 
   // Optimization opportunity. Most websites do not have fragment.
-  std::optional<std::string_view> fragment = helpers::prune_fragment(url_data);
+  std::optional<std::string_view> fragment = helpers::prune_hash(url_data);
   // We add it last so that an implementation like ada::url_aggregator
   // can append it last to its internal buffer, thus improving performance.
 

--- a/src/url-getters.cpp
+++ b/src/url-getters.cpp
@@ -85,9 +85,8 @@ namespace ada {
 [[nodiscard]] std::string url::get_hash() const noexcept {
   // If this’s URL’s fragment is either null or the empty string, then return
   // the empty string. Return U+0023 (#), followed by this’s URL’s fragment.
-  return (!fragment.has_value() || (fragment.value().empty()))
-             ? ""
-             : "#" + fragment.value();
+  return (!hash.has_value() || (hash.value().empty())) ? ""
+                                                       : "#" + hash.value();
 }
 
 }  // namespace ada

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -150,7 +150,7 @@ bool url::set_port(const std::string_view input) {
 
 void url::set_hash(const std::string_view input) {
   if (input.empty()) {
-    fragment = std::nullopt;
+    hash = std::nullopt;
     helpers::strip_trailing_spaces_from_opaque_path(*this);
     return;
   }
@@ -158,8 +158,8 @@ void url::set_hash(const std::string_view input) {
   std::string new_value;
   new_value = input[0] == '#' ? input.substr(1) : input;
   helpers::remove_ascii_tab_or_newline(new_value);
-  fragment = unicode::percent_encode(
-      new_value, ada::character_sets::FRAGMENT_PERCENT_ENCODE);
+  hash = unicode::percent_encode(new_value,
+                                 ada::character_sets::FRAGMENT_PERCENT_ENCODE);
   return;
 }
 
@@ -225,7 +225,7 @@ bool url::set_href(const std::string_view input) {
     port = out->port;
     path = out->path;
     query = out->query;
-    fragment = out->fragment;
+    hash = out->hash;
     type = out->type;
     non_special_scheme = out->non_special_scheme;
     has_opaque_path = out->has_opaque_path;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -562,7 +562,7 @@ std::string url::to_string() const {
   answer.append("\",\n");
   answer.append("\t\"opaque path\":");
   answer.append((has_opaque_path ? "true" : "false"));
-  if (base_search_has_value()) {
+  if (has_search()) {
     answer.append(",\n");
     answer.append("\t\"query\":\"");
     helpers::encode_json(query.value(), back);

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -568,10 +568,10 @@ std::string url::to_string() const {
     helpers::encode_json(query.value(), back);
     answer.append("\"");
   }
-  if (fragment.has_value()) {
+  if (hash.has_value()) {
     answer.append(",\n");
-    answer.append("\t\"fragment\":\"");
-    helpers::encode_json(fragment.value(), back);
+    answer.append("\t\"hash\":\"");
+    helpers::encode_json(hash.value(), back);
     answer.append("\"");
   }
   answer.append("\n}");

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -62,7 +62,7 @@ template <bool has_state_override>
       // If url’s port is url’s scheme’s default port, then set url’s port to
       // null.
       if (components.port == urls_scheme_port) {
-        clear_base_port();
+        clear_port();
       }
     }
   } else {  // slow path
@@ -105,7 +105,7 @@ template <bool has_state_override>
       // If url’s port is url’s scheme’s default port, then set url’s port to
       // null.
       if (components.port == urls_scheme_port) {
-        clear_base_port();
+        clear_port();
       }
     }
   }
@@ -286,7 +286,7 @@ bool url_aggregator::set_port(const std::string_view input) {
   std::string trimmed(input);
   helpers::remove_ascii_tab_or_newline(trimmed);
   if (trimmed.empty()) {
-    clear_base_port();
+    clear_port();
     return true;
   }
   // Input should not start with control characters.
@@ -317,7 +317,7 @@ bool url_aggregator::set_pathname(const std::string_view input) {
   if (has_opaque_path) {
     return false;
   }
-  clear_base_pathname();
+  clear_pathname();
   parse_path(input);
   if (checkers::begins_with(input, "//") && !has_authority() &&
       !has_dash_dot()) {
@@ -374,7 +374,7 @@ void url_aggregator::set_search(const std::string_view input) {
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   if (input.empty()) {
-    clear_base_search();
+    clear_search();
     helpers::strip_trailing_spaces_from_opaque_path(*this);
     return;
   }
@@ -578,7 +578,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // Let host be the result of host parsing host_view with url is not special.
     if (host_view.empty()) {
       if (has_hostname()) {
-        clear_base_hostname();  // easy!
+        clear_hostname();  // easy!
       } else if (has_dash_dot()) {
         add_authority_slashes_if_needed();
         delete_dash_dot();
@@ -604,7 +604,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
 
   if (new_host.empty()) {
     // Set url’s host to the empty string.
-    clear_base_hostname();
+    clear_hostname();
   } else {
     // Let host be the result of host parsing buffer with url is not special.
     if (!parse_host(new_host)) {
@@ -616,7 +616,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // If host is "localhost", then set host to the empty string.
     if (helpers::substring(buffer, components.host_start,
                            components.host_end) == "localhost") {
-      clear_base_hostname();
+      clear_hostname();
     }
   }
   ADA_ASSERT_TRUE(validate());

--- a/tests/url_components.cpp
+++ b/tests/url_components.cpp
@@ -165,7 +165,7 @@ bool urltestdata_encoding(const char* source) {
                       "port should have been omitted " + out.to_string());
         }
 
-        if (url.get_pathname_length() > 0) {
+        if (!url.get_pathname().empty()) {
           size_t pathname_end = std::string::npos;
           if (out.search_start != ada::url_components::omitted) {
             pathname_end = out.search_start;
@@ -179,12 +179,12 @@ bool urltestdata_encoding(const char* source) {
               "pathname mismatch " + out.to_string() + " " + url.get_href());
         }
 
-        if (url.get_search().length() > 0) {
+        if (!url.get_search().empty()) {
           TEST_ASSERT(href.substr(out.search_start, url.get_search().size()),
                       url.get_search(), "search mismatch " + out.to_string());
         }
 
-        if (url.get_hash().length() > 0) {
+        if (!url.get_hash().empty()) {
           TEST_ASSERT(href.substr(out.hash_start, url.get_hash().size()),
                       url.get_hash(), "hash mismatch " + out.to_string());  //}
         }

--- a/tests/url_components.cpp
+++ b/tests/url_components.cpp
@@ -184,7 +184,7 @@ bool urltestdata_encoding(const char* source) {
                       url.get_search(), "search mismatch " + out.to_string());
         }
 
-        if (url.fragment.has_value()) {
+        if (url.get_hash().length() > 0) {
           TEST_ASSERT(href.substr(out.hash_start, url.get_hash().size()),
                       url.get_hash(), "hash mismatch " + out.to_string());  //}
         }


### PR DESCRIPTION
Fixes https://github.com/ada-url/ada/issues/322

Contains a breaking change where `fragment` is renamed to `hash`. We were using `fragment` in `ada::url` but `hash` in `url::aggregator`, even though the functions to set it was `set_hash`.