### PR TITLE
Demonstration on how to move the private methods to 'private' status.

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -6,7 +6,6 @@
 #define ADA_HELPERS_H
 
 #include "ada/common_defs.h"
-#include "ada/url.h"
 #include "ada/state.h"
 #include "ada/url_base.h"
 

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -15,7 +15,7 @@
 namespace ada {
 struct url_aggregator;
 struct url;
-}
+}  // namespace ada
 /**
  * @namespace ada::parser
  * @brief Includes the definitions for supported parsers

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -6,14 +6,16 @@
 #define ADA_PARSER_H
 
 #include "ada/state.h"
-#include "ada/url.h"
 #include "ada/encoding_type.h"
 #include "ada/expected.h"
-#include "ada/url_aggregator.h"
 
 #include <optional>
 #include <string_view>
 
+namespace ada {
+struct url_aggregator;
+struct url;
+}
 /**
  * @namespace ada::parser
  * @brief Includes the definitions for supported parsers

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -14,6 +14,7 @@
 #include "ada/url_base.h"
 #include "ada/url_components.h"
 #include "ada/parser.h"
+#include "ada/helpers.h"
 
 #include <algorithm>
 #include <charconv>
@@ -249,7 +250,6 @@ struct url : url_base {
    */
   [[nodiscard]] ada_really_inline bool includes_credentials() const noexcept;
 
-
   /**
    * Useful for implementing efficient serialization for the URL.
    *
@@ -275,8 +275,10 @@ struct url : url_base {
       const noexcept;
 
  private:
-   friend ada::url ada::parser::parse_url<ada::url>(std::string_view, const ada::url*);
-
+  friend ada::url ada::parser::parse_url<ada::url>(std::string_view,
+                                                   const ada::url *);
+  friend void ada::helpers::strip_trailing_spaces_from_opaque_path<ada::url>(
+      ada::url &url) noexcept;
   /**
    * @private
    * A URL’s username is an ASCII string identifying a username. It is initially

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -293,7 +293,8 @@ struct url_aggregator : url_base {
              bool check_trailing_content = false) noexcept override;
 
  private:
-  friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(std::string_view, const ada::url_aggregator*);
+  friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(
+      std::string_view, const ada::url_aggregator *);
   /**
    * @private
    * To optimize performance, you may indicate how much memory to allocate

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -8,12 +8,12 @@
 #include "ada/common_defs.h"
 #include "ada/url_base.h"
 #include "ada/url_components.h"
+#include "ada/parser.h"
 
 #include <string>
 #include <string_view>
 
 namespace ada {
-
 /**
  * @brief Lightweight URL struct.
  *
@@ -287,6 +287,13 @@ struct url_aggregator : url_base {
   /** @private */
   inline void add_authority_slashes_if_needed() noexcept;
 
+  /** @private */
+  ada_really_inline size_t
+  parse_port(std::string_view view,
+             bool check_trailing_content = false) noexcept override;
+
+ private:
+  friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(std::string_view, const ada::url_aggregator*);
   /**
    * @private
    * To optimize performance, you may indicate how much memory to allocate
@@ -294,12 +301,6 @@ struct url_aggregator : url_base {
    */
   inline void reserve(uint32_t capacity);
 
-  /** @private */
-  ada_really_inline size_t
-  parse_port(std::string_view view,
-             bool check_trailing_content = false) noexcept override;
-
- private:
   /** @private */
   std::string buffer{};
 


### PR DESCRIPTION
Currently we rely on comments to identify some methods as being private. The proper C++ way is to 'befriend' the functions that are allowed to access private methods. In our case, that function is parse_url. So we can just add a friend declaration.

This PR is just a demonstration and I am not planning to flush it out, in large part because it will introduce conflicts with what @anonrig is doing in other branches.

This is just a temporary PR for demonstration purposes.