### PR TITLE
adds friend declarations to ada::url and ada::url_aggregator

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -6,7 +6,6 @@
 #define ADA_HELPERS_H
 
 #include "ada/common_defs.h"
-#include "ada/url.h"
 #include "ada/state.h"
 #include "ada/url_base.h"
 

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -6,13 +6,19 @@
 #define ADA_PARSER_H
 
 #include "ada/state.h"
-#include "ada/url.h"
 #include "ada/encoding_type.h"
 #include "ada/expected.h"
-#include "ada/url_aggregator.h"
 
 #include <optional>
 #include <string_view>
+
+/**
+ * @private
+ */
+namespace ada {
+struct url_aggregator;
+struct url;
+}  // namespace ada
 
 /**
  * @namespace ada::parser

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -388,6 +388,10 @@ struct url : url_base {
       const noexcept;
 
  private:
+  friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(
+      std::string_view, const ada::url_aggregator *);
+  friend void ada::helpers::strip_trailing_spaces_from_opaque_path<ada::url>(
+      ada::url &url) noexcept;
   /**
    * @private
    *

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -300,6 +300,10 @@ struct url_aggregator : url_base {
              bool check_trailing_content = false) noexcept override;
 
  private:
+  friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(
+      std::string_view, const ada::url_aggregator *);
+  friend void ada::helpers::strip_trailing_spaces_from_opaque_path<
+      ada::url_aggregator>(ada::url_aggregator &url) noexcept;
   /** @private */
   std::string buffer{};
 


### PR DESCRIPTION
This would allow (later) the move of the 'private' methods to the private section of the classes.

I deliberately make this PR small and non-invasive to avoid conflicts with other PRs.

PR https://github.com/ada-url/ada/pull/336 demonstrates how to do it.