### PR TITLE
build: add missing import.cmake

### DIFF
--- a/.github/workflows/ubuntu-release.yml
+++ b/.github/workflows/ubuntu-release.yml
@@ -1,0 +1,28 @@
+name: Ubuntu 22.04 (Release build)
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu-release-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        cxx: [g++-12, clang++-14]
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - name: Setup Ninja
+        run: sudo apt-get install ninja-build
+      - name: Prepare
+        run: cmake -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -G Ninja -B build
+        env:
+          CXX: ${{matrix.cxx}}
+      - name: Build
+        run: cmake --build build -j=2
+      - name: Test
+        run: ctest --output-on-failure --test-dir build

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(adaparse adaparse.cpp)
 target_link_libraries(adaparse PRIVATE ada)
 target_include_directories(adaparse PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
+include(${PROJECT_SOURCE_DIR}/cmake/import.cmake)
 import_dependency(cxxopts jarro2783/cxxopts eb78730)
 add_dependency(cxxopts)
 target_link_libraries(adaparse PRIVATE cxxopts::cxxopts)


### PR DESCRIPTION
When `BUILD_TESTING` flag is disabled, build crashes at the moment. This is due to the missing `import.cmake` statement inside `tools` folder. 

An example error from the homebrew pull request:

Ref: https://github.com/Homebrew/homebrew-core/actions/runs/4737212538/jobs/8409814274?pr=128710

Logs

```
==> cmake -B build -DCMAKE_INSTALL_PREFIX=/opt/homebrew/Cellar/ada/2.1.0 -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev -DBUILD_TESTING=OFF -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/homebrew/Library/Homebrew/shims/mac/super/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/homebrew/Library/Homebrew/shims/mac/super/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Code formatting is not enabled.
-- Compiler ID : AppleClang
-- CMAKE_BUILD_TYPE : Release
-- Assuming GCC-like compiler.
-- Found Python3: /opt/homebrew/bin/python3.11 (found version "3.11.3") found components: Interpreter 
-- Python found, we are going to amalgamate.py.
CMake Error at tools/CMakeLists.txt:5 (import_dependency):
  Unknown CMake command "import_dependency".
```