### PR TITLE
fix: look for ICU.

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -48,6 +48,39 @@ target_link_libraries(percent_encode PRIVATE benchmark::benchmark)
 
 option(ADA_COMPETITION "Whether to install various competitors." OFF)
 
+# We only build url_whatwg if ICU is found, so we need to make
+# finding ICU easy.
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  message(STATUS "Apple system detected.")
+  # People who run macOS often use brew.
+  if(EXISTS /opt/homebrew/opt/icu4c)
+    message(STATUS "icu is provided by homebrew at /opt/homebrew/opt/icu4c.")
+    ## This is a bit awkward, but it is a lot better than asking the
+    ## user to figure that out.
+    list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/icu4c/include")
+    list(APPEND CMAKE_LIBRARY_PATH "/opt/homebrew/opt/icu4c/lib")
+  elseif(EXISTS /usr/local/opt/icu4c)
+    message(STATUS "icu is provided by homebrew at /usr/local/opt/icu4c.")
+    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/icu4c/include")
+    list(APPEND CMAKE_LIBRARY_PATH "/usr/local/opt/icu4c/lib")
+  endif()
+endif()
+
+find_package(ICU COMPONENTS uc i18n)
+### If the user does not have ICU, let us help them with instructions:
+if(NOT ICU_FOUND)
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      if(EXISTS /opt/homebrew)
+        message(STATUS "Under macOS, you may install ICU with brew, using 'brew install icu4c'.")
+      else()
+        message(STATUS "Under macOS, you should install brew (see https://brew.sh) and then icu4c ('brew install icu4c').")
+      endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      message(STATUS "Under Linux, you may be able to install ICU with a command such as 'apt-get install libicu-dev'." )
+  endif()
+endif(NOT ICU_FOUND)
+
 if(ICU_FOUND)
     set_off(URL_BUILD_TESTS)
     set_off(URL_USE_LIBS)


### PR DESCRIPTION
At least one competitor requires ICU. If we don't look for ICU, this competitor never gets built and so it never gets benchmarked.