### PR TITLE
fix: ubsan signed overflow violations

### DIFF
--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -2632,7 +2632,9 @@ uint32_t find_range_index(uint32_t key) {
 }
 
 bool ascii_has_upper_case(char* input, size_t length) {
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   uint64_t broadcast_80 = broadcast(0x80);
   uint64_t broadcast_Ap = broadcast(128 - 'A');
   uint64_t broadcast_Zp = broadcast(128 - 'Z' - 1);
@@ -2654,7 +2656,9 @@ bool ascii_has_upper_case(char* input, size_t length) {
 }
 
 void ascii_map(char* input, size_t length) {
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   uint64_t broadcast_80 = broadcast(0x80);
   uint64_t broadcast_Ap = broadcast(128 - 'A');
   uint64_t broadcast_Zp = broadcast(128 - 'Z' - 1);

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -210,7 +210,9 @@ ada_really_inline size_t find_next_host_delimiter_special(
   auto index_of_first_set_byte = [](uint64_t v) {
     return ((((v - 1) & 0x101010101010101) * 0x101010101010101) >> 56) - 1;
   };
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   size_t i = location;
   uint64_t mask1 = broadcast(':');
   uint64_t mask2 = broadcast('/');
@@ -273,7 +275,9 @@ ada_really_inline size_t find_next_host_delimiter(std::string_view view,
   auto index_of_first_set_byte = [](uint64_t v) {
     return ((((v - 1) & 0x101010101010101) * 0x101010101010101) >> 56) - 1;
   };
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   size_t i = location;
   uint64_t mask1 = broadcast(':');
   uint64_t mask2 = broadcast('/');
@@ -599,7 +603,9 @@ find_authority_delimiter_special(std::string_view view) noexcept {
   auto index_of_first_set_byte = [](uint64_t v) {
     return ((((v - 1) & 0x101010101010101) * 0x101010101010101) >> 56) - 1;
   };
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   size_t i = 0;
   uint64_t mask1 = broadcast('@');
   uint64_t mask2 = broadcast('/');
@@ -647,7 +653,9 @@ find_authority_delimiter(std::string_view view) noexcept {
   auto index_of_first_set_byte = [](uint64_t v) {
     return ((((v - 1) & 0x101010101010101) * 0x101010101010101) >> 56) - 1;
   };
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   size_t i = 0;
   uint64_t mask1 = broadcast('@');
   uint64_t mask2 = broadcast('/');

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -12,7 +12,9 @@ ADA_POP_DISABLE_WARNINGS
 namespace ada::unicode {
 
 constexpr bool to_lower_ascii(char* input, size_t length) noexcept {
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   uint64_t broadcast_80 = broadcast(0x80);
   uint64_t broadcast_Ap = broadcast(128 - 'A');
   uint64_t broadcast_Zp = broadcast(128 - 'Z' - 1);
@@ -43,7 +45,9 @@ ada_really_inline constexpr bool has_tabs_or_newline(
   auto has_zero_byte = [](uint64_t v) {
     return ((v - 0x0101010101010101) & ~(v)&0x8080808080808080);
   };
-  auto broadcast = [](uint8_t v) -> uint64_t { return 0x101010101010101 * v; };
+  auto broadcast = [](uint8_t v) -> uint64_t {
+    return 0x101010101010101ull * v;
+  };
   size_t i = 0;
   uint64_t mask1 = broadcast('\r');
   uint64_t mask2 = broadcast('\n');


### PR DESCRIPTION
In these instances, the uint8_t inputs multiplied with the literal, which is a signed long, will make a signed long. For certain inputs, this will overflow, despite the return type being unsigned. Fix by making it always unsigned in the first place.

I found this because a user in my distribution (which builds all prod packages with a subset of ubsan by default) reported crashes newly introduced in newest nodejs, which apparently brings ada as a dependency. While the branch used by nodejs appears to be different, just putting this here anyway.