### PR TITLE
fix: better guard empty string inputs

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -36,10 +36,8 @@ result_type parse_url(std::string_view user_input,
 
   // We refuse to parse URL strings that exceed 4GB. Such strings are almost
   // surely the result of a bug or are otherwise a security concern.
-  // An empty URL is not a valid URL.
   if (user_input.size() >=
-          std::string_view::size_type(std::numeric_limits<uint32_t>::max) ||
-      user_input.size() == 0) {
+      std::string_view::size_type(std::numeric_limits<uint32_t>::max)) {
     url.is_valid = false;
   }
   // Going forward, user_input.size() is in [1,
@@ -61,10 +59,11 @@ result_type parse_url(std::string_view user_input,
     // it may not matter, but in other instances, it could.
     ////
     // This rounds up to the next power of two.
-    // We know that user_input.size() is in [1,
+    // We know that user_input.size() is in [0,
     // std::numeric_limits<uint32_t>::max).
     uint32_t reserve_capacity =
-        (0xFFFFFFFF >> helpers::leading_zeroes(uint32_t(user_input.size()))) +
+        (0xFFFFFFFF >>
+         helpers::leading_zeroes(uint32_t(1 | user_input.size()))) +
         1;
     url.reserve(reserve_capacity);
     //

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -36,13 +36,15 @@ result_type parse_url(std::string_view user_input,
 
   // We refuse to parse URL strings that exceed 4GB. Such strings are almost
   // surely the result of a bug or are otherwise a security concern.
+  // An empty URL is not a valid URL.
   if (user_input.size() >=
-      std::string_view::size_type(std::numeric_limits<uint32_t>::max)) {
+          std::string_view::size_type(std::numeric_limits<uint32_t>::max) ||
+      user_input.size() == 0) {
     url.is_valid = false;
   }
-
-  // If we are provided with an invalid base, or the optional_url was invalid,
-  // we must return.
+  // Going forward, user_input.size() is in [1,
+  // std::numeric_limits<uint32_t>::max). If we are provided with an invalid
+  // base, or the optional_url was invalid, we must return.
   if (base_url != nullptr) {
     url.is_valid &= base_url->is_valid;
   }
@@ -59,6 +61,8 @@ result_type parse_url(std::string_view user_input,
     // it may not matter, but in other instances, it could.
     ////
     // This rounds up to the next power of two.
+    // We know that user_input.size() is in [1,
+    // std::numeric_limits<uint32_t>::max).
     uint32_t reserve_capacity =
         (0xFFFFFFFF >> helpers::leading_zeroes(uint32_t(user_input.size()))) +
         1;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -40,7 +40,7 @@ result_type parse_url(std::string_view user_input,
       std::string_view::size_type(std::numeric_limits<uint32_t>::max)) {
     url.is_valid = false;
   }
-  // Going forward, user_input.size() is in [1,
+  // Going forward, user_input.size() is in [0,
   // std::numeric_limits<uint32_t>::max). If we are provided with an invalid
   // base, or the optional_url was invalid, we must return.
   if (base_url != nullptr) {

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -16,6 +16,12 @@ TYPED_TEST(basic_tests, set_host_should_return_false_sometimes) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, empty_url_should_return_false) {
+  auto r = ada::parse<TypeParam>("");
+  ASSERT_FALSE(r);
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, set_host_should_return_true_sometimes) {
   auto r = ada::parse<TypeParam>("https://www.google.com");
   ASSERT_TRUE(r->set_host("something"));


### PR DESCRIPTION
We potentially reserve string capacity based on the string input size. When the string is empty, there was a potential for us to reserve an undefined amount of memory. This did not happen on current systems but could theoretically happen.

The simple fix is to OR the string size with '1' so that the string size is at least 1, always, and never zero.