### PR TITLE
Doc our perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gantt
     dateFormat  X
     axisFormat %s
 
-    section ada (url-aggregator)
+    section ada
     188   : 0, 188
     section servo url
     664   : 0, 664

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ across a wide range of platforms (e.g., Windows, Linux, macOS). It fully
 supports the relevant [Unicode Technical Standard](https://www.unicode.org/reports/tr46/#ToUnicode).
 
 
-Ada is fast. On a benchmark where we need to validate and normalize [thousands URLs found
+## Ada is fast. 
+
+On a benchmark where we need to validate and normalize [thousands URLs found
 on popular websites](https://github.com/ada-url/url-various-datasets/tree/main/top100), 
 we find that ada can be several times faster than popular competitors (system: Apple MacBook 2022
 with LLVM 14).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ The Ada library passes the full range of tests from the specification,
 across a wide range of platforms (e.g., Windows, Linux, macOS). It fully
 supports the relevant [Unicode Technical Standard](https://www.unicode.org/reports/tr46/#ToUnicode).
 
+
+Ada is fast. On a benchmark where we need to validate and normalize [thousands URLs found
+on popular websites](https://github.com/ada-url/url-various-datasets/tree/main/top100), 
+we find that ada can be several times faster than popular competitors (system: Apple MacBook 2022
+with LLVM 14).
+
+
+```mermaid
+gantt
+    title Processing time (ns/URL) on top100.txt
+    dateFormat  X
+    axisFormat %s
+
+    section ada (url-aggregator)
+    188   : 0, 188
+    section servo url
+    664   : 0, 664
+    section CURL
+    1471   : 0, 1471
+```
+
 ## Requirements
 
 - A recent C++ compiler supporting C++17. We test GCC 9 or better, LLVM 10 or better and Microsoft Visual Studio 2022.

--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -85,14 +85,9 @@ static void BasicBench_AdaURL(benchmark::State& state) {
 
 auto BasicBench_AdaURL_href = BasicBench_AdaURL<PARSE_AND_HREF, ada::url>;
 BENCHMARK(BasicBench_AdaURL_href);
-auto BasicBench_AdaURL_just_parse = BasicBench_AdaURL<JUST_PARSE, ada::url>;
-BENCHMARK(BasicBench_AdaURL_just_parse);
 auto BasicBench_AdaURL_aggregator_href =
     BasicBench_AdaURL<PARSE_AND_HREF, ada::url_aggregator>;
 BENCHMARK(BasicBench_AdaURL_aggregator_href);
-auto BasicBench_AdaURL_aggregator_just_parse =
-    BasicBench_AdaURL<JUST_PARSE, ada::url_aggregator>;
-BENCHMARK(BasicBench_AdaURL_aggregator_just_parse);
 
 #if ADA_url_whatwg_ENABLED
 size_t count_whatwg_invalid() {


### PR DESCRIPTION
Mostly, this PR removes two useless benchmarks, and it adds a short new section to the README to say that ada is fast.