### PR TITLE
fix bug with get_host() and get_hostname() when there is no host

### DIFF
--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -702,8 +702,11 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 [[nodiscard]] std::string_view url_aggregator::get_host() const noexcept {
   ada_log("url_aggregator::get_host");
+  // Technically, we should check if there is a hostname, but
+  // the code below works even if there isn't.
+  // if(!has_hostname()) { return ""; }
   size_t start = components.host_start;
-  if (buffer.size() > components.host_start &&
+  if (components.host_end > components.host_start &&
       buffer[components.host_start] == '@') {
     start++;
   }
@@ -717,9 +720,12 @@ bool url_aggregator::set_hostname(const std::string_view input) {
 
 [[nodiscard]] std::string_view url_aggregator::get_hostname() const noexcept {
   ada_log("url_aggregator::get_hostname");
+  // Technically, we should check if there is a hostname, but
+  // the code below works even if there isn't.
+  // if(!has_hostname()) { return ""; }
   size_t start = components.host_start;
   // So host_start is not where the host begins.
-  if (buffer.size() > components.host_start &&
+  if (components.host_end > components.host_start &&
       buffer[components.host_start] == '@') {
     start++;
   }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -8,6 +8,18 @@ template <class T>
 struct basic_tests : testing::Test {};
 TYPED_TEST_SUITE(basic_tests, Types);
 
+TYPED_TEST(basic_tests, insane_url) {
+  auto r = ada::parse<ada::url_aggregator>("e:@EEEEEEEEEE");
+  ASSERT_TRUE(r);
+  ASSERT_EQ(r->get_protocol(), "e:");
+  ASSERT_EQ(r->get_username(), "");
+  ASSERT_EQ(r->get_password(), "");
+  ASSERT_EQ(r->get_hostname(), "");
+  ASSERT_EQ(r->get_port(), "");
+  ASSERT_EQ(r->get_pathname(), "@EEEEEEEEEE");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, set_host_should_return_false_sometimes) {
   auto r = ada::parse<TypeParam>("mailto:a@b.com");
   ASSERT_FALSE(r->set_host("something"));


### PR DESCRIPTION
This fixes a bug whereas get_host() and get_hostname() get in trouble… when there is no host and they try to nevertheless compute one. We get a string_view with a negative size.:wq