### PR TITLE
fix: update release script to consider only PRs with base.ref "main"

### DIFF
--- a/tools/release/lib/release.py
+++ b/tools/release/lib/release.py
@@ -13,7 +13,7 @@ def is_valid_tag(tag: str) -> bool:
 
 
 def create_release(
-    repository: Repository, tag: str, notes: str
+        repository: Repository, tag: str, notes: str
 ) -> Union[None, Type[Exception]]:
     if not is_valid_tag(tag):
         raise Exception(f"Invalid tag: {tag}")
@@ -29,9 +29,7 @@ def create_release(
         ) from exp
 
 
-def get_sorted_merged_pulls(
-    pulls: List[PullRequest], last_release: Optional[GitRelease]
-) -> List[PullRequest]:
+def get_sorted_merged_pulls(pulls: List[PullRequest], last_release: Optional[GitRelease]) -> List[PullRequest]:
     # Get merged pulls after last release
     if not last_release:
         return sorted(
@@ -39,6 +37,7 @@ def get_sorted_merged_pulls(
                 pull
                 for pull in pulls
                 if pull.merged
+                   and pull.base.ref == "main"
                    and not pull.title.startswith("chore: release")
                    and not pull.user.login.startswith("github-actions")
             ),
@@ -50,6 +49,7 @@ def get_sorted_merged_pulls(
             pull
             for pull in pulls
             if pull.merged
+               and pull.base.ref == "main"
                and (pull.merged_at > last_release.created_at)
                and not pull.title.startswith("chore: release")
                and not pull.user.login.startswith("github-actions")
@@ -73,7 +73,7 @@ def get_pr_contributors(pull_request: PullRequest) -> List[str]:
 
 
 def get_old_contributors(
-    pulls: List[PullRequest], last_release: Optional[GitRelease]
+        pulls: List[PullRequest], last_release: Optional[GitRelease]
 ) -> Set[str]:
     contributors = set()
     if last_release:
@@ -92,7 +92,7 @@ def get_old_contributors(
 
 
 def get_new_contributors(
-    old_contributors: List[str], merged_pulls: List[PullRequest]
+        old_contributors: List[str], merged_pulls: List[PullRequest]
 ) -> List[str]:
     new_contributors = set()
     for pull in merged_pulls:
@@ -125,9 +125,9 @@ def multiple_contributors_mention_md(contributors: List[str]) -> str:
         contrib_by = contrib_by[:-2]
         last_comma = contrib_by.rfind(", ")
         contrib_by = (
-            contrib_by[:last_comma].strip()
-            + " and "
-            + contrib_by[last_comma + 1:].strip()
+                contrib_by[:last_comma].strip()
+                + " and "
+                + contrib_by[last_comma + 1:].strip()
         )
     return contrib_by
 
@@ -146,7 +146,7 @@ def whats_changed_md(repo_full_name: str, merged_pulls: List[PullRequest]) -> Li
 
 
 def get_first_contribution(
-    merged_pulls: List[str], contributor: str
+        merged_pulls: List[str], contributor: str
 ) -> Optional[PullRequest]:
     for pull in merged_pulls:
         contrubutors = get_pr_contributors(pull)
@@ -158,7 +158,7 @@ def get_first_contribution(
 
 
 def new_contributors_md(
-    repo_full_name: str, merged_pulls: List[PullRequest], new_contributors: List[str]
+        repo_full_name: str, merged_pulls: List[PullRequest], new_contributors: List[str]
 ) -> List[str]:
     contributors_by_pr = {}
     contributors_md = []
@@ -186,7 +186,7 @@ def new_contributors_md(
 
 
 def full_changelog_md(
-    repository_name: str, last_tag_name: str, next_tag_name: str
+        repository_name: str, last_tag_name: str, next_tag_name: str
 ) -> Optional[str]:
     if not last_tag_name:
         return None

--- a/tools/release/lib/release.py
+++ b/tools/release/lib/release.py
@@ -13,7 +13,7 @@ def is_valid_tag(tag: str) -> bool:
 
 
 def create_release(
-        repository: Repository, tag: str, notes: str
+    repository: Repository, tag: str, notes: str
 ) -> Union[None, Type[Exception]]:
     if not is_valid_tag(tag):
         raise Exception(f"Invalid tag: {tag}")
@@ -29,7 +29,9 @@ def create_release(
         ) from exp
 
 
-def get_sorted_merged_pulls(pulls: List[PullRequest], last_release: Optional[GitRelease]) -> List[PullRequest]:
+def get_sorted_merged_pulls(
+    pulls: List[PullRequest], last_release: Optional[GitRelease]
+) -> List[PullRequest]:
     # Get merged pulls after last release
     if not last_release:
         return sorted(
@@ -37,9 +39,9 @@ def get_sorted_merged_pulls(pulls: List[PullRequest], last_release: Optional[Git
                 pull
                 for pull in pulls
                 if pull.merged
-                   and pull.base.ref == "main"
-                   and not pull.title.startswith("chore: release")
-                   and not pull.user.login.startswith("github-actions")
+                and pull.base.ref == "main"
+                and not pull.title.startswith("chore: release")
+                and not pull.user.login.startswith("github-actions")
             ),
             key=lambda pull: pull.merged_at,
         )
@@ -49,10 +51,10 @@ def get_sorted_merged_pulls(pulls: List[PullRequest], last_release: Optional[Git
             pull
             for pull in pulls
             if pull.merged
-               and pull.base.ref == "main"
-               and (pull.merged_at > last_release.created_at)
-               and not pull.title.startswith("chore: release")
-               and not pull.user.login.startswith("github-actions")
+            and pull.base.ref == "main"
+            and (pull.merged_at > last_release.created_at)
+            and not pull.title.startswith("chore: release")
+            and not pull.user.login.startswith("github-actions")
         ),
         key=lambda pull: pull.merged_at,
     )
@@ -73,7 +75,7 @@ def get_pr_contributors(pull_request: PullRequest) -> List[str]:
 
 
 def get_old_contributors(
-        pulls: List[PullRequest], last_release: Optional[GitRelease]
+    pulls: List[PullRequest], last_release: Optional[GitRelease]
 ) -> Set[str]:
     contributors = set()
     if last_release:
@@ -92,7 +94,7 @@ def get_old_contributors(
 
 
 def get_new_contributors(
-        old_contributors: List[str], merged_pulls: List[PullRequest]
+    old_contributors: List[str], merged_pulls: List[PullRequest]
 ) -> List[str]:
     new_contributors = set()
     for pull in merged_pulls:
@@ -125,9 +127,9 @@ def multiple_contributors_mention_md(contributors: List[str]) -> str:
         contrib_by = contrib_by[:-2]
         last_comma = contrib_by.rfind(", ")
         contrib_by = (
-                contrib_by[:last_comma].strip()
-                + " and "
-                + contrib_by[last_comma + 1:].strip()
+            contrib_by[:last_comma].strip()
+            + " and "
+            + contrib_by[last_comma + 1 :].strip()
         )
     return contrib_by
 
@@ -146,7 +148,7 @@ def whats_changed_md(repo_full_name: str, merged_pulls: List[PullRequest]) -> Li
 
 
 def get_first_contribution(
-        merged_pulls: List[str], contributor: str
+    merged_pulls: List[str], contributor: str
 ) -> Optional[PullRequest]:
     for pull in merged_pulls:
         contrubutors = get_pr_contributors(pull)
@@ -158,7 +160,7 @@ def get_first_contribution(
 
 
 def new_contributors_md(
-        repo_full_name: str, merged_pulls: List[PullRequest], new_contributors: List[str]
+    repo_full_name: str, merged_pulls: List[PullRequest], new_contributors: List[str]
 ) -> List[str]:
     contributors_by_pr = {}
     contributors_md = []
@@ -186,7 +188,7 @@ def new_contributors_md(
 
 
 def full_changelog_md(
-        repository_name: str, last_tag_name: str, next_tag_name: str
+    repository_name: str, last_tag_name: str, next_tag_name: str
 ) -> Optional[str]:
     if not last_tag_name:
         return None

--- a/tools/release/lib/tests/test_release.py
+++ b/tools/release/lib/tests/test_release.py
@@ -6,9 +6,10 @@ Release = namedtuple("Release", ["title", "created_at"])
 User = namedtuple("User", ["login"])
 Commit = namedtuple("Commit", ["author", "commit"])
 CommitMessage = namedtuple("CommitMessage", ["message"])
+PullRequestBase = namedtuple("PullRequestBase", "ref")
 PullRequestTuple = namedtuple(
     "PullRequest",
-    ["title", "number", "state", "merged", "merged_at", "user", "commits"],
+    ["title", "number", "state", "base", "merged", "merged_at", "user", "commits"],
 )
 
 
@@ -41,6 +42,7 @@ class RepoStub:
                         number=1,
                         state="open",
                         merged=False,
+                        base=PullRequestBase("main"),
                         merged_at=datetime(2023, 2, 2),
                         user=User("contributor_1"),
                         commits=[
@@ -68,6 +70,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 2, 1),
+                        base=PullRequestBase("main"),
                         user=User("contributor_2"),
                         commits=[
                             Commit(
@@ -106,6 +109,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 2, 2),
+                        base=PullRequestBase("main"),
                         user=User("contributor_3"),
                         commits=[
                             Commit(
@@ -132,6 +136,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 2, 3),
+                        base=PullRequestBase("main"),
                         user=User("contributor_4"),
                         commits=[
                             Commit(
@@ -158,6 +163,7 @@ class RepoStub:
                         state="closed",
                         merged=False,
                         merged_at=datetime(2023, 2, 4),
+                        base=PullRequestBase("main"),
                         user=User("contributor_3"),
                         commits=[
                             Commit(
@@ -184,6 +190,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 2, 5),
+                        base=PullRequestBase("main"),
                         user=User("contributor_2"),
                         commits=[
                             Commit(
@@ -210,6 +217,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 5, 2),
+                        base=PullRequestBase("main"),
                         user=User("new_contributor_2"),
                         commits=[
                             Commit(
@@ -242,6 +250,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 5, 5),
+                        base=PullRequestBase("main"),
                         user=User("contributor_3"),
                         commits=[
                             Commit(
@@ -274,6 +283,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 5, 1),
+                        base=PullRequestBase("main"),
                         user=User("new_contributor_1"),
                         commits=[
                             Commit(
@@ -312,6 +322,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 5, 10),
+                        base=PullRequestBase("another_branch"),
                         user=User("new_contributor_1"),
                         commits=[
                             Commit(
@@ -330,6 +341,7 @@ class RepoStub:
                         state="closed",
                         merged=True,
                         merged_at=datetime(2023, 5, 9),
+                        base=PullRequestBase("main"),
                         user=User("new_contributor_1"),
                         commits=[
                             Commit(
@@ -359,6 +371,7 @@ def test_get_sorted_merged_pulls():
             pull
             for pull in pulls
             if pull.merged
+               and pull.base.ref == "main"
                and not pull.title.startswith("chore: release")
                and not pull.user.login.startswith("github-actions")
         ],
@@ -428,7 +441,6 @@ def test_whats_changed_md():
         "* Feature 8 by @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 in https://github.com/ada-url/ada/pull/15",
         "* Feature 9 by @new_contributor_2 and @new_contributor_coauthor1 in https://github.com/ada-url/ada/pull/13",
         "* Feature 7 by @contributor_3 and @new_contributor_coauthor2 in https://github.com/ada-url/ada/pull/14",
-        "* Feature 11 by @new_contributor_1 in https://github.com/ada-url/ada/pull/16",
     ]
 
 
@@ -461,8 +473,8 @@ def test_full_changelog_md():
         repo_stub.full_name, last_tag.title, "v3.0.0"
     )
     assert (
-        full_changelog
-        == "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
+            full_changelog
+            == "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
     )
 
     full_changelog = release.full_changelog_md(repo_stub.full_name, None, "v3.0.0")
@@ -474,19 +486,18 @@ def test_contruct_release_notes():
 
     notes = release.contruct_release_notes(repo_stub, "v3.0.0")
     assert (
-        notes
-        == "## What's changed\n"
-        + "* Feature 8 by @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 in https://github.com/ada-url/ada/pull/15\n"
-        + "* Feature 9 by @new_contributor_2 and @new_contributor_coauthor1 in https://github.com/ada-url/ada/pull/13\n"
-        + "* Feature 7 by @contributor_3 and @new_contributor_coauthor2 in https://github.com/ada-url/ada/pull/14\n"
-        + "* Feature 11 by @new_contributor_1 in https://github.com/ada-url/ada/pull/16\n"
-        + "\n"
-        + "## New Contributors\n"
-        + "* @new_contributor_2 and @new_contributor_coauthor1 made their first contribution in https://github.com/ada-url/ada/pull/13\n"
-        + "* @new_contributor_coauthor2 made their first contribution in https://github.com/ada-url/ada/pull/14\n"
-        + "* @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 made their first contribution in https://github.com/ada-url/ada/pull/15\n"
-        + "\n"
-        + "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
+            notes
+            == "## What's changed\n"
+            + "* Feature 8 by @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 in https://github.com/ada-url/ada/pull/15\n"
+            + "* Feature 9 by @new_contributor_2 and @new_contributor_coauthor1 in https://github.com/ada-url/ada/pull/13\n"
+            + "* Feature 7 by @contributor_3 and @new_contributor_coauthor2 in https://github.com/ada-url/ada/pull/14\n"
+            + "\n"
+            + "## New Contributors\n"
+            + "* @new_contributor_2 and @new_contributor_coauthor1 made their first contribution in https://github.com/ada-url/ada/pull/13\n"
+            + "* @new_contributor_coauthor2 made their first contribution in https://github.com/ada-url/ada/pull/14\n"
+            + "* @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 made their first contribution in https://github.com/ada-url/ada/pull/15\n"
+            + "\n"
+            + "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
     )
 
 

--- a/tools/release/lib/tests/test_release.py
+++ b/tools/release/lib/tests/test_release.py
@@ -371,9 +371,9 @@ def test_get_sorted_merged_pulls():
             pull
             for pull in pulls
             if pull.merged
-               and pull.base.ref == "main"
-               and not pull.title.startswith("chore: release")
-               and not pull.user.login.startswith("github-actions")
+            and pull.base.ref == "main"
+            and not pull.title.startswith("chore: release")
+            and not pull.user.login.startswith("github-actions")
         ],
         key=lambda pull: pull.merged_at,
     )
@@ -473,8 +473,8 @@ def test_full_changelog_md():
         repo_stub.full_name, last_tag.title, "v3.0.0"
     )
     assert (
-            full_changelog
-            == "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
+        full_changelog
+        == "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
     )
 
     full_changelog = release.full_changelog_md(repo_stub.full_name, None, "v3.0.0")
@@ -486,18 +486,18 @@ def test_contruct_release_notes():
 
     notes = release.contruct_release_notes(repo_stub, "v3.0.0")
     assert (
-            notes
-            == "## What's changed\n"
-            + "* Feature 8 by @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 in https://github.com/ada-url/ada/pull/15\n"
-            + "* Feature 9 by @new_contributor_2 and @new_contributor_coauthor1 in https://github.com/ada-url/ada/pull/13\n"
-            + "* Feature 7 by @contributor_3 and @new_contributor_coauthor2 in https://github.com/ada-url/ada/pull/14\n"
-            + "\n"
-            + "## New Contributors\n"
-            + "* @new_contributor_2 and @new_contributor_coauthor1 made their first contribution in https://github.com/ada-url/ada/pull/13\n"
-            + "* @new_contributor_coauthor2 made their first contribution in https://github.com/ada-url/ada/pull/14\n"
-            + "* @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 made their first contribution in https://github.com/ada-url/ada/pull/15\n"
-            + "\n"
-            + "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
+        notes
+        == "## What's changed\n"
+        + "* Feature 8 by @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 in https://github.com/ada-url/ada/pull/15\n"
+        + "* Feature 9 by @new_contributor_2 and @new_contributor_coauthor1 in https://github.com/ada-url/ada/pull/13\n"
+        + "* Feature 7 by @contributor_3 and @new_contributor_coauthor2 in https://github.com/ada-url/ada/pull/14\n"
+        + "\n"
+        + "## New Contributors\n"
+        + "* @new_contributor_2 and @new_contributor_coauthor1 made their first contribution in https://github.com/ada-url/ada/pull/13\n"
+        + "* @new_contributor_coauthor2 made their first contribution in https://github.com/ada-url/ada/pull/14\n"
+        + "* @new_contributor_1, @new_contributor_coauthor3 and @new_contributor_coauthor4 made their first contribution in https://github.com/ada-url/ada/pull/15\n"
+        + "\n"
+        + "**Full Changelog**: https://github.com/ada-url/ada/compare/v1.0.3...v3.0.0"
     )
 
 


### PR DESCRIPTION
example:
"some fixes to the C API" in the releease [v2.4.0](https://github.com/ada-url/ada/releases/tag/v2.4.0) that merges [dlemire/fix_c](https://github.com/ada-url/ada/tree/dlemire/fix_c) into  [add-c-api](https://github.com/ada-url/ada/tree/add-c-api) (not merge into the main branch so shouldn't be listed directly in the release notes)