### PR TITLE
emscripten support

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Build
         run: cmake --build buildwasm
       - name: Test
-        run: node wasm.js
+        run: ctest --tests-dir buildwasm

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,0 +1,36 @@
+name: emscripten
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mymindstorm/setup-emsdk@v11
+      - name: Verify
+        run: emcc -v
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure
+        uses: emcmake  cmake -B buildwasm
+      - name: Build
+        uses: cmake --build buildwasm

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Build
         run: cmake --build buildwasm
       - name: Test
-        run: ctest --tests-dir buildwasm
+        run: ctest --test-dir buildwasm

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -25,12 +25,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
       - uses: mymindstorm/setup-emsdk@v12
       - name: Verify
         run: emcc -v
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Configure
         run: emcmake  cmake -B buildwasm
       - name: Build
         run: cmake --build buildwasm
+      - name: Test
+        run: node wasm.js

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -25,12 +25,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: mymindstorm/setup-emsdk@v11
+      - uses: mymindstorm/setup-emsdk@v12
       - name: Verify
         run: emcc -v
       - name: Checkout
         uses: actions/checkout@v2
       - name: Configure
-        uses: emcmake  cmake -B buildwasm
+        run: emcmake  cmake -B buildwasm
       - name: Build
-        uses: cmake --build buildwasm
+        run: cmake --build buildwasm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,8 @@ if(NOT EMSCRIPTEN)
     message(STATUS "Big-endian system detected.")
   endif()
 endif()
-
-file(WRITE wasm.js "
+if(EMSCRIPTEN)
+  file(WRITE wasm.js "
  const child_process = require('child_process');
  const assert = require('assert');
  const test = require('node:test');
@@ -95,6 +95,7 @@ file(WRITE wasm.js "
    assert.deepStrictEqual(JSON.parse(stdout), expected);
  });
 ")
+endif(EMSCRIPTEN)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,35 @@ if(NOT EMSCRIPTEN)
   endif()
 endif()
 
+file(WRITE wasm.js "
+ const child_process = require('child_process');
+ const assert = require('assert');
+ const test = require('node:test');
+
+ const expected = {
+   'buffer': 'https://google.com/?q=Yagiz#Nizipli',
+   'protocol': 'https:',
+   'host': 'google.com',
+   'path': '/',
+   'opaque path': false,
+   'query': '?q=Yagiz',
+   'fragment': '#Nizipli',
+   'protocol_end': 6,
+   'username_end': 8,
+   'host_start': 8,
+   'host_end': 18,
+   'port': null,
+   'pathname_start': 18,
+   'search_start': 19,
+   'hash_start': 27
+ };
+
+ test('wasm', () => {
+   const { stdout } = child_process.spawnSync(process.execPath, ['${CMAKE_CURRENT_BINARY_DIR}/tools/cli/adaparse.js', 'https://google.com/?q=Yagiz#Nizipli'])
+   assert.deepStrictEqual(JSON.parse(stdout), expected);
+ });
+")
+
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,14 +63,6 @@ set_target_properties(
   SOVERSION "${ADA_LIB_SOVERSION}"
   WINDOWS_EXPORT_ALL_SYMBOLS YES
 )
-if(NOT EMSCRIPTEN)
-  include (TestBigEndian)
-  TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
-  if(IS_BIG_ENDIAN)
-    message(STATUS "Big-endian system detected.")
-  endif()
-endif()
-
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ else(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
   endif()
 endif(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
 
+if (BUILD_TESTING AND EMSCRIPTEN)
+  add_subdirectory(tests-wasm)
+endif(BUILD_TESTING AND EMSCRIPTEN)
+
 add_library(ada::ada ALIAS ada)
 
 set_target_properties(
@@ -66,41 +70,12 @@ if(NOT EMSCRIPTEN)
     message(STATUS "Big-endian system detected.")
   endif()
 endif()
-if(EMSCRIPTEN)
-  file(WRITE wasm.js "
- const child_process = require('child_process');
- const assert = require('assert');
- const test = require('node:test');
 
- const expected = {
-   'buffer': 'https://google.com/?q=Yagiz#Nizipli',
-   'protocol': 'https:',
-   'host': 'google.com',
-   'path': '/',
-   'opaque path': false,
-   'query': '?q=Yagiz',
-   'fragment': '#Nizipli',
-   'protocol_end': 6,
-   'username_end': 8,
-   'host_start': 8,
-   'host_end': 18,
-   'port': null,
-   'pathname_start': 18,
-   'search_start': 19,
-   'hash_start': 27
- };
-
- test('wasm', () => {
-   const { stdout } = child_process.spawnSync(process.execPath, ['${CMAKE_CURRENT_BINARY_DIR}/tools/cli/adaparse.js', 'https://google.com/?q=Yagiz#Nizipli'])
-   assert.deepStrictEqual(JSON.parse(stdout), expected);
- });
-")
-endif(EMSCRIPTEN)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
-if(NOT ADA_COVERAGE)
+if(NOT ADA_COVERAGE AND NOT EMSCRIPTEN)
   add_subdirectory(singleheader)
   add_subdirectory(tools)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,23 +33,23 @@ if((BUILD_TESTING OR ADA_BENCHMARKS) AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
   add_dependency(gtest)
 endif()
 
-if (BUILD_TESTING)
+if (BUILD_TESTING AND NOT EMSCRIPTEN)
   message(STATUS "The tests are enabled.")
   add_subdirectory(tests)
 else()
   if(is_top_project)
     message(STATUS "The tests are disabled.")
   endif()
-endif(BUILD_TESTING)
+endif(BUILD_TESTING AND NOT EMSCRIPTEN)
 
-If(ADA_BENCHMARKS)
+If(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
   message(STATUS "Ada benchmarks enabled.")
   add_subdirectory(benchmarks)
-else(ADA_BENCHMARKS)
+else(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
   if(is_top_project)
     message(STATUS "Ada benchmarks disabled. Set ADA_BENCHMARKS=ON to enable them.")
   endif()
-endif(ADA_BENCHMARKS)
+endif(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
 
 add_library(ada::ada ALIAS ada)
 
@@ -59,11 +59,12 @@ set_target_properties(
   SOVERSION "${ADA_LIB_SOVERSION}"
   WINDOWS_EXPORT_ALL_SYMBOLS YES
 )
-
-include (TestBigEndian)
-TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
-if(IS_BIG_ENDIAN)
-  message(STATUS "Big-endian system detected.")
+if(NOT EMSCRIPTEN)
+  include (TestBigEndian)
+  TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+  if(IS_BIG_ENDIAN)
+    message(STATUS "Big-endian system detected.")
+  endif()
 endif()
 
 include(CMakePackageConfigHelpers)

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -238,7 +238,7 @@ ada_really_inline size_t find_next_host_delimiter_special(
                         has_zero_byte(xor3) | has_zero_byte(xor4) |
                         has_zero_byte(xor5);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
   if (i < view.size()) {
@@ -256,7 +256,7 @@ ada_really_inline size_t find_next_host_delimiter_special(
                         has_zero_byte(xor3) | has_zero_byte(xor4) |
                         has_zero_byte(xor5);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
   return view.size();
@@ -300,7 +300,7 @@ ada_really_inline size_t find_next_host_delimiter(std::string_view view,
     uint64_t is_match = has_zero_byte(xor1) | has_zero_byte(xor2) |
                         has_zero_byte(xor4) | has_zero_byte(xor5);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
   if (i < view.size()) {
@@ -318,7 +318,7 @@ ada_really_inline size_t find_next_host_delimiter(std::string_view view,
     uint64_t is_match = has_zero_byte(xor1) | has_zero_byte(xor2) |
                         has_zero_byte(xor4) | has_zero_byte(xor5);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
   return view.size();
@@ -625,7 +625,7 @@ find_authority_delimiter_special(std::string_view view) noexcept {
     uint64_t is_match = has_zero_byte(xor1) | has_zero_byte(xor2) |
                         has_zero_byte(xor3) | has_zero_byte(xor4);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
 
@@ -640,7 +640,7 @@ find_authority_delimiter_special(std::string_view view) noexcept {
     uint64_t is_match = has_zero_byte(xor1) | has_zero_byte(xor2) |
                         has_zero_byte(xor3) | has_zero_byte(xor4);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
 
@@ -673,7 +673,7 @@ find_authority_delimiter(std::string_view view) noexcept {
     uint64_t is_match =
         has_zero_byte(xor1) | has_zero_byte(xor2) | has_zero_byte(xor3);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
 
@@ -687,7 +687,7 @@ find_authority_delimiter(std::string_view view) noexcept {
     uint64_t is_match =
         has_zero_byte(xor1) | has_zero_byte(xor2) | has_zero_byte(xor3);
     if (is_match) {
-      return i + index_of_first_set_byte(is_match);
+      return size_t(i + index_of_first_set_byte(is_match));
     }
   }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -36,8 +36,8 @@ result_type parse_url(std::string_view user_input,
 
   // We refuse to parse URL strings that exceed 4GB. Such strings are almost
   // surely the result of a bug or are otherwise a security concern.
-  if (user_input.size() >=
-      std::string_view::size_type(std::numeric_limits<uint32_t>::max)) {
+  // std::numeric_limits<uint32_t>::max appears busted on some platforms (emscripten)
+  if (user_input.size() > 0xFFFFFFFF) {
     url.is_valid = false;
   }
   // Going forward, user_input.size() is in [0,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -36,8 +36,7 @@ result_type parse_url(std::string_view user_input,
 
   // We refuse to parse URL strings that exceed 4GB. Such strings are almost
   // surely the result of a bug or are otherwise a security concern.
-  // std::numeric_limits<uint32_t>::max appears busted on some platforms (emscripten)
-  if (user_input.size() > 0xFFFFFFFF) {
+  if (user_input.size() > std::numeric_limits<uint32_t>::max()) {
     url.is_valid = false;
   }
   // Going forward, user_input.size() is in [0,

--- a/tests-wasm/CMakeLists.txt
+++ b/tests-wasm/CMakeLists.txt
@@ -1,0 +1,11 @@
+link_libraries(ada)
+add_executable(wasm wasm.cpp)
+set_target_properties(wasm PROPERTIES LINK_FLAGS    "-Os -s WASM=1 -s ENVIRONMENT=node -s EXPORT_NAME=loadWASM -s MODULARIZE=1 --bind --no-entry")
+configure_file(test.js.in test.js)
+
+find_program(NODEJS_BINARY NAMES node nodejs)
+if(NODEJS_BINARY)
+  add_test(NAME wasmtest
+         COMMAND "${NODEJS_BINARY}" "${CMAKE_CURRENT_BINARY_DIR}/test.js")
+endif(NODEJS_BINARY)
+

--- a/tests-wasm/test.js.in
+++ b/tests-wasm/test.js.in
@@ -1,0 +1,35 @@
+const child_process = require('child_process');
+const assert = require('assert');
+const test = require('node:test');
+const wasm = require('${CMAKE_CURRENT_BINARY_DIR}/wasm');
+
+function toJS(obj) {
+  const result = {};
+  for (const key of Object.keys(obj.__proto__)) {
+       result[key] = typeof obj[key] === "object" ? toJS(obj[key]) : obj[key];
+  }
+  return result;
+}
+
+const expected = {
+  "result": "success",
+  "href": "https://google.com/?q=Yagiz#Nizipli",
+  "type": 2,
+  "components": {
+    "protocol_end": 6,
+    "username_end": 8,
+    "host_start": 8,
+    "host_end": 18,
+    "port": 4294967295,
+    "pathname_start": 18,
+    "search_start": 19,
+    "hash_start": 27
+  }
+};
+
+test('wasm', async () => {
+  const { parse } = await wasm();
+  console.log();
+  assert.deepStrictEqual(toJS(parse('https://google.com/?q=Yagiz#Nizipli')), expected);
+});
+

--- a/tests-wasm/wasm.cpp
+++ b/tests-wasm/wasm.cpp
@@ -2,20 +2,16 @@
 #include <emscripten/emscripten.h>
 #include <emscripten/bind.h>
 
-
 using namespace emscripten;
 
-struct parse_result
-{
+struct parse_result {
   std::string result;
   std::string href;
   uint32_t type;
   ada::url_components components;
 };
 
-
-parse_result parse(const std::string &input)
-{
+parse_result parse(const std::string &input) {
   auto out = ada::parse<ada::url_aggregator>(input);
   parse_result result;
   if (!out.has_value()) {
@@ -31,19 +27,19 @@ parse_result parse(const std::string &input)
 
 EMSCRIPTEN_BINDINGS(url_components) {
   class_<parse_result>("Result")
-    .property("result", &parse_result::result)
-    .property("href", &parse_result::href)
-    .property("type", &parse_result::type)
-    .property("components", &parse_result::components);
+      .property("result", &parse_result::result)
+      .property("href", &parse_result::href)
+      .property("type", &parse_result::type)
+      .property("components", &parse_result::components);
   class_<ada::url_components>("URLComponents")
-    .property("protocol_end", &ada::url_components::protocol_end)
-    .property("username_end", &ada::url_components::username_end)
-    .property("host_start", &ada::url_components::host_start)
-    .property("host_end", &ada::url_components::host_end)
-    .property("port", &ada::url_components::port)
-    .property("pathname_start", &ada::url_components::pathname_start)
-    .property("search_start", &ada::url_components::search_start)
-    .property("hash_start", &ada::url_components::hash_start);
+      .property("protocol_end", &ada::url_components::protocol_end)
+      .property("username_end", &ada::url_components::username_end)
+      .property("host_start", &ada::url_components::host_start)
+      .property("host_end", &ada::url_components::host_end)
+      .property("port", &ada::url_components::port)
+      .property("pathname_start", &ada::url_components::pathname_start)
+      .property("search_start", &ada::url_components::search_start)
+      .property("hash_start", &ada::url_components::hash_start);
 
   function("parse", &parse);
 }

--- a/tests-wasm/wasm.cpp
+++ b/tests-wasm/wasm.cpp
@@ -1,0 +1,49 @@
+#include "ada.h"
+#include <emscripten/emscripten.h>
+#include <emscripten/bind.h>
+
+
+using namespace emscripten;
+
+struct parse_result
+{
+  std::string result;
+  std::string href;
+  uint32_t type;
+  ada::url_components components;
+};
+
+
+parse_result parse(const std::string &input)
+{
+  auto out = ada::parse<ada::url_aggregator>(input);
+  parse_result result;
+  if (!out.has_value()) {
+    result.result = "fail";
+  } else {
+    result.result = "success";
+    result.href = std::string(out->get_href());
+    result.type = out->type;
+    result.components = out->get_components();
+  }
+  return result;
+}
+
+EMSCRIPTEN_BINDINGS(url_components) {
+  class_<parse_result>("Result")
+    .property("result", &parse_result::result)
+    .property("href", &parse_result::href)
+    .property("type", &parse_result::type)
+    .property("components", &parse_result::components);
+  class_<ada::url_components>("URLComponents")
+    .property("protocol_end", &ada::url_components::protocol_end)
+    .property("username_end", &ada::url_components::username_end)
+    .property("host_start", &ada::url_components::host_start)
+    .property("host_end", &ada::url_components::host_end)
+    .property("port", &ada::url_components::port)
+    .property("pathname_start", &ada::url_components::pathname_start)
+    .property("search_start", &ada::url_components::search_start)
+    .property("hash_start", &ada::url_components::hash_start);
+
+  function("parse", &parse);
+}


### PR DESCRIPTION
This is closely related to https://github.com/ada-url/ada/pull/411 but I am trying to keep everything as automated as possible.

You can build and test as follows:

```
emcmake  cmake -B buildwasm
cmake --build buildwasm
ctest --test-dir buildwasm
```

It is essentially a derivative of the work @MoLow did and he should get most of the credit. I just automated the process.