### PR TITLE
chore: add ADA_TOOLS option

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure
-        run: emcmake  cmake -B buildwasm
+        run: emcmake  cmake -B buildwasm -D ADA_TOOLS=OFF
       - name: Build
         run: cmake --build buildwasm
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ include(GNUInstallDirs)
 
 if(NOT ADA_COVERAGE AND NOT EMSCRIPTEN)
   add_subdirectory(singleheader)
+endif()
+
+if(ADA_TOOLS)
   add_subdirectory(tools)
 endif()
 

--- a/cmake/ada-flags.cmake
+++ b/cmake/ada-flags.cmake
@@ -12,6 +12,7 @@ if(ADA_SANITIZE_UNDEFINED)
   message(STATUS "Undefined sanitizer enabled.")
 endif()
 option(ADA_COVERAGE "Compute coverage" OFF)
+option(ADA_TOOLS "Build cli tools (adaparse)" ON)
 
 if (ADA_COVERAGE)
     message(STATUS "You want to compute coverage. We assume that you have installed gcovr.")


### PR DESCRIPTION
This patch adds a new `ADA_TOOLS` option to allow users enable/disable the build of ada cli tools (`adaparse`) manually.

When trying to add a new port for `ada-url` in `vcpkg`, I found it failed to build `adaparse` on UWP: https://github.com/microsoft/vcpkg/pull/31485 .

`adaparse` uses `fmt::output_file` defined in `fmt/os.h`. However, since UWP doesn't provide _pipe, `FMT_USE_FCNTL` is defined as 0, which in turn means `fmt::output_file` does not exist.

https://github.com/fmtlib/fmt/blob/master/include/fmt/os.h#L23