### PR TITLE
Removing optimization that never got used

### DIFF
--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -94,7 +94,7 @@ ada_really_inline constexpr bool contains_forbidden_domain_code_point(
  * then the second bit is set to 1.
  * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
  */
-ada_really_inline constexpr bool contains_forbidden_domain_code_point_or_upper(
+ada_really_inline constexpr uint8_t contains_forbidden_domain_code_point_or_upper(
     const char* input, size_t length) noexcept;
 
 /**

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -94,8 +94,9 @@ ada_really_inline constexpr bool contains_forbidden_domain_code_point(
  * then the second bit is set to 1.
  * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
  */
-ada_really_inline constexpr uint8_t contains_forbidden_domain_code_point_or_upper(
-    const char* input, size_t length) noexcept;
+ada_really_inline constexpr uint8_t
+contains_forbidden_domain_code_point_or_upper(const char* input,
+                                              size_t length) noexcept;
 
 /**
  * Checks if the input is a forbidden doamin code point.

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -223,7 +223,7 @@ static_assert(sizeof(is_forbidden_domain_code_point_table_or_upper) == 256);
 static_assert(is_forbidden_domain_code_point_table_or_upper[uint8_t('A')] == 2);
 static_assert(is_forbidden_domain_code_point_table_or_upper[uint8_t('Z')] == 2);
 
-ada_really_inline constexpr bool contains_forbidden_domain_code_point_or_upper(
+ada_really_inline constexpr uint8_t contains_forbidden_domain_code_point_or_upper(
     const char* input, size_t length) noexcept {
   size_t i = 0;
   uint8_t accumulator{};

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -223,8 +223,9 @@ static_assert(sizeof(is_forbidden_domain_code_point_table_or_upper) == 256);
 static_assert(is_forbidden_domain_code_point_table_or_upper[uint8_t('A')] == 2);
 static_assert(is_forbidden_domain_code_point_table_or_upper[uint8_t('Z')] == 2);
 
-ada_really_inline constexpr uint8_t contains_forbidden_domain_code_point_or_upper(
-    const char* input, size_t length) noexcept {
+ada_really_inline constexpr uint8_t
+contains_forbidden_domain_code_point_or_upper(const char* input,
+                                              size_t length) noexcept {
   size_t i = 0;
   uint8_t accumulator{};
   for (; i + 4 <= length; i += 4) {

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -479,22 +479,6 @@ ada_really_inline bool url_aggregator::parse_host(std::string_view input) {
     }
     ada_log("parse_host fast path ", get_hostname());
     return true;
-  } else if (is_forbidden_or_upper == 2) {
-    // We have encountered at least one upper case ASCII letter, let us
-    // try to convert it to lower case. If there is no 'xn-' in the result,
-    // we can then use a secondary fast path.
-    std::string _buffer = std::string(input);
-    unicode::to_lower_ascii(_buffer.data(), _buffer.size());
-    if (input.find("xn-") == std::string_view::npos) {
-      // secondary fast path when input is not all lower case
-      update_base_hostname(input);
-      if (checkers::is_ipv4(get_hostname())) {
-        ada_log("parse_host fast path ipv4");
-        return parse_ipv4(get_hostname());
-      }
-      ada_log("parse_host fast path ", get_hostname());
-      return true;
-    }
   }
   // We have encountered at least one forbidden code point or the input contains
   // 'xn-' (case insensitive), so we need to call 'to_ascii' to perform the full


### PR DESCRIPTION
We had an accidental casting of a byte value to a bool which was disabling an optimization in our code. It turns out that this 'fast' path was never used.

Removing it does not measurably affect the performance and it removes lines of code we can do without.

This routine could be revisited later for more optimizations.

Current main branch on benchdata (Apple M1, LLVM 14):

```
BasicBench_AdaURL_aggregator_href   16168863 ns     16168814 ns           43 GHz=3.4071 cycle/byte=6.30681 cycles/url=547.804 instructions/byte=28.5425 instructions/cycle=4.52566 instructions/ns=15.4194 instructions/url=2.47918k ns/url=160.783 speed=537.336M/s time/byte=1.86103ns time/url=161.648ns url/s=6.18629M/s
```

With this PR

```
BasicBench_AdaURL_aggregator_href   15900795 ns     15900750 ns           44 GHz=3.49309 cycle/byte=6.3603 cycles/url=552.451 instructions/byte=28.1538 instructions/cycle=4.42649 instructions/ns=15.4621 instructions/url=2.44542k ns/url=158.155 speed=546.395M/s time/byte=1.83018ns time/url=158.968ns url/s=6.29058M/s
```