### PR TITLE
docs: fix typos in code comment

### DIFF
--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -563,7 +563,7 @@ size_t count_rust_invalid() {
 // https://twitter.com/ecbos_/status/1627494441656238082?s=61&t=vCdcfSGWHH056CBdklWfCg
 static void BasicBench_ServoUrl(benchmark::State& state) {
   // Other benchmarks copy the 'standard url' to a structure.
-  // We try to mimick the effect.
+  // We try to mimic the effect.
   volatile size_t success = 0;
 
   for (auto _ : state) {

--- a/benchmarks/performancecounters/apple_arm_events.h
+++ b/benchmarks/performancecounters/apple_arm_events.h
@@ -248,7 +248,7 @@ static u32 (*kpc_get_counter_count)(u32 classes);
 
 /// Get counter accumulations.
 /// If `all_cpus` is true, the buffer count should not smaller than
-/// (cpu_count * counter_count). Otherwize, the buffer count should not smaller
+/// (cpu_count * counter_count). Otherwise, the buffer count should not smaller
 /// than (counter_count).
 /// @see kpc_get_counter_count(), kpc_cpu_count().
 /// @param all_cpus true for all CPUs, false for current cpu.
@@ -376,7 +376,7 @@ static int kperf_lightweight_pet_set(u32 enabled) {
 // These functions do not require root privileges.
 // -----------------------------------------------------------------------------
 
-// KPEP CPU archtecture constants.
+// KPEP CPU architecture constants.
 #define KPEP_ARCH_I386 0
 #define KPEP_ARCH_X86_64 1
 #define KPEP_ARCH_ARM 2
@@ -416,7 +416,7 @@ typedef struct kpep_db {
   usize fixed_counter_count;
   usize config_counter_count;
   usize power_counter_count;
-  u32 archtecture;  ///< see `KPEP CPU archtecture constants` above.
+  u32 archtecture;  ///< see `KPEP CPU architecture constants` above.
   u32 fixed_counter_bits;
   u32 config_counter_bits;
   u32 power_counter_bits;

--- a/benchmarks/performancecounters/apple_arm_events.h
+++ b/benchmarks/performancecounters/apple_arm_events.h
@@ -416,7 +416,7 @@ typedef struct kpep_db {
   usize fixed_counter_count;
   usize config_counter_count;
   usize power_counter_count;
-  u32 archtecture;  ///< see `KPEP CPU architecture constants` above.
+  u32 architecture;  ///< see `KPEP CPU architecture constants` above.
   u32 fixed_counter_bits;
   u32 config_counter_bits;
   u32 power_counter_bits;

--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -13,7 +13,7 @@
 namespace ada::checkers {
 
 inline bool has_hex_prefix_unsafe(std::string_view input) {
-  // This is actualy efficient code, see has_hex_prefix for the assembly.
+  // This is actually efficient code, see has_hex_prefix for the assembly.
   uint32_t value_one = 1;
   bool is_little_endian = (reinterpret_cast<char*>(&value_one)[0] == 1);
   uint16_t word0x{};

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -242,7 +242,7 @@ namespace ada {
 #define ADA_DEVELOPMENT_CHECKS 1
 #endif  // __OPTIMIZE__
 #endif  // _MSC_VER
-#endif  // SIMDJSON_DEVELOPMENT_CHECKS
+#endif  // ADA_DEVELOPMENT_CHECKS
 
 #define ADA_STR(x) #x
 

--- a/include/ada/expected.h
+++ b/include/ada/expected.h
@@ -1214,7 +1214,7 @@ struct default_constructor_tag {
 };
 
 // expected_default_ctor_base will ensure that expected has a deleted default
-// consturctor if T is not default constructible.
+// constructor if T is not default constructible.
 // This specialization is for when T is default constructible
 template <class T, class E,
           bool Enable =

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -99,7 +99,7 @@ contains_forbidden_domain_code_point_or_upper(const char* input,
                                               size_t length) noexcept;
 
 /**
- * Checks if the input is a forbidden doamin code point.
+ * Checks if the input is a forbidden domain code point.
  * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
  */
 ada_really_inline constexpr bool is_forbidden_domain_code_point(

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -152,7 +152,7 @@ struct url : url_base {
   [[nodiscard]] const std::string_view get_pathname() const noexcept;
 
   /**
-   * Compute the pathname length in bytes witout instantiating a view or a
+   * Compute the pathname length in bytes without instantiating a view or a
    * string.
    * @return size of the pathname in bytes
    * @see https://url.spec.whatwg.org/#dom-url-pathname

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -744,7 +744,7 @@ inline void ada::url_aggregator::add_authority_slashes_if_needed() noexcept {
   ADA_ASSERT_TRUE(validate());
   // Protocol setter will insert `http:` to the URL. It is up to hostname setter
   // to insert
-  // `//` initially to the buffer, since it depends on the hostname existance.
+  // `//` initially to the buffer, since it depends on the hostname existence.
   if (has_authority()) {
     return;
   }

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -112,7 +112,7 @@ struct url_aggregator : url_base {
    */
   [[nodiscard]] std::string_view get_pathname() const noexcept;
   /**
-   * Compute the pathname length in bytes witout instantiating a view or a
+   * Compute the pathname length in bytes without instantiating a view or a
    * string.
    * @return size of the pathname in bytes
    * @see https://url.spec.whatwg.org/#dom-url-pathname

--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -9195,7 +9195,7 @@ bool is_label_valid(const std::u32string_view label) {
   // - For Nontransitional Processing, each value must be either valid or
   // deviation.
 
-  // If CheckJoiners, the label must satisify the ContextJ rules from Appendix
+  // If CheckJoiners, the label must satisfy the ContextJ rules from Appendix
   // A, in The Unicode Code Points and Internationalized Domain Names for
   // Applications (IDNA) [IDNA2008].
   constexpr static uint32_t virama[] = {

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -164,7 +164,7 @@ ada_really_inline void remove_ascii_tab_or_newline(
 ada_really_inline std::string_view substring(std::string_view input,
                                              size_t pos) noexcept {
   ADA_ASSERT_TRUE(pos <= input.size());
-  // The following is safer but uneeded if we have the above line:
+  // The following is safer but unneeded if we have the above line:
   // return pos > input.size() ? std::string_view() : input.substr(pos);
   return input.substr(pos);
 }


### PR DESCRIPTION
Some misspellings are detected by using [codespell](https://github.com/codespell-project/codespell) with the following command line:

```bash
$ codespell -L crate,unexpect,OT --skip "*.json"
```