### PR TITLE
Add AVX2 Support

### DIFF
--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -286,6 +286,10 @@ namespace ada {
   } while (0)
 #endif
 
+#if defined(__AVX2__)
+#define ADA_AVX2 1
+#endif
+
 #if defined(__SSE2__) || defined(__x86_64__) || defined(__x86_64) || \
     (defined(_M_AMD64) || defined(_M_X64) ||                         \
      (defined(_M_IX86_FP) && _M_IX86_FP == 2))


### PR DESCRIPTION
- Add `ADA_AVX2` macro in `include/ada/common_defs.h` enabled if `defined(__AVX2__)`
- Implement `has_tabs_or_newline` using AVX2