### PR TITLE
Added OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ada
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ada-url/ada/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ada-url/ada)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7085/badge)](https://bestpractices.coreinfrastructure.org/projects/7085)
 [![Ubuntu 22.04](https://github.com/ada-url/ada/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/ada-url/ada/actions/workflows/ubuntu.yml)
 [![VS17-CI](https://github.com/ada-url/ada/actions/workflows/visual_studio.yml/badge.svg)](https://github.com/ada-url/ada/actions/workflows/visual_studio.yml)


### PR DESCRIPTION
### Main Changes

Added OpenSSF Badge ([![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ada-url/ada/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ada-url/ada)) to `README.md`

### Changelog

- de56da94b2228b76a1e48d9fde754efb83c7493a docs: added OpenSSF Scorecard badge by @UlisesGascon 