### PR TITLE
Restrict permissions for GITHUB_TOKEN usage in pipelines

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     permissions:

--- a/.github/workflows/wpt-updater.yml
+++ b/.github/workflows/wpt-updater.yml
@@ -11,6 +11,9 @@ concurrency:
   group: wpt-updater
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Main Changes

Implementing best practices related to OpenSSF Scorecard.

### Context

> The `GITHUB_TOKEN` is an automatically generated secret to make authenticated calls to the GitHub API
If the token is compromised, it can be abused to compromise your environment (e.g., to overwrite releases or source code). This compromise will also impact everyone using your software in their supply chain. [Ref]( https://github.com/step-security/secure-repo#1-automatically-set-minimum-github_token-permissions)

**Additional info**
- [Step Security: Automatically set minimum GITHUB_TOKEN permissions](https://github.com/step-security/secure-repo#1-automatically-set-minimum-github_token-permissions)
- [GitHub Actions: Control permissions for GITHUB_TOKEN](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/)

### Changelog


- 3113faf chore: restrict permissions for GITHUB_TOKEN usage in pipeline by @UlisesGascon

