### PR TITLE
Pinned Github Actions dependencies

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,20 +21,20 @@ jobs:
     steps:
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@c9485cb75e3e39a122264a45ce667d3b57188675 # master
         with:
          oss-fuzz-project-name: 'ada-url'
          language: c++
          sanitizer: ${{ matrix.sanitizer }}
       - name: Run Fuzzers (${{ matrix.sanitizer }})
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@c9485cb75e3e39a122264a45ce667d3b57188675 # master
         with:
          oss-fuzz-project-name: 'ada-url'
          language: c++
          fuzz-seconds: 300
          sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: steps.build.outcome == 'success'
         with:
           name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -25,12 +25,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
-      - uses: mymindstorm/setup-emsdk@v12
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      - uses: mymindstorm/setup-emsdk@ab889da2abbcbb280f91ec4c215d3bb4f3a8f775 # v12
       - name: Verify
         run: emcc -v
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Configure
         run: emcmake  cmake -B buildwasm -D ADA_TOOLS=OFF
       - name: Build


### PR DESCRIPTION
### Main Changes

Pinned missing Github Actions dependencies

### Context

[Full Report](https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/ada-url/ada/commit/0c67ed538d1ef4a813086820abc0f43ab2e9b732)

![Captura de pantalla 2023-06-25 a las 11 57 22](https://github.com/ada-url/ada/assets/5110813/828a099c-2f38-4158-b041-6c06a3aa2e5a)

### Changelog

- 159ba96 chore: pinned Github Actions dependencies by @UlisesGascon


