### PR TITLE
Update Dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,19 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
 
   - package-ecosystem: cargo
     directory: /benchmarks/competitors/servo-url
     schedule:
-      interval: daily
+      interval: monthly
 
   - package-ecosystem: pip
     directory: /tools/release
     schedule:
-      interval: daily
+      interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     directory: /benchmarks/competitors/servo-url
     schedule:
       interval: daily
+
+  - package-ecosystem: pip
+    directory: /tools/release
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: cargo
+    directory: /benchmarks/competitors/servo-url
+    schedule:
+      interval: daily


### PR DESCRIPTION
### Main Changes

Extended Dependabot config for Docker, Cargo and Pip

### Changelog
- eae406c chore: added support for docker in dependabot by @UlisesGascon
- 80ef5c5 chore: added support for Cargo in dependabot by @UlisesGascon
- 3e5d1f1 chore: added support for pip in dependabot by @UlisesGascon
