### PR TITLE
feat: Implement url_search_params::has(name, value)

### DIFF
--- a/fuzz/parse.cc
+++ b/fuzz/parse.cc
@@ -111,6 +111,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   }
   search_params.remove(source);
   search_params.remove(source, base_source);
+  if (search_params.has(base_source, source)) {
+    search_params.remove(base_source);
+    search_params.remove(base_source, source);
+  }
 
   return 0;
 }  // extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {

--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -96,6 +96,15 @@ inline bool url_search_params::has(const std::string_view key) noexcept {
   return entry != params.end();
 }
 
+inline bool url_search_params::has(std::string_view key,
+                                   std::string_view value) noexcept {
+  auto entry =
+      std::find_if(params.begin(), params.end(), [&key, &value](auto &param) {
+        return param.first == key && param.second == value;
+      });
+  return entry != params.end();
+}
+
 inline std::string url_search_params::to_string() {
   auto character_set = ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE;
   std::string out{};

--- a/include/ada/url_search_params.h
+++ b/include/ada/url_search_params.h
@@ -57,6 +57,7 @@ struct url_search_params {
    * @see https://url.spec.whatwg.org/#dom-urlsearchparams-has
    */
   inline bool has(std::string_view key) noexcept;
+  inline bool has(std::string_view key, std::string_view value) noexcept;
 
   /**
    * @see https://url.spec.whatwg.org/#dom-urlsearchparams-set

--- a/tests/url_search_params.cpp
+++ b/tests/url_search_params.cpp
@@ -155,3 +155,15 @@ TEST(url_search_params, string_constructor_with_edge_cases) {
   ASSERT_TRUE(p.has("møø"));
   SUCCEED();
 }
+
+TEST(url_search_params, has) {
+  auto search_params = ada::url_search_params("key1=value1&key2=value2");
+  ASSERT_TRUE(search_params.has("key1"));
+  ASSERT_TRUE(search_params.has("key2"));
+  ASSERT_TRUE(search_params.has("key1", "value1"));
+  ASSERT_TRUE(search_params.has("key2", "value2"));
+  ASSERT_TRUE(!search_params.has("key3"));
+  ASSERT_TRUE(!search_params.has("key1", "value2"));
+  ASSERT_TRUE(!search_params.has("key3", "value3"));
+  SUCCEED();
+}


### PR DESCRIPTION
According to https://url.spec.whatwg.org/#dom-urlsearchparams-has, we need to provide a `has` function that takes two arguments `name` and `value`.