### PR TITLE
using a table-based convert_hex_to_binary function for better speed

### DIFF
--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -157,7 +157,7 @@ ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept;
  * @details Convert hex to binary. Caller is responsible to ensure that
  * the parameter is an hexadecimal digit (0-9, A-F, a-f).
  */
-unsigned constexpr convert_hex_to_binary(char c) noexcept;
+ada_really_inline unsigned constexpr convert_hex_to_binary(char c) noexcept;
 
 /**
  * first_percent should be  = input.find('%')

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -154,7 +154,8 @@ ada_really_inline constexpr bool is_single_dot_path_segment(
 ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept;
 
 /**
- * @details Convert hex to binary.
+ * @details Convert hex to binary. Caller is responsible to ensure that
+ * the parameter is an hexadecimal digit (0-9, A-F, a-f).
  */
 unsigned constexpr convert_hex_to_binary(char c) noexcept;
 

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -368,13 +368,12 @@ ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
 }
 
+constexpr static char hex_to_binary_table[] = {
+    0,  1,  2,  3,  4, 5, 6, 7, 8, 9, 0, 0,  0,  0,  0,  0,  0, 10, 11,
+    12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0, 0,  0,
+    0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13, 14, 15};
 unsigned constexpr convert_hex_to_binary(const char c) noexcept {
-  // this code can be optimized.
-  if (c <= '9') {
-    return c - '0';
-  }
-  char del = c >= 'a' ? 'a' : 'A';
-  return 10 + (c - del);
+  return hex_to_binary_table[c - '0'];
 }
 
 std::string percent_decode(const std::string_view input, size_t first_percent) {

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -293,11 +293,6 @@ static_assert(unicode::is_alnum_plus('1'));
 static_assert(unicode::is_alnum_plus('a'));
 static_assert(unicode::is_alnum_plus('b'));
 
-ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept {
-  return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') ||
-         (c >= 'a' && c <= 'f');
-}
-
 ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept {
   return (unsigned char)c <= ' ';
 }
@@ -369,9 +364,17 @@ ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept {
 }
 
 constexpr static char hex_to_binary_table[] = {
-    0,  1,  2,  3,  4, 5, 6, 7, 8, 9, 0, 0,  0,  0,  0,  0,  0, 10, 11,
-    12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0, 0,  0,
-    0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13, 14, 15};
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, -1, 10, 11,
+    12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15};
+
+ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept {
+  if (c > 'f' || c < '0') {
+    return false;
+  }
+  return hex_to_binary_table[c - '0'] != -1;
+}
+
 unsigned constexpr convert_hex_to_binary(const char c) noexcept {
   return hex_to_binary_table[c - '0'];
 }

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -293,6 +293,11 @@ static_assert(unicode::is_alnum_plus('1'));
 static_assert(unicode::is_alnum_plus('a'));
 static_assert(unicode::is_alnum_plus('b'));
 
+ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept {
+  return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') ||
+         (c >= 'a' && c <= 'f');
+}
+
 ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept {
   return (unsigned char)c <= ' ';
 }
@@ -363,29 +368,12 @@ ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
 }
 
-constexpr static char hex_to_binary_table[256] = {
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,
-    9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1};
-
-ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept {
-  return hex_to_binary_table[(unsigned char)c] != -1;
-}
-
-ada_really_inline unsigned constexpr convert_hex_to_binary(
-    const char c) noexcept {
-  return hex_to_binary_table[(unsigned char)c];
+constexpr static char hex_to_binary_table[] = {
+    0,  1,  2,  3,  4, 5, 6, 7, 8, 9, 0, 0,  0,  0,  0,  0,  0, 10, 11,
+    12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0, 0,  0,
+    0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13, 14, 15};
+unsigned constexpr convert_hex_to_binary(const char c) noexcept {
+  return hex_to_binary_table[c - '0'];
 }
 
 std::string percent_decode(const std::string_view input, size_t first_percent) {

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -363,20 +363,29 @@ ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
 }
 
-constexpr static char hex_to_binary_table[] = {
-    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, -1, 10, 11,
-    12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15};
+constexpr static char hex_to_binary_table[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,
+    9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1};
 
 ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept {
-  if (c > 'f' || c < '0') {
-    return false;
-  }
-  return hex_to_binary_table[c - '0'] != -1;
+  return hex_to_binary_table[(unsigned char)c] != -1;
 }
 
-unsigned constexpr convert_hex_to_binary(const char c) noexcept {
-  return hex_to_binary_table[c - '0'];
+ada_really_inline unsigned constexpr convert_hex_to_binary(
+    const char c) noexcept {
+  return hex_to_binary_table[(unsigned char)c];
 }
 
 std::string percent_decode(const std::string_view input, size_t first_percent) {


### PR DESCRIPTION
This is an alternative to https://github.com/ada-url/ada/pull/473

Using [the search-params benchmark](https://github.com/ada-url/ada/pull/477), we can use `benchmarks/bench_search_params` to test the speed at which we can parse search parameters. This task is percent-decoding intensive.


GCC 11, Ice Lake processor.

Main:

```
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
url_search_params_AdaURL      65900 ns        65735 ns        10671 GHz=3.19635 cycle/byte=11.6984 cycles/url=32.773k instructions/byte=40.3667 instructions/cycle=3.45062 instructions/ns=11.0294 instructions/url=113.087k ns/url=10.2532k speed=170.473M/s time/byte=5.86604ns time/url=16.4337us url/s=60.8505k/s
```

PR https://github.com/ada-url/ada/pull/473

```
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
url_search_params_AdaURL      65202 ns        65028 ns        10785 GHz=3.19652 cycle/byte=11.5858 cycles/url=32.4575k instructions/byte=40.3469 instructions/cycle=3.48245 instructions/ns=11.1317 instructions/url=113.032k ns/url=10.154k speed=172.325M/s time/byte=5.80298ns time/url=16.257us url/s=61.5118k/s
```

Table approach:

```
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
url_search_params_AdaURL      57930 ns        57759 ns        11989 GHz=1.99858 cycle/byte=9.17089 cycles/url=25.6923k instructions/byte=40.4051 instructions/cycle=4.40579 instructions/ns=8.80533 instructions/url=113.195k ns/url=12.8552k speed=194.012M/s time/byte=5.15432ns time/url=14.4398us url/s=69.253k/s
```

The table-based approach more than 10% faster than our main branch and, according to these tests, faster than PR https://github.com/ada-url/ada/pull/473

cc @ttsugriy 


This is a precursor to https://github.com/ada-url/ada/pull/459