### PR TITLE
Speed up is_ascii_hex_digit

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -294,8 +294,9 @@ static_assert(unicode::is_alnum_plus('a'));
 static_assert(unicode::is_alnum_plus('b'));
 
 ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept {
-  return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') ||
-         (c >= 'a' && c <= 'f');
+  if (c >= '0' && c <= '9') return true;
+  char lowercased = c | 0x20;
+  return (lowercased >= 'a' && lowercased <= 'f');
 }
 
 ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept {


### PR DESCRIPTION
It's possible to reduce the number of required comparisons by converting `c` into lowercase, so that instead of checking both lowercase and uppercase ranges, only lowercase range needs to be checked.

This allows clang to generate branchless x86_64 asm (https://compiler-explorer.com/z/P6f7c8e4T). Instead of
```
is_ascii_hex_digit(char):                # @is_ascii_hex_digit(char)
        lea     ecx, [rdi - 48]
        mov     al, 1
        cmp     cl, 10
        jb      .LBB0_3
        lea     ecx, [rdi - 65]
        cmp     cl, 6
        jb      .LBB0_3
        add     dil, -97
        cmp     dil, 6
        setb    al
.LBB0_3:
        ret
```
clang generates
```
is_ascii_hex_digit(char):                # @is_ascii_hex_digit(char)
        lea     eax, [rdi - 48]
        cmp     al, 10
        setb    cl
        or      dil, 32
        add     dil, -97
        cmp     dil, 6
        setb    al
        or      al, cl
        ret
```
that is 2 instructions shorter and contains no branches.