### PR TITLE
feat: add url host type attribute

### DIFF
--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -17,8 +17,18 @@ namespace ada {
  * Type of URL host as an enum.
  */
 enum url_host_type : uint8_t {
+  /**
+   * Represents common URLs such as "https://www.google.com"
+   */
   DEFAULT = 0,
+  /**
+   * Represents ipv4 addresses such as "http://127.0.0.1"
+   */
   IPV4 = 1,
+  /**
+   * Represents ipv6 addresses such as
+   * "http://[2001:db8:3333:4444:5555:6666:7777:8888]"
+   */
   IPV6 = 2,
 };
 

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -14,6 +14,15 @@
 namespace ada {
 
 /**
+ * Type of URL host as an enum.
+ */
+enum url_host_type : uint8_t {
+  DEFAULT = 0,
+  IPV4 = 1,
+  IPV6 = 2,
+};
+
+/**
  * @brief Base class of URL implementations
  *
  * @details A url_base contains a few attributes: is_valid, has_opaque_path and
@@ -34,6 +43,11 @@ struct url_base {
    * A URL has an opaque path if its path is a string.
    */
   bool has_opaque_path{false};
+
+  /**
+   * URL hosts type
+   */
+  url_host_type host_type = url_host_type::DEFAULT;
 
   /**
    * @private

--- a/include/ada_c.h
+++ b/include/ada_c.h
@@ -67,6 +67,7 @@ ada_string ada_get_hostname(ada_url result);
 ada_string ada_get_pathname(ada_url result);
 ada_string ada_get_search(ada_url result);
 ada_string ada_get_protocol(ada_url result);
+uint8_t ada_get_url_host_type(ada_url result);
 
 // url_aggregator setters
 // if ada_is_valid(result)) is false, the setters have no effect

--- a/src/ada_c.cpp
+++ b/src/ada_c.cpp
@@ -205,6 +205,14 @@ ada_string ada_get_protocol(ada_url result) noexcept {
   return ada_string_create(out.data(), out.length());
 }
 
+uint8_t ada_get_url_host_type(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (!r) {
+    return 0;
+  }
+  return r->host_type;
+}
+
 bool ada_set_href(ada_url result, const char* input, size_t length) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (!r) {

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -93,6 +93,7 @@ final:
   } else {
     host = ada::serializers::ipv4(ipv4);  // We have to reserialize the address.
   }
+  host_type = IPV4;
   return true;
 }
 
@@ -322,6 +323,7 @@ bool url::parse_ipv6(std::string_view input) {
   }
   host = ada::serializers::ipv6(address);
   ada_log("parse_ipv6 ", *host);
+  host_type = IPV6;
   return true;
 }
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -935,6 +935,7 @@ final:
     update_base_hostname(
         ada::serializers::ipv4(ipv4));  // We have to reserialize the address.
   }
+  host_type = IPV4;
   ADA_ASSERT_TRUE(validate());
   return true;
 }
@@ -1170,6 +1171,7 @@ bool url_aggregator::parse_ipv6(std::string_view input) {
   update_base_hostname(ada::serializers::ipv6(address));
   ada_log("parse_ipv6 ", get_hostname());
   ADA_ASSERT_TRUE(validate());
+  host_type = IPV6;
   return true;
 }
 

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -106,6 +106,8 @@ TEST(ada_c, setters) {
   ada_set_protocol(url, "wss", 3);
   ASSERT_EQ(convert_string(ada_get_protocol(url)), "wss:");
 
+  ASSERT_EQ(ada_get_url_host_type(url), 0);
+
   ada_free(url);
 
   SUCCEED();

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -366,3 +366,15 @@ TYPED_TEST(basic_tests, node_issue_48254) {
   ASSERT_FALSE(url);
   SUCCEED();
 }
+
+TYPED_TEST(basic_tests, url_host_type) {
+  ASSERT_EQ(ada::parse<TypeParam>("http://localhost:3000")->host_type,
+            ada::url_host_type::DEFAULT);
+  ASSERT_EQ(ada::parse<TypeParam>("http://0.0.0.0")->host_type,
+            ada::url_host_type::IPV4);
+  ASSERT_EQ(
+      ada::parse<TypeParam>("http://[2001:db8:3333:4444:5555:6666:7777:8888]")
+          ->host_type,
+      ada::url_host_type::IPV6);
+  SUCCEED();
+}


### PR DESCRIPTION
This is one of the missing features comparing `ada-url` rust crate with `url` crate. Original implementation of `url` crate is available at: https://docs.rs/url/2.4.0/url/enum.Host.html