### PR TITLE
feat: add ada_clear_* methods to c api

### DIFF
--- a/fuzz/parse.cc
+++ b/fuzz/parse.cc
@@ -76,6 +76,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     length += out_aggregator->get_hash().size();
     length += out_aggregator->get_origin().size();
     length += out_aggregator->get_port().size();
+
+    // clear methods
+    out_aggregator->clear_port();
+    out_aggregator->clear_pathname();
+    out_aggregator->clear_search();
+    out_aggregator->clear_hash();
   }
 
   /**

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -700,7 +700,9 @@ inline void url_aggregator::clear_hostname() {
                        " with " + components.to_string() + "\n" + to_diagram());
 #endif
   ADA_ASSERT_TRUE(has_authority());
-  ADA_ASSERT_TRUE(has_empty_hostname());
+  ADA_ASSERT_EQUAL(has_empty_hostname(), true,
+                   "hostname should have been cleared on buffer=" + buffer +
+                       " with " + components.to_string() + "\n" + to_diagram());
   ADA_ASSERT_TRUE(validate());
 }
 

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -196,6 +196,11 @@ struct url_aggregator : url_base {
   /** @return true if the URL has a search component */
   [[nodiscard]] inline bool has_search() const noexcept override;
 
+  inline void clear_port();
+  inline void clear_hash();
+  inline void clear_pathname() override;
+  inline void clear_search() override;
+
  private:
   friend ada::url_aggregator ada::parser::parse_url<ada::url_aggregator>(
       std::string_view, const ada::url_aggregator *);
@@ -270,11 +275,7 @@ struct url_aggregator : url_base {
   inline void update_base_port(uint32_t input);
   inline void append_base_pathname(const std::string_view input);
   inline uint32_t retrieve_base_port() const;
-  inline void clear_port();
   inline void clear_hostname();
-  inline void clear_hash();
-  inline void clear_pathname() override;
-  inline void clear_search() override;
   inline void clear_password();
   inline bool has_dash_dot() const noexcept;
   void delete_dash_dot();

--- a/include/ada_c.h
+++ b/include/ada_c.h
@@ -84,6 +84,12 @@ bool ada_set_pathname(ada_url result, const char* input, size_t length);
 void ada_set_search(ada_url result, const char* input, size_t length);
 void ada_set_hash(ada_url result, const char* input, size_t length);
 
+// url_aggregator clear methods
+void ada_clear_port(ada_url result);
+void ada_clear_hash(ada_url result);
+void ada_clear_pathname(ada_url result);
+void ada_clear_search(ada_url result);
+
 // url_aggregator functions
 // if ada_is_valid(result) is false, functions below will return false
 bool ada_has_credentials(ada_url result);

--- a/src/ada_c.cpp
+++ b/src/ada_c.cpp
@@ -301,6 +301,34 @@ void ada_set_hash(ada_url result, const char* input, size_t length) noexcept {
   }
 }
 
+void ada_clear_port(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_port();
+  }
+}
+
+void ada_clear_hash(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_hash();
+  }
+}
+
+void ada_clear_pathname(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_pathname();
+  }
+}
+
+void ada_clear_search(ada_url result) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(result);
+  if (r) {
+    r->clear_search();
+  }
+}
+
 bool ada_has_credentials(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (!r) {

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -87,9 +87,14 @@ TEST(ada_c, setters) {
 
   ada_set_port(url, "4242", 4);
   ASSERT_EQ(convert_string(ada_get_port(url)), "4242");
+  ada_clear_port(url);
+  ASSERT_EQ(convert_string(ada_get_port(url)), "");
+  ASSERT_FALSE(ada_has_port(url));
 
   ada_set_hash(url, "new-hash", strlen("new-hash"));
   ASSERT_EQ(convert_string(ada_get_hash(url)), "#new-hash");
+  ada_clear_hash(url);
+  ASSERT_FALSE(ada_has_hash(url));
 
   ada_set_hostname(url, "new-host", strlen("new-host"));
   ASSERT_EQ(convert_string(ada_get_hostname(url)), "new-host");
@@ -99,9 +104,13 @@ TEST(ada_c, setters) {
 
   ada_set_pathname(url, "new-pathname", strlen("new-pathname"));
   ASSERT_EQ(convert_string(ada_get_pathname(url)), "/new-pathname");
+  ada_clear_pathname(url);
+  ASSERT_EQ(convert_string(ada_get_pathname(url)), "");
 
   ada_set_search(url, "new-search", strlen("new-search"));
   ASSERT_EQ(convert_string(ada_get_search(url)), "?new-search");
+  ada_clear_search(url);
+  ASSERT_EQ(convert_string(ada_get_search(url)), "");
 
   ada_set_protocol(url, "wss", 3);
   ASSERT_EQ(convert_string(ada_get_protocol(url)), "wss:");


### PR DESCRIPTION
These methods are required for the Rust crate and is useful for others as well.