### PR TITLE
Avoid potentially unnecessary string reallocs.

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -422,9 +422,10 @@ std::string percent_encode(const std::string_view input,
     return std::string(input);
   }
 
-  std::string result(input.substr(0, std::distance(input.begin(), pointer)));
+  std::string result;
   result.reserve(input.length());  // in the worst case, percent encoding might
                                    // produce 3 characters.
+  result.append(input.substr(0, std::distance(input.begin(), pointer)));
 
   for (; pointer != input.end(); pointer++) {
     if (character_sets::bit_at(character_set, *pointer)) {


### PR DESCRIPTION
In case `result` is not created using a subset of the `input` `result.reserve(input.size())` would result in increasing `result`'s size with likely reallocation.

It's similar to https://github.com/ada-url/ada/pull/484