### PR TITLE
refactor: merge `ada_parse` and `ada_is_valid`

### DIFF
--- a/include/ada_c.h
+++ b/include/ada_c.h
@@ -38,11 +38,16 @@ typedef struct {
 
 typedef void* ada_url;
 
+typedef struct {
+  ada_url url;
+  bool is_valid;
+} ada_parse_result;
+
 // input should be a null terminated C string (ASCII or UTF-8)
 // you must call ada_free on the returned pointer
-ada_url ada_parse(const char* input, size_t length);
-ada_url ada_parse_with_base(const char* input, size_t input_length,
-                            const char* base, size_t base_length);
+ada_parse_result ada_parse(const char* input, size_t length);
+ada_parse_result ada_parse_with_base(const char* input, size_t input_length,
+                                     const char* base, size_t base_length);
 
 // input and base should be a null terminated C strings
 bool ada_can_parse(const char* input, size_t length);
@@ -53,10 +58,7 @@ void ada_free(ada_url result);
 void ada_free_owned_string(ada_owned_string owned);
 ada_url ada_copy(ada_url input);
 
-bool ada_is_valid(ada_url result);
-
 // url_aggregator getters
-// if ada_is_valid(result)) is false, an empty string is returned
 ada_owned_string ada_get_origin(ada_url result);
 ada_string ada_get_href(ada_url result);
 ada_string ada_get_username(ada_url result);

--- a/singleheader/demo.c
+++ b/singleheader/demo.c
@@ -12,30 +12,26 @@ int main(int c, char* arg[]) {
   const char* input =
       "https://username:password@www.google.com:8080/"
       "pathname?query=true#hash-exists";
-  ada_url url = ada_parse(input, strlen(input));
-  if (!ada_is_valid(url)) {
+  ada_parse_result out = ada_parse(input, strlen(input));
+  if (!out.is_valid) {
     puts("failure");
     return EXIT_FAILURE;
   }
-  ada_print(ada_get_href(
-      url));  // prints
-              // https://username:password@host:8080/pathname?query=true#hash-exists
-  ada_print(ada_get_protocol(url));  // prints https:
-  ada_print(ada_get_username(url));  // prints username
-  ada_set_href(url, "https://www.yagiz.co", strlen("https://www.yagiz.co"));
-  if (!ada_is_valid(url)) {
-    puts("failure");
-    return EXIT_FAILURE;
-  }
-  ada_set_hash(url, "new-hash", strlen("new-hash"));
-  ada_set_hostname(url, "new-host", strlen("new-host"));
-  ada_set_host(url, "changed-host:9090", strlen("changed-host:9090"));
-  ada_set_pathname(url, "new-pathname", strlen("new-pathname"));
-  ada_set_search(url, "new-search", strlen("new-search"));
-  ada_set_protocol(url, "wss", 3);
-  ada_print(ada_get_href(
-      url));  // will print
-              // wss://changed-host:9090/new-pathname?new-search#new-hash
-  ada_free(url);
+  ada_print(ada_get_href(out.url));
+  // prints
+  // https://username:password@host:8080/pathname?query=true#hash-exists
+  ada_print(ada_get_protocol(out.url));  // prints https:
+  ada_print(ada_get_username(out.url));  // prints username
+  ada_set_href(out.url, "https://www.yagiz.co", strlen("https://www.yagiz.co"));
+  ada_set_hash(out.url, "new-hash", strlen("new-hash"));
+  ada_set_hostname(out.url, "new-host", strlen("new-host"));
+  ada_set_host(out.url, "changed-host:9090", strlen("changed-host:9090"));
+  ada_set_pathname(out.url, "new-pathname", strlen("new-pathname"));
+  ada_set_search(out.url, "new-search", strlen("new-search"));
+  ada_set_protocol(out.url, "wss", 3);
+  ada_print(ada_get_href(out.url));
+  // will print
+  // wss://changed-host:9090/new-pathname?new-search#new-hash
+  ada_free(out.url);
   return EXIT_SUCCESS;
 }

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -14,11 +14,11 @@ TEST(ada_c, ada_parse) {
   std::string_view input =
       "https://username:password@www.google.com:8080/"
       "pathname?query=true#hash-exists";
-  ada_url url = ada_parse(input.data(), input.length());
+  ada_parse_result out = ada_parse(input.data(), input.length());
 
-  ASSERT_TRUE(ada_is_valid(url));
+  ASSERT_TRUE(out.is_valid);
 
-  ada_free(url);
+  ada_free(out.url);
 
   SUCCEED();
 }
@@ -28,12 +28,12 @@ TEST(ada_c, ada_parse_with_base) {
   std::string_view base =
       "https://username:password@www.google.com:8080/"
       "pathname?query=true#hash-exists";
-  ada_url url = ada_parse_with_base(input.data(), input.length(), base.data(),
-                                    base.length());
+  ada_parse_result out = ada_parse_with_base(input.data(), input.length(),
+                                             base.data(), base.length());
 
-  ASSERT_TRUE(ada_is_valid(url));
+  ASSERT_TRUE(out.is_valid);
 
-  ada_free(url);
+  ada_free(out.url);
 
   SUCCEED();
 }
@@ -42,28 +42,28 @@ TEST(ada_c, getters) {
   std::string_view input =
       "https://username:password@www.google.com:8080/"
       "pathname?query=true#hash-exists";
-  ada_url url = ada_parse(input.data(), input.length());
+  ada_parse_result out = ada_parse(input.data(), input.length());
 
-  ASSERT_TRUE(ada_is_valid(url));
+  ASSERT_TRUE(out.is_valid);
 
-  ada_owned_string origin = ada_get_origin(url);
+  ada_owned_string origin = ada_get_origin(out.url);
   ASSERT_EQ(convert_string(origin), "https://www.google.com:8080");
   ada_free_owned_string(origin);
 
-  ASSERT_EQ(convert_string(ada_get_href(url)),
+  ASSERT_EQ(convert_string(ada_get_href(out.url)),
             "https://username:password@www.google.com:8080/"
             "pathname?query=true#hash-exists");
-  ASSERT_EQ(convert_string(ada_get_username(url)), "username");
-  ASSERT_EQ(convert_string(ada_get_password(url)), "password");
-  ASSERT_EQ(convert_string(ada_get_port(url)), "8080");
-  ASSERT_EQ(convert_string(ada_get_hash(url)), "#hash-exists");
-  ASSERT_EQ(convert_string(ada_get_host(url)), "www.google.com:8080");
-  ASSERT_EQ(convert_string(ada_get_hostname(url)), "www.google.com");
-  ASSERT_EQ(convert_string(ada_get_pathname(url)), "/pathname");
-  ASSERT_EQ(convert_string(ada_get_search(url)), "?query=true");
-  ASSERT_EQ(convert_string(ada_get_protocol(url)), "https:");
+  ASSERT_EQ(convert_string(ada_get_username(out.url)), "username");
+  ASSERT_EQ(convert_string(ada_get_password(out.url)), "password");
+  ASSERT_EQ(convert_string(ada_get_port(out.url)), "8080");
+  ASSERT_EQ(convert_string(ada_get_hash(out.url)), "#hash-exists");
+  ASSERT_EQ(convert_string(ada_get_host(out.url)), "www.google.com:8080");
+  ASSERT_EQ(convert_string(ada_get_hostname(out.url)), "www.google.com");
+  ASSERT_EQ(convert_string(ada_get_pathname(out.url)), "/pathname");
+  ASSERT_EQ(convert_string(ada_get_search(out.url)), "?query=true");
+  ASSERT_EQ(convert_string(ada_get_protocol(out.url)), "https:");
 
-  ada_free(url);
+  ada_free(out.url);
 
   SUCCEED();
 }
@@ -72,50 +72,50 @@ TEST(ada_c, setters) {
   std::string input =
       "https://username:password@www.google.com:8080/"
       "pathname?query=true#hash-exists";
-  ada_url url = ada_parse(input.data(), input.length());
+  ada_parse_result out = ada_parse(input.data(), input.length());
 
-  ASSERT_TRUE(ada_is_valid(url));
+  ASSERT_TRUE(out.is_valid);
 
-  ada_set_href(url, "https://www.yagiz.co", strlen("https://www.yagiz.co"));
-  ASSERT_EQ(convert_string(ada_get_href(url)), "https://www.yagiz.co/");
+  ada_set_href(out.url, "https://www.yagiz.co", strlen("https://www.yagiz.co"));
+  ASSERT_EQ(convert_string(ada_get_href(out.url)), "https://www.yagiz.co/");
 
-  ada_set_username(url, "new-username", strlen("new-username"));
-  ASSERT_EQ(convert_string(ada_get_username(url)), "new-username");
+  ada_set_username(out.url, "new-username", strlen("new-username"));
+  ASSERT_EQ(convert_string(ada_get_username(out.url)), "new-username");
 
-  ada_set_password(url, "new-password", strlen("new-password"));
-  ASSERT_EQ(convert_string(ada_get_password(url)), "new-password");
+  ada_set_password(out.url, "new-password", strlen("new-password"));
+  ASSERT_EQ(convert_string(ada_get_password(out.url)), "new-password");
 
-  ada_set_port(url, "4242", 4);
-  ASSERT_EQ(convert_string(ada_get_port(url)), "4242");
-  ada_clear_port(url);
-  ASSERT_EQ(convert_string(ada_get_port(url)), "");
-  ASSERT_FALSE(ada_has_port(url));
+  ada_set_port(out.url, "4242", 4);
+  ASSERT_EQ(convert_string(ada_get_port(out.url)), "4242");
+  ada_clear_port(out.url);
+  ASSERT_EQ(convert_string(ada_get_port(out.url)), "");
+  ASSERT_FALSE(ada_has_port(out.url));
 
-  ada_set_hash(url, "new-hash", strlen("new-hash"));
-  ASSERT_EQ(convert_string(ada_get_hash(url)), "#new-hash");
-  ada_clear_hash(url);
-  ASSERT_FALSE(ada_has_hash(url));
+  ada_set_hash(out.url, "new-hash", strlen("new-hash"));
+  ASSERT_EQ(convert_string(ada_get_hash(out.url)), "#new-hash");
+  ada_clear_hash(out.url);
+  ASSERT_FALSE(ada_has_hash(out.url));
 
-  ada_set_hostname(url, "new-host", strlen("new-host"));
-  ASSERT_EQ(convert_string(ada_get_hostname(url)), "new-host");
+  ada_set_hostname(out.url, "new-host", strlen("new-host"));
+  ASSERT_EQ(convert_string(ada_get_hostname(out.url)), "new-host");
 
-  ada_set_host(url, "changed-host:9090", strlen("changed-host:9090"));
-  ASSERT_EQ(convert_string(ada_get_host(url)), "changed-host:9090");
+  ada_set_host(out.url, "changed-host:9090", strlen("changed-host:9090"));
+  ASSERT_EQ(convert_string(ada_get_host(out.url)), "changed-host:9090");
 
-  ada_set_pathname(url, "new-pathname", strlen("new-pathname"));
-  ASSERT_EQ(convert_string(ada_get_pathname(url)), "/new-pathname");
+  ada_set_pathname(out.url, "new-pathname", strlen("new-pathname"));
+  ASSERT_EQ(convert_string(ada_get_pathname(out.url)), "/new-pathname");
 
-  ada_set_search(url, "new-search", strlen("new-search"));
-  ASSERT_EQ(convert_string(ada_get_search(url)), "?new-search");
-  ada_clear_search(url);
-  ASSERT_EQ(convert_string(ada_get_search(url)), "");
+  ada_set_search(out.url, "new-search", strlen("new-search"));
+  ASSERT_EQ(convert_string(ada_get_search(out.url)), "?new-search");
+  ada_clear_search(out.url);
+  ASSERT_EQ(convert_string(ada_get_search(out.url)), "");
 
-  ada_set_protocol(url, "wss", 3);
-  ASSERT_EQ(convert_string(ada_get_protocol(url)), "wss:");
+  ada_set_protocol(out.url, "wss", 3);
+  ASSERT_EQ(convert_string(ada_get_protocol(out.url)), "wss:");
 
-  ASSERT_EQ(ada_get_host_type(url), 0);
+  ASSERT_EQ(ada_get_host_type(out.url), 0);
 
-  ada_free(url);
+  ada_free(out.url);
 
   SUCCEED();
 }
@@ -132,15 +132,16 @@ TEST(ada_c, can_parse) {
 
 TEST(ada_c, ada_url_components) {
   std::string input = "https://www.google.com";
-  ada_url url = ada_parse(input.data(), input.length());
-  const ada_url_components* components = ada_get_components(url);
+  ada_parse_result out = ada_parse(input.data(), input.length());
+  ASSERT_TRUE(out.is_valid);
+  const ada_url_components* components = ada_get_components(out.url);
 
   ASSERT_EQ(components->protocol_end, 6);
   ASSERT_EQ(components->port, ada_url_omitted);
   ASSERT_EQ(components->search_start, ada_url_omitted);
   ASSERT_EQ(components->hash_start, ada_url_omitted);
 
-  ada_free(url);
+  ada_free(out.url);
 
   SUCCEED();
 }
@@ -148,15 +149,16 @@ TEST(ada_c, ada_url_components) {
 TEST(ada_c, ada_copy) {
   std::string lemire_blog = "https://lemire.me";
   std::string anonrig_blog = "https://yagiz.co";
-  ada_url first = ada_parse(lemire_blog.data(), lemire_blog.length());
-  ada_url second = ada_copy(first);
+  ada_parse_result first = ada_parse(lemire_blog.data(), lemire_blog.length());
+  ASSERT_TRUE(first.is_valid);
+  ada_url second = ada_copy(first.url);
 
   ASSERT_TRUE(ada_set_href(second, anonrig_blog.data(), anonrig_blog.size()));
 
-  ASSERT_EQ(convert_string(ada_get_href(first)), "https://lemire.me/");
+  ASSERT_EQ(convert_string(ada_get_href(first.url)), "https://lemire.me/");
   ASSERT_EQ(convert_string(ada_get_href(second)), "https://yagiz.co/");
 
-  ada_free(first);
+  ada_free(first.url);
   ada_free(second);
 
   SUCCEED();
@@ -181,31 +183,31 @@ TEST(ada_c, ada_idna) {
 TEST(ada_c, ada_clear_hash) {
   // Make sure a hash attribute with `#` is removed.
   std::string_view input = "https://www.google.com/hello-world?query=1#";
-  ada_url out = ada_parse(input.data(), input.size());
-  ASSERT_TRUE(ada_is_valid(out));
+  ada_parse_result out = ada_parse(input.data(), input.size());
+  ASSERT_TRUE(out.is_valid);
 
-  ada_clear_hash(out);
-  ASSERT_EQ(convert_string(ada_get_hash(out)), "");
-  ASSERT_FALSE(ada_has_hash(out));
-  ASSERT_EQ(convert_string(ada_get_href(out)),
+  ada_clear_hash(out.url);
+  ASSERT_EQ(convert_string(ada_get_hash(out.url)), "");
+  ASSERT_FALSE(ada_has_hash(out.url));
+  ASSERT_EQ(convert_string(ada_get_href(out.url)),
             "https://www.google.com/hello-world?query=1");
 
-  ada_free(out);
+  ada_free(out.url);
   SUCCEED();
 }
 
 TEST(ada_c, ada_clear_search) {
   // Make sure a search attribute with `?` is removed.
   std::string_view input = "https://www.google.com/hello-world?#hash";
-  ada_url out = ada_parse(input.data(), input.size());
-  ASSERT_TRUE(ada_is_valid(out));
+  ada_parse_result out = ada_parse(input.data(), input.size());
+  ASSERT_TRUE(out.is_valid);
 
-  ada_clear_search(out);
-  ASSERT_EQ(convert_string(ada_get_search(out)), "");
-  ASSERT_FALSE(ada_has_search(out));
-  ASSERT_EQ(convert_string(ada_get_href(out)),
+  ada_clear_search(out.url);
+  ASSERT_EQ(convert_string(ada_get_search(out.url)), "");
+  ASSERT_FALSE(ada_has_search(out.url));
+  ASSERT_EQ(convert_string(ada_get_href(out.url)),
             "https://www.google.com/hello-world#hash");
 
-  ada_free(out);
+  ada_free(out.url);
   SUCCEED();
 }


### PR DESCRIPTION
For environments where `ffi` has a cost, calling twice for every parsing operation reduces the performance by 15%. The following should in theory improve the performance.

PS: This is a breaking change. We didn't follow semver in C API until now, but should we?