### PR TITLE
More thorough install check (Linux)

### DIFF
--- a/.github/workflows/ubuntu_install.yml
+++ b/.github/workflows/ubuntu_install.yml
@@ -23,12 +23,17 @@ concurrency:
 jobs:
   ubuntu-build:
     runs-on: ubuntu-22.04
+    strategy:
+    matrix:
+      include:
+        - {shared: ON}
+        - {shared: OFF}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -G Ninja -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
+        run: cmake -G Ninja -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
       - name: Build
         run: cmake --build build -j=2
       - name: Install
@@ -37,3 +42,5 @@ jobs:
         run: cmake -DCMAKE_INSTALL_PREFIX:PATH=../../destination -S tests/installation -B buildbabyada
       - name: Build test package
         run: cmake --build buildbabyada
+      - name: Run example
+        run: ./buildbabyada/babyada


### PR DESCRIPTION
Basically this PR builds a CMake project that depends on ada and *runs* the resulting binary. The current tests do not make sure that that produced binary is runnable.