### PR TITLE
test: reproduce node.js bug

### DIFF
--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -807,7 +807,8 @@ inline bool url_aggregator::has_hostname() const noexcept {
 
 inline bool url_aggregator::has_port() const noexcept {
   ada_log("url_aggregator::has_port");
-  return components.pathname_start != components.host_end;
+  // A URL cannot have a username/password/port if its host is null or the empty string, or its scheme is "file".
+  return has_hostname() && components.pathname_start != components.host_end;
 }
 
 inline bool url_aggregator::has_dash_dot() const noexcept {

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -807,7 +807,8 @@ inline bool url_aggregator::has_hostname() const noexcept {
 
 inline bool url_aggregator::has_port() const noexcept {
   ada_log("url_aggregator::has_port");
-  // A URL cannot have a username/password/port if its host is null or the empty string, or its scheme is "file".
+  // A URL cannot have a username/password/port if its host is null or the empty
+  // string, or its scheme is "file".
   return has_hostname() && components.pathname_start != components.host_end;
 }
 

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -55,7 +55,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
     }
 
     // Let host be the result of host parsing host_view with url is not special.
-    if (host_view.empty()) {
+    if (host_view.empty() && !is_special()) {
       host = "";
       return true;
     }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -552,13 +552,12 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // empty string, and either url includes credentials or url's port is
     // non-null, return.
     else if (host_view.empty() &&
-             (is_special() || has_credentials() ||
-              components.port != url_components::omitted)) {
+             (is_special() || has_credentials() || has_port())) {
       return false;
     }
 
     // Let host be the result of host parsing host_view with url is not special.
-    if (host_view.empty()) {
+    if (host_view.empty() && !is_special()) {
       if (has_hostname()) {
         clear_hostname();  // easy!
       } else if (has_dash_dot()) {

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -378,3 +378,12 @@ TYPED_TEST(basic_tests, url_host_type) {
       ada::url_host_type::IPV6);
   SUCCEED();
 }
+
+// https://github.com/nodejs/node/issues/49650
+TYPED_TEST(basic_tests, nodejs_49650) {
+  auto out = ada::parse<TypeParam>("http://foo");
+  ASSERT_TRUE(out);
+  ASSERT_FALSE(out->set_host("::"));
+  ASSERT_EQ(out->get_href(), "http://foo/");
+  SUCCEED();
+}


### PR DESCRIPTION
Passing `set_host("::")` produces invalid URL. Therefore, it is causing Node.js to fail on the next setter.

PS: Safari doesn't have this bug.

```
{
	const url = new URL('http://foo')
	url.host = '::' // does *not* crash
	url.port = 3000 // crashes with the described error below
}
```

Ref: https://github.com/nodejs/node/issues/49650