### PR TITLE
std::equal is not necessarily constexpr in C++17

### DIFF
--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -54,9 +54,10 @@ inline constexpr bool is_normalized_windows_drive_letter(
   return input.size() >= 2 && (is_alpha(input[0]) && (input[1] == ':'));
 }
 
-ada_really_inline constexpr bool begins_with(std::string_view view,
+ada_really_inline bool begins_with(std::string_view view,
                                              std::string_view prefix) {
   // in C++20, you have view.begins_with(prefix)
+  // std::equal is constexpr in C++20
   return view.size() >= prefix.size() &&
          std::equal(prefix.begin(), prefix.end(), view.begin());
 }

--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -55,7 +55,7 @@ inline constexpr bool is_normalized_windows_drive_letter(
 }
 
 ada_really_inline bool begins_with(std::string_view view,
-                                             std::string_view prefix) {
+                                   std::string_view prefix) {
   // in C++20, you have view.begins_with(prefix)
   // std::equal is constexpr in C++20
   return view.size() >= prefix.size() &&

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -70,9 +70,9 @@ inline constexpr bool is_normalized_windows_drive_letter(
     std::string_view input) noexcept;
 
 /**
- * @warning Will be removed when Ada supports C++20.
+ * @warning Will be removed when Ada requires C++20.
  */
-ada_really_inline constexpr bool begins_with(std::string_view view,
+ada_really_inline bool begins_with(std::string_view view,
                                              std::string_view prefix);
 
 /**

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -73,7 +73,7 @@ inline constexpr bool is_normalized_windows_drive_letter(
  * @warning Will be removed when Ada requires C++20.
  */
 ada_really_inline bool begins_with(std::string_view view,
-                                             std::string_view prefix);
+                                   std::string_view prefix);
 
 /**
  * Returns true if an input is an ipv4 address.


### PR DESCRIPTION
std::equal is not necessarily constexpr in C++17, so PR  https://github.com/ada-url/ada/pull/474 broke ada technically.

I am removing the constexpr qualifier for now.

See https://en.cppreference.com/w/cpp/algorithm/equal