### PR TITLE
Warning fixes

### DIFF
--- a/include/ada/ada_idna.h
+++ b/include/ada/ada_idna.h
@@ -88,7 +88,7 @@ namespace ada::idna {
 /**
  * @see https://www.unicode.org/reports/tr46/#Validity_Criteria
  */
-bool is_label_valid(const std::u32string_view label);
+bool is_label_valid(std::u32string_view label);
 
 }  // namespace ada::idna
 

--- a/include/ada/character_sets-inl.h
+++ b/include/ada/character_sets-inl.h
@@ -507,7 +507,7 @@ constexpr uint8_t WWW_FORM_URLENCODED_PERCENT_ENCODE[32] = {
     // F8     F9     FA     FB     FC     FD     FE     FF
     0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 | 0x40 | 0x80};
 
-ada_really_inline bool bit_at(const uint8_t a[], const uint8_t i) {
+ada_really_inline bool bit_at(const std::uint8_t a[], const std::uint8_t i) {
   return !!(a[i >> 3] & (1 << (i & 7)));
 }
 

--- a/include/ada/character_sets-inl.h
+++ b/include/ada/character_sets-inl.h
@@ -507,10 +507,10 @@ constexpr uint8_t WWW_FORM_URLENCODED_PERCENT_ENCODE[32] = {
     // F8     F9     FA     FB     FC     FD     FE     FF
     0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 | 0x40 | 0x80};
 
-ada_really_inline bool bit_at(const std::uint8_t a[], const std::uint8_t i) {
+ada_really_inline bool bit_at(const uint8_t a[], const uint8_t i) {
   return !!(a[i >> 3] & (1 << (i & 7)));
 }
 
 }  // namespace ada::character_sets
 
-#endif  // ADA_CHARACTER_SETS_H
+#endif  // ADA_CHARACTER_SETS_INL_H

--- a/include/ada/character_sets.h
+++ b/include/ada/character_sets.h
@@ -15,7 +15,7 @@
  * @brief Includes the definitions for unicode character sets.
  */
 namespace ada::character_sets {
-ada_really_inline bool bit_at(const std::uint8_t a[], std::uint8_t i);
+ada_really_inline bool bit_at(const uint8_t a[], uint8_t i);
 }  // namespace ada::character_sets
 
 #endif  // ADA_CHARACTER_SETS_H

--- a/include/ada/character_sets.h
+++ b/include/ada/character_sets.h
@@ -8,14 +8,14 @@
 #define ADA_CHARACTER_SETS_H
 
 #include "ada/common_defs.h"
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * @namespace ada::character_sets
  * @brief Includes the definitions for unicode character sets.
  */
 namespace ada::character_sets {
-ada_really_inline bool bit_at(const uint8_t a[], const uint8_t i);
+ada_really_inline bool bit_at(const std::uint8_t a[], std::uint8_t i);
 }  // namespace ada::character_sets
 
 #endif  // ADA_CHARACTER_SETS_H

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -70,7 +70,7 @@ ada_really_inline bool shorten_path(std::string_view& path,
  *
  * @see https://url.spec.whatwg.org/
  */
-ada_really_inline void parse_prepared_path(const std::string_view input,
+ada_really_inline void parse_prepared_path(std::string_view input,
                                            ada::scheme::type type,
                                            std::string& path);
 

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -60,4 +60,4 @@ constexpr ada::scheme::type get_scheme_type(std::string_view scheme) noexcept {
 
 }  // namespace ada::scheme
 
-#endif  // ADA_SCHEME_H
+#endif  // ADA_SCHEME_INL_H

--- a/include/ada/serializers.h
+++ b/include/ada/serializers.h
@@ -38,7 +38,7 @@ std::string ipv6(const std::array<uint16_t, 8>& address) noexcept;
  * network address.
  * @see https://url.spec.whatwg.org/#concept-ipv4-serializer
  */
-std::string ipv4(const uint64_t address) noexcept;
+std::string ipv4(uint64_t address) noexcept;
 
 }  // namespace ada::serializers
 

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -78,8 +78,7 @@ ada_really_inline bool has_tabs_or_newline(
  * Checks if the input is a forbidden host code point.
  * @see https://url.spec.whatwg.org/#forbidden-host-code-point
  */
-ada_really_inline constexpr bool is_forbidden_host_code_point(
-    char c) noexcept;
+ada_really_inline constexpr bool is_forbidden_host_code_point(char c) noexcept;
 
 /**
  * Checks if the input contains a forbidden domain code point.

--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -79,7 +79,7 @@ ada_really_inline bool has_tabs_or_newline(
  * @see https://url.spec.whatwg.org/#forbidden-host-code-point
  */
 ada_really_inline constexpr bool is_forbidden_host_code_point(
-    const char c) noexcept;
+    char c) noexcept;
 
 /**
  * Checks if the input contains a forbidden domain code point.
@@ -103,12 +103,12 @@ contains_forbidden_domain_code_point_or_upper(const char* input,
  * @see https://url.spec.whatwg.org/#forbidden-domain-code-point
  */
 ada_really_inline constexpr bool is_forbidden_domain_code_point(
-    const char c) noexcept;
+    char c) noexcept;
 
 /**
  * Checks if the input is alphanumeric, '+', '-' or '.'
  */
-ada_really_inline constexpr bool is_alnum_plus(const char c) noexcept;
+ada_really_inline constexpr bool is_alnum_plus(char c) noexcept;
 
 /**
  * @details An ASCII hex digit is an ASCII upper hex digit or ASCII lower hex
@@ -116,7 +116,7 @@ ada_really_inline constexpr bool is_alnum_plus(const char c) noexcept;
  * range U+0041 (A) to U+0046 (F), inclusive. An ASCII lower hex digit is an
  * ASCII digit or a code point in the range U+0061 (a) to U+0066 (f), inclusive.
  */
-ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept;
+ada_really_inline constexpr bool is_ascii_hex_digit(char c) noexcept;
 
 /**
  * Checks if the input is a C0 control or space character.
@@ -125,33 +125,33 @@ ada_really_inline constexpr bool is_ascii_hex_digit(const char c) noexcept;
  * A C0 control is a code point in the range U+0000 NULL to U+001F INFORMATION
  * SEPARATOR ONE, inclusive.
  */
-ada_really_inline constexpr bool is_c0_control_or_space(const char c) noexcept;
+ada_really_inline constexpr bool is_c0_control_or_space(char c) noexcept;
 
 /**
  * Checks if the input is a ASCII tab or newline character.
  *
  * @details An ASCII tab or newline is U+0009 TAB, U+000A LF, or U+000D CR.
  */
-ada_really_inline constexpr bool is_ascii_tab_or_newline(const char c) noexcept;
+ada_really_inline constexpr bool is_ascii_tab_or_newline(char c) noexcept;
 
 /**
  * @details A double-dot path segment must be ".." or an ASCII case-insensitive
  * match for ".%2e", "%2e.", or "%2e%2e".
  */
 ada_really_inline ada_constexpr bool is_double_dot_path_segment(
-    const std::string_view input) noexcept;
+    std::string_view input) noexcept;
 
 /**
  * @details A single-dot path segment must be "." or an ASCII case-insensitive
  * match for "%2e".
  */
 ada_really_inline constexpr bool is_single_dot_path_segment(
-    const std::string_view input) noexcept;
+    std::string_view input) noexcept;
 
 /**
  * @details ipv4 character might contain 0-9 or a-f character ranges.
  */
-ada_really_inline constexpr bool is_lowercase_hex(const char c) noexcept;
+ada_really_inline constexpr bool is_lowercase_hex(char c) noexcept;
 
 /**
  * @details Convert hex to binary. Caller is responsible to ensure that
@@ -167,20 +167,20 @@ ada_really_inline unsigned constexpr convert_hex_to_binary(char c) noexcept;
  * @see https://github.com/nodejs/node/blob/main/src/node_url.cc#L245
  * @see https://encoding.spec.whatwg.org/#utf-8-decode-without-bom
  */
-std::string percent_decode(const std::string_view input, size_t first_percent);
+std::string percent_decode(std::string_view input, size_t first_percent);
 
 /**
  * Returns a percent-encoding string whether percent encoding was needed or not.
  * @see https://github.com/nodejs/node/blob/main/src/node_url.cc#L226
  */
-std::string percent_encode(const std::string_view input,
+std::string percent_encode(std::string_view input,
                            const uint8_t character_set[]);
 /**
  * Returns a percent-encoded string version of input, while starting the percent
  * encoding at the provided index.
  * @see https://github.com/nodejs/node/blob/main/src/node_url.cc#L226
  */
-std::string percent_encode(const std::string_view input,
+std::string percent_encode(std::string_view input,
                            const uint8_t character_set[], size_t index);
 /**
  * Returns true if percent encoding was needed, in which case, we store
@@ -190,13 +190,13 @@ std::string percent_encode(const std::string_view input,
  * @see https://github.com/nodejs/node/blob/main/src/node_url.cc#L226
  */
 template <bool append>
-bool percent_encode(const std::string_view input, const uint8_t character_set[],
+bool percent_encode(std::string_view input, const uint8_t character_set[],
                     std::string& out);
 /**
  * Returns the index at which percent encoding should start, or (equivalently),
  * the length of the prefix that does not require percent encoding.
  */
-ada_really_inline size_t percent_encode_index(const std::string_view input,
+ada_really_inline size_t percent_encode_index(std::string_view input,
                                               const uint8_t character_set[]);
 /**
  * Lowers the string in-place, assuming that the content is ASCII.

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -39,7 +39,7 @@ inline std::ostream &operator<<(std::ostream &out, const ada::url &u) {
   return out << u.to_string();
 }
 
-size_t url::get_pathname_length() const noexcept { return path.size(); }
+[[nodiscard]] size_t url::get_pathname_length() const noexcept { return path.size(); }
 
 [[nodiscard]] ada_really_inline ada::url_components url::get_components()
     const noexcept {

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -39,7 +39,9 @@ inline std::ostream &operator<<(std::ostream &out, const ada::url &u) {
   return out << u.to_string();
 }
 
-[[nodiscard]] size_t url::get_pathname_length() const noexcept { return path.size(); }
+[[nodiscard]] size_t url::get_pathname_length() const noexcept {
+  return path.size();
+}
 
 [[nodiscard]] ada_really_inline ada::url_components url::get_components()
     const noexcept {

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -349,9 +349,8 @@ struct url : url_base {
    */
   [[nodiscard]] inline bool cannot_have_credentials_or_port() const;
 
-  ada_really_inline size_t
-  parse_port(std::string_view view,
-             bool check_trailing_content) noexcept override;
+  ada_really_inline size_t parse_port(
+      std::string_view view, bool check_trailing_content) noexcept override;
 
   ada_really_inline size_t parse_port(std::string_view view) noexcept override {
     return this->parse_port(view, false);
@@ -374,8 +373,7 @@ struct url : url_base {
   [[nodiscard]] ada_really_inline bool parse_host(std::string_view input);
 
   template <bool has_state_override = false>
-  [[nodiscard]] ada_really_inline bool parse_scheme(
-      std::string_view input);
+  [[nodiscard]] ada_really_inline bool parse_scheme(std::string_view input);
 
   inline void clear_pathname() override;
   inline void clear_search() override;

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -41,7 +41,7 @@ struct url : url_base {
   url(url &&u) noexcept = default;
   url &operator=(url &&u) noexcept = default;
   url &operator=(const url &u) = default;
-  ~url() = default;
+  ~url() override = default;
 
   /**
    * @private
@@ -102,7 +102,7 @@ struct url : url_base {
   /**
    * Returns a JSON string representation of this URL.
    */
-  std::string to_string() const override;
+  [[nodiscard]] std::string to_string() const override;
 
   /**
    * @see https://url.spec.whatwg.org/#dom-url-href
@@ -149,7 +149,7 @@ struct url : url_base {
    * @return a newly allocated string.
    * @see https://url.spec.whatwg.org/#dom-url-pathname
    */
-  [[nodiscard]] const std::string_view get_pathname() const noexcept;
+  [[nodiscard]] std::string_view get_pathname() const noexcept;
 
   /**
    * Compute the pathname length in bytes without instantiating a view or a
@@ -157,7 +157,7 @@ struct url : url_base {
    * @return size of the pathname in bytes
    * @see https://url.spec.whatwg.org/#dom-url-pathname
    */
-  ada_really_inline size_t get_pathname_length() const noexcept;
+  [[nodiscard]] ada_really_inline size_t get_pathname_length() const noexcept;
 
   /**
    * Return U+003F (?), followed by this's URL's query.
@@ -177,60 +177,60 @@ struct url : url_base {
    * @return Returns true on successful operation.
    * @see https://url.spec.whatwg.org/#dom-url-username
    */
-  bool set_username(const std::string_view input);
+  bool set_username(std::string_view input);
 
   /**
    * @return Returns true on success.
    * @see https://url.spec.whatwg.org/#dom-url-password
    */
-  bool set_password(const std::string_view input);
+  bool set_password(std::string_view input);
 
   /**
    * @return Returns true on success.
    * @see https://url.spec.whatwg.org/#dom-url-port
    */
-  bool set_port(const std::string_view input);
+  bool set_port(std::string_view input);
 
   /**
    * This function always succeeds.
    * @see https://url.spec.whatwg.org/#dom-url-hash
    */
-  void set_hash(const std::string_view input);
+  void set_hash(std::string_view input);
 
   /**
    * This function always succeeds.
    * @see https://url.spec.whatwg.org/#dom-url-search
    */
-  void set_search(const std::string_view input);
+  void set_search(std::string_view input);
 
   /**
    * @return Returns true on success.
    * @see https://url.spec.whatwg.org/#dom-url-search
    */
-  bool set_pathname(const std::string_view input);
+  bool set_pathname(std::string_view input);
 
   /**
    * @return Returns true on success.
    * @see https://url.spec.whatwg.org/#dom-url-host
    */
-  bool set_host(const std::string_view input);
+  bool set_host(std::string_view input);
 
   /**
    * @return Returns true on success.
    * @see https://url.spec.whatwg.org/#dom-url-hostname
    */
-  bool set_hostname(const std::string_view input);
+  bool set_hostname(std::string_view input);
 
   /**
    * @return Returns true on success.
    * @see https://url.spec.whatwg.org/#dom-url-protocol
    */
-  bool set_protocol(const std::string_view input);
+  bool set_protocol(std::string_view input);
 
   /**
    * @see https://url.spec.whatwg.org/#dom-url-href
    */
-  bool set_href(const std::string_view input);
+  bool set_href(std::string_view input);
 
   /**
    * The password getter steps are to return this's URL's password.
@@ -301,9 +301,9 @@ struct url : url_base {
   inline void update_base_search(std::string_view input,
                                  const uint8_t query_percent_encode_set[]);
   inline void update_base_search(std::optional<std::string> input);
-  inline void update_base_pathname(const std::string_view input);
-  inline void update_base_username(const std::string_view input);
-  inline void update_base_password(const std::string_view input);
+  inline void update_base_pathname(std::string_view input);
+  inline void update_base_username(std::string_view input);
+  inline void update_base_password(std::string_view input);
   inline void update_base_port(std::optional<uint16_t> input);
 
   /**
@@ -351,7 +351,11 @@ struct url : url_base {
 
   ada_really_inline size_t
   parse_port(std::string_view view,
-             bool check_trailing_content = false) noexcept override;
+             bool check_trailing_content) noexcept override;
+
+  ada_really_inline size_t parse_port(std::string_view view) noexcept override {
+    return this->parse_port(view, false);
+  }
 
   /**
    * Take the scheme from another URL. The scheme string is copied from the
@@ -371,7 +375,7 @@ struct url : url_base {
 
   template <bool has_state_override = false>
   [[nodiscard]] ada_really_inline bool parse_scheme(
-      const std::string_view input);
+      std::string_view input);
 
   inline void clear_pathname() override;
   inline void clear_search() override;
@@ -387,7 +391,7 @@ struct url : url_base {
    *
    * @see https://url.spec.whatwg.org/
    */
-  ada_really_inline void parse_path(const std::string_view input);
+  ada_really_inline void parse_path(std::string_view input);
 
   /**
    * Set the scheme for this URL. The provided scheme should be a valid

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -833,7 +833,8 @@ inline bool url_aggregator::has_port() const noexcept {
          components.pathname_start + 1 < buffer.size();
 }
 
-[[nodiscard]] inline std::string_view url_aggregator::get_href() const noexcept {
+[[nodiscard]] inline std::string_view url_aggregator::get_href()
+    const noexcept {
   ada_log("url_aggregator::get_href");
   return buffer;
 }

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -152,7 +152,7 @@ inline void url_aggregator::update_base_hostname(const std::string_view input) {
   ADA_ASSERT_TRUE(validate());
 }
 
-ada_really_inline uint32_t
+[[nodiscard]] ada_really_inline uint32_t
 url_aggregator::get_pathname_length() const noexcept {
   ada_log("url_aggregator::get_pathname_length");
   uint32_t ending_index = uint32_t(buffer.size());
@@ -587,7 +587,7 @@ inline void url_aggregator::clear_port() {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline uint32_t url_aggregator::retrieve_base_port() const {
+[[nodiscard]] inline uint32_t url_aggregator::retrieve_base_port() const {
   ada_log("url_aggregator::retrieve_base_port");
   return components.port;
 }
@@ -812,7 +812,7 @@ inline bool url_aggregator::has_port() const noexcept {
   return has_hostname() && components.pathname_start != components.host_end;
 }
 
-inline bool url_aggregator::has_dash_dot() const noexcept {
+[[nodiscard]] inline bool url_aggregator::has_dash_dot() const noexcept {
   // If url's host is null, url does not have an opaque path, url's path's size
   // is greater than 1, and url's path[0] is the empty string, then append
   // U+002F (/) followed by U+002E (.) to output.
@@ -833,7 +833,7 @@ inline bool url_aggregator::has_dash_dot() const noexcept {
          components.pathname_start + 1 < buffer.size();
 }
 
-inline std::string_view url_aggregator::get_href() const noexcept {
+[[nodiscard]] inline std::string_view url_aggregator::get_href() const noexcept {
   ada_log("url_aggregator::get_href");
   return buffer;
 }

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -224,14 +224,12 @@ struct url_aggregator : url_base {
    */
   inline void reserve(uint32_t capacity);
 
-  ada_really_inline size_t
-  parse_port(std::string_view view,
-             bool check_trailing_content) noexcept override;
+  ada_really_inline size_t parse_port(
+      std::string_view view, bool check_trailing_content) noexcept override;
 
   ada_really_inline size_t parse_port(std::string_view view) noexcept override {
     return this->parse_port(view, false);
   }
-
 
   /**
    * Return true on success.

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -28,18 +28,18 @@ struct url_aggregator : url_base {
   url_aggregator(url_aggregator &&u) noexcept = default;
   url_aggregator &operator=(url_aggregator &&u) noexcept = default;
   url_aggregator &operator=(const url_aggregator &u) = default;
-  ~url_aggregator() = default;
+  ~url_aggregator() override = default;
 
-  bool set_href(const std::string_view input);
-  bool set_host(const std::string_view input);
-  bool set_hostname(const std::string_view input);
-  bool set_protocol(const std::string_view input);
-  bool set_username(const std::string_view input);
-  bool set_password(const std::string_view input);
-  bool set_port(const std::string_view input);
-  bool set_pathname(const std::string_view input);
-  void set_search(const std::string_view input);
-  void set_hash(const std::string_view input);
+  bool set_href(std::string_view input);
+  bool set_host(std::string_view input);
+  bool set_hostname(std::string_view input);
+  bool set_protocol(std::string_view input);
+  bool set_username(std::string_view input);
+  bool set_password(std::string_view input);
+  bool set_port(std::string_view input);
+  bool set_pathname(std::string_view input);
+  void set_search(std::string_view input);
+  void set_hash(std::string_view input);
 
   [[nodiscard]] bool has_valid_domain() const noexcept override;
   /**
@@ -57,7 +57,7 @@ struct url_aggregator : url_base {
    * @see https://url.spec.whatwg.org/#dom-url-href
    * @see https://url.spec.whatwg.org/#concept-url-serializer
    */
-  inline std::string_view get_href() const noexcept;
+  [[nodiscard]] inline std::string_view get_href() const noexcept;
   /**
    * The username getter steps are to return this's URL's username.
    * This function does not allocate memory.
@@ -117,7 +117,7 @@ struct url_aggregator : url_base {
    * @return size of the pathname in bytes
    * @see https://url.spec.whatwg.org/#dom-url-pathname
    */
-  ada_really_inline uint32_t get_pathname_length() const noexcept;
+  [[nodiscard]] ada_really_inline uint32_t get_pathname_length() const noexcept;
   /**
    * Return U+003F (?), followed by this's URL's query.
    * This function does not allocate memory.
@@ -166,18 +166,18 @@ struct url_aggregator : url_base {
   /**
    * Returns a string representation of this URL.
    */
-  std::string to_string() const override;
+  [[nodiscard]] std::string to_string() const override;
   /**
    * Returns a string diagram of this URL.
    */
-  std::string to_diagram() const;
+  [[nodiscard]] std::string to_diagram() const;
 
   /**
    * Verifies that the parsed URL could be valid. Useful for debugging purposes.
    * @return true if the URL is valid, otherwise return true of the offsets are
    * possible.
    */
-  bool validate() const noexcept;
+  [[nodiscard]] bool validate() const noexcept;
 
   /** @return true if it has an host but it is the empty string */
   [[nodiscard]] inline bool has_empty_hostname() const noexcept;
@@ -226,7 +226,12 @@ struct url_aggregator : url_base {
 
   ada_really_inline size_t
   parse_port(std::string_view view,
-             bool check_trailing_content = false) noexcept override;
+             bool check_trailing_content) noexcept override;
+
+  ada_really_inline size_t parse_port(std::string_view view) noexcept override {
+    return this->parse_port(view, false);
+  }
+
 
   /**
    * Return true on success.
@@ -255,7 +260,7 @@ struct url_aggregator : url_base {
   [[nodiscard]] inline bool cannot_have_credentials_or_port() const;
 
   template <bool override_hostname = false>
-  bool set_host_or_hostname(const std::string_view input);
+  bool set_host_or_hostname(std::string_view input);
 
   ada_really_inline bool parse_host(std::string_view input);
 
@@ -266,26 +271,26 @@ struct url_aggregator : url_base {
   inline void update_base_search(std::string_view input);
   inline void update_base_search(std::string_view input,
                                  const uint8_t *query_percent_encode_set);
-  inline void update_base_pathname(const std::string_view input);
-  inline void update_base_username(const std::string_view input);
-  inline void append_base_username(const std::string_view input);
-  inline void update_base_password(const std::string_view input);
-  inline void append_base_password(const std::string_view input);
+  inline void update_base_pathname(std::string_view input);
+  inline void update_base_username(std::string_view input);
+  inline void append_base_username(std::string_view input);
+  inline void update_base_password(std::string_view input);
+  inline void append_base_password(std::string_view input);
   inline void update_base_port(uint32_t input);
-  inline void append_base_pathname(const std::string_view input);
-  inline uint32_t retrieve_base_port() const;
+  inline void append_base_pathname(std::string_view input);
+  [[nodiscard]] inline uint32_t retrieve_base_port() const;
   inline void clear_hostname();
   inline void clear_password();
   inline void clear_pathname() override;
-  inline bool has_dash_dot() const noexcept;
+  [[nodiscard]] inline bool has_dash_dot() const noexcept;
   void delete_dash_dot();
   inline void consume_prepared_path(std::string_view input);
   template <bool has_state_override = false>
   [[nodiscard]] ada_really_inline bool parse_scheme_with_colon(
-      const std::string_view input);
+      std::string_view input);
   ada_really_inline uint32_t replace_and_resize(uint32_t start, uint32_t end,
                                                 std::string_view input);
-  inline bool has_authority() const noexcept;
+  [[nodiscard]] inline bool has_authority() const noexcept;
   inline void set_protocol_as_file();
   inline void set_scheme(std::string_view new_scheme) noexcept;
   /**

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -112,12 +112,17 @@ struct url_base {
    * @see https://url.spec.whatwg.org/#host-parsing
    */
   virtual ada_really_inline size_t parse_port(
-      std::string_view view, bool check_trailing_content = false) noexcept = 0;
+      std::string_view view, bool check_trailing_content) noexcept = 0;
+
+
+  virtual ada_really_inline size_t parse_port(std::string_view view) noexcept {
+    return this->parse_port(view, false);
+  }
 
   /**
    * Returns a JSON string representation of this URL.
    */
-  virtual std::string to_string() const = 0;
+  [[nodiscard]] virtual std::string to_string() const = 0;
 
   /** @private */
   virtual inline void clear_pathname() = 0;
@@ -126,10 +131,10 @@ struct url_base {
   virtual inline void clear_search() = 0;
 
   /** @private */
-  virtual inline bool has_hash() const noexcept = 0;
+  [[nodiscard]] virtual inline bool has_hash() const noexcept = 0;
 
   /** @private */
-  virtual inline bool has_search() const noexcept = 0;
+  [[nodiscard]] virtual inline bool has_search() const noexcept = 0;
 
 };  // url_base
 

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -111,9 +111,8 @@ struct url_base {
    * @return On failure, it returns zero.
    * @see https://url.spec.whatwg.org/#host-parsing
    */
-  virtual ada_really_inline size_t parse_port(
-      std::string_view view, bool check_trailing_content) noexcept = 0;
-
+  virtual ada_really_inline size_t
+  parse_port(std::string_view view, bool check_trailing_content) noexcept = 0;
 
   virtual ada_really_inline size_t parse_port(std::string_view view) noexcept {
     return this->parse_port(view, false);

--- a/include/ada/url_components.h
+++ b/include/ada/url_components.h
@@ -67,12 +67,12 @@ struct url_components {
    * @return true if the offset values are
    *  consistent with a possible URL string
    */
-  bool check_offset_consistency() const noexcept;
+  [[nodiscard]] bool check_offset_consistency() const noexcept;
 
   /**
    * Converts a url_components to JSON stringified version.
    */
-  std::string to_string() const;
+  [[nodiscard]] std::string to_string() const;
 
 };  // struct url_components
 

--- a/src/url-getters.cpp
+++ b/src/url-getters.cpp
@@ -63,7 +63,7 @@ namespace ada {
   return host.value_or("");
 }
 
-[[nodiscard]] const std::string_view url::get_pathname() const noexcept {
+[[nodiscard]] std::string_view url::get_pathname() const noexcept {
   return path;
 }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -529,10 +529,9 @@ ada_really_inline void url::parse_path(std::string_view input) {
       path = "/";
     }
   }
-  return;
 }
 
-std::string url::to_string() const {
+[[nodiscard]] std::string url::to_string() const {
   if (!is_valid) {
     return "null";
   }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -753,7 +753,7 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   return helpers::substring(buffer, 0, components.protocol_end);
 }
 
-std::string ada::url_aggregator::to_string() const {
+[[nodiscard]] std::string ada::url_aggregator::to_string() const {
   ada_log("url_aggregator::to_string buffer:", buffer, "[", buffer.size(),
           " bytes]");
   if (!is_valid) {
@@ -1198,7 +1198,7 @@ bool url_aggregator::parse_opaque_host(std::string_view input) {
   return true;
 }
 
-std::string url_aggregator::to_diagram() const {
+[[nodiscard]] std::string url_aggregator::to_diagram() const {
   if (!is_valid) {
     return "invalid";
   }
@@ -1355,7 +1355,7 @@ std::string url_aggregator::to_diagram() const {
   return answer;
 }
 
-bool url_aggregator::validate() const noexcept {
+[[nodiscard]] bool url_aggregator::validate() const noexcept {
   if (!is_valid) {
     return true;
   }

--- a/src/url_components.cpp
+++ b/src/url_components.cpp
@@ -7,7 +7,7 @@
 
 namespace ada {
 
-bool url_components::check_offset_consistency() const noexcept {
+[[nodiscard]] bool url_components::check_offset_consistency() const noexcept {
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
    *       |     |    |          | ^^^^|       |   |
@@ -83,7 +83,7 @@ bool url_components::check_offset_consistency() const noexcept {
   return true;
 }
 
-std::string url_components::to_string() const {
+[[nodiscard]] std::string url_components::to_string() const {
   std::string answer;
   auto back = std::back_insert_iterator(answer);
   answer.append("{\n");


### PR DESCRIPTION
- const-qualified in the function declaration; const-qualification of parameters only has an effect in function definitions
- Some `[[nodiscard]]`s added
- default argument for `parse_port` which is a virtual function is not recommended, I changed it to two different functions
- using `<cstdint>` instead of `<stdint.h>`
- Adding `override` for virtual destructors
- Small changes like comment mismatch fixes and useless "return" statement removal