### PR TITLE
Build the string directly instead of copying and then pruning tabs or newlines

### DIFF
--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -84,8 +84,8 @@ ada_really_inline void remove_ascii_tab_or_newline(std::string& input) noexcept;
  * @private
  * Create a new string that all ASCII tab or newline characters are removed.
  */
-ada_really_inline std::string get_ascii_tab_or_newline_removed(
-    std::string_view input) noexcept;
+[[nodiscard]] ada_really_inline std::string get_ascii_tab_or_newline_removed(
+    std::string_view input);
 
 /**
  * @private

--- a/include/ada/helpers.h
+++ b/include/ada/helpers.h
@@ -82,6 +82,13 @@ ada_really_inline void remove_ascii_tab_or_newline(std::string& input) noexcept;
 
 /**
  * @private
+ * Create a new string that all ASCII tab or newline characters are removed.
+ */
+ada_really_inline std::string get_ascii_tab_or_newline_removed(
+    std::string_view input) noexcept;
+
+/**
+ * @private
  * Return the substring from input going from index pos to the end.
  * This function cannot throw.
  */

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -161,7 +161,7 @@ ada_really_inline void remove_ascii_tab_or_newline(
 }
 
 ada_really_inline std::string get_ascii_tab_or_newline_removed(
-    std::string_view input) noexcept {
+    std::string_view input) {
   std::string res;
   res.reserve(input.size());
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <charconv>
 #include <cstring>
+#include <iterator>
 #include <sstream>
 
 namespace ada::helpers {
@@ -155,10 +156,19 @@ ada_really_inline void remove_ascii_tab_or_newline(
   // if this ever becomes a performance issue, we could use an approach similar
   // to has_tabs_or_newline
   input.erase(std::remove_if(input.begin(), input.end(),
-                             [](char c) {
-                               return ada::unicode::is_ascii_tab_or_newline(c);
-                             }),
+                             ada::unicode::is_ascii_tab_or_newline),
               input.end());
+}
+
+ada_really_inline std::string get_ascii_tab_or_newline_removed(
+    std::string_view input) noexcept {
+  std::string res;
+  res.reserve(input.size());
+
+  std::copy_if(input.begin(), input.end(), std::back_insert_iterator{res},
+               std::not_fn(ada::unicode::is_ascii_tab_or_newline));
+
+  return res;
 }
 
 ada_really_inline std::string_view substring(std::string_view input,

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -25,12 +25,9 @@ template ada::result<url_aggregator> parse<url_aggregator>(
 
 std::string href_from_file(std::string_view input) {
   // This is going to be much faster than constructing a URL.
-  std::string tmp_buffer;
   std::string_view internal_input;
   if (unicode::has_tabs_or_newline(input)) {
-    tmp_buffer = input;
-    helpers::remove_ascii_tab_or_newline(tmp_buffer);
-    internal_input = tmp_buffer;
+    internal_input = helpers::get_ascii_tab_or_newline_removed(input);
   } else {
     internal_input = input;
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,7 @@
 #include "ada.h"
 #include "ada/common_defs.h"
 #include "ada/character_sets-inl.h"
+#include "ada/helpers.h"
 #include "ada/unicode.h"
 #include "ada/url-inl.h"
 #include "ada/log.h"
@@ -69,14 +70,9 @@ result_type parse_url(std::string_view user_input,
     //
     //
   }
-  std::string tmp_buffer;
   std::string_view internal_input;
   if (unicode::has_tabs_or_newline(user_input)) {
-    tmp_buffer = user_input;
-    // Optimization opportunity: Instead of copying and then pruning, we could
-    // just directly build the string from user_input.
-    helpers::remove_ascii_tab_or_newline(tmp_buffer);
-    internal_input = tmp_buffer;
+    internal_input = helpers::get_ascii_tab_or_newline_removed(user_input);
   } else {
     internal_input = user_input;
   }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -495,7 +495,7 @@ ada_really_inline void url::parse_path(std::string_view input) {
   ada_log("parse_path ", input);
   std::string_view internal_input;
   if (unicode::has_tabs_or_newline(input)) {
-    internal_input = helpers::get_ascii_tab_or_newline_removed(user_input);
+    internal_input = helpers::get_ascii_tab_or_newline_removed(input);
   } else {
     internal_input = input;
   }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -493,14 +493,9 @@ ada_really_inline bool url::parse_host(std::string_view input) {
 
 ada_really_inline void url::parse_path(std::string_view input) {
   ada_log("parse_path ", input);
-  std::string tmp_buffer;
   std::string_view internal_input;
   if (unicode::has_tabs_or_newline(input)) {
-    tmp_buffer = input;
-    // Optimization opportunity: Instead of copying and then pruning, we could
-    // just directly build the string from user_input.
-    helpers::remove_ascii_tab_or_newline(tmp_buffer);
-    internal_input = tmp_buffer;
+    internal_input = helpers::get_ascii_tab_or_newline_removed(user_input);
   } else {
     internal_input = input;
   }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -330,14 +330,9 @@ ada_really_inline void url_aggregator::parse_path(std::string_view input) {
   ada_log("url_aggregator::parse_path ", input);
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
-  std::string tmp_buffer;
   std::string_view internal_input;
   if (unicode::has_tabs_or_newline(input)) {
-    tmp_buffer = input;
-    // Optimization opportunity: Instead of copying and then pruning, we could
-    // just directly build the string from user_input.
-    helpers::remove_ascii_tab_or_newline(tmp_buffer);
-    internal_input = tmp_buffer;
+    internal_input = helpers::get_ascii_tab_or_newline_removed(user_input);
   } else {
     internal_input = input;
   }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -332,7 +332,7 @@ ada_really_inline void url_aggregator::parse_path(std::string_view input) {
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
   std::string_view internal_input;
   if (unicode::has_tabs_or_newline(input)) {
-    internal_input = helpers::get_ascii_tab_or_newline_removed(user_input);
+    internal_input = helpers::get_ascii_tab_or_newline_removed(input);
   } else {
     internal_input = input;
   }


### PR DESCRIPTION
Following the comment below, I add a new function called `get_ascii_tab_or_newline_removed` to build the string directly instead of copying and then pruning tabs or newlines.

https://github.com/ada-url/ada/blob/d8f77a1d7c7928fa67ddca8ff6116bf3758f083f/src/url.cpp#L500-L502

Note:
- Due to [NRVO](https://en.cppreference.com/w/cpp/language/copy_elision) in C++ compilers, returning a local variable back to caller should be effective as pass pointers. (neither copy ctor nor move ctor will be called)
- If we add something like `inline` or `always_inline` attribute, it is better to put the definition to the header file instead of source file. Since all inline optimizitions cannot take effect if the definition cannot be reached (except link-time optimization enabled). since the definition may be in another translation unit if we put them in a source file.