### PR TITLE
perf: update whatwg_url package to latest commit

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -91,7 +91,7 @@ if(ICU_FOUND)
     CPMAddPackage(
       NAME url_whatwg
       GITHUB_REPOSITORY rmisev/url_whatwg
-      GIT_TAG cbcf3043eccb380cb4bef7486465ac3b02d2f674
+      GIT_TAG 72bcabf
       OPTIONS  "URL_BUILD_TESTS OFF" "URL_USE_LIBS OFF"
     )
     add_library(url_whatwg_lib STATIC "${url_whatwg_SOURCE_DIR}/src/url.cpp"
@@ -101,6 +101,7 @@ if(ICU_FOUND)
       "${url_whatwg_SOURCE_DIR}/src/url_search_params.cpp"
       "${url_whatwg_SOURCE_DIR}/src/url_utf.cpp"
       "${url_whatwg_SOURCE_DIR}/src/url.cpp")
+    target_include_directories(url_whatwg_lib PUBLIC "${url_whatwg_SOURCE_DIR}/include")
     target_link_libraries(url_whatwg_lib PRIVATE ICU::uc ICU::i18n)
 
 

--- a/benchmarks/benchmark_header.h
+++ b/benchmarks/benchmark_header.h
@@ -11,7 +11,7 @@
 #include <http_parser.h>
 #endif
 #if ADA_url_whatwg_ENABLED
-#include <src/url.h>
+#include <upa/url.h>
 #endif
 
 #include "ada.h"

--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -93,8 +93,8 @@ BENCHMARK(BasicBench_AdaURL_aggregator_href);
 size_t count_whatwg_invalid() {
   size_t how_many = 0;
   for (std::string& url_string : url_examples) {
-    whatwg::url url;
-    if (!whatwg::success(url.parse(url_string, nullptr))) {
+    upa::url url;
+    if (!upa::success(url.parse(url_string, nullptr))) {
       how_many++;
     }
   }
@@ -108,8 +108,8 @@ static void BasicBench_whatwg(benchmark::State& state) {
   volatile size_t href_size = 0;
   for (auto _ : state) {
     for (std::string& url_string : url_examples) {
-      whatwg::url url;
-      if (whatwg::success(url.parse(url_string, nullptr))) {
+      upa::url url;
+      if (upa::success(url.parse(url_string, nullptr))) {
         success++;
         if (!just_parse) {
           href_size += url.href().size();
@@ -123,8 +123,8 @@ static void BasicBench_whatwg(benchmark::State& state) {
       std::atomic_thread_fence(std::memory_order_acquire);
       collector.start();
       for (std::string& url_string : url_examples) {
-        whatwg::url url;
-        if (whatwg::success(url.parse(url_string, nullptr))) {
+        upa::url url;
+        if (upa::success(url.parse(url_string, nullptr))) {
           success++;
           if (!just_parse) {
             href_size += url.href().size();

--- a/benchmarks/wpt_bench.cpp
+++ b/benchmarks/wpt_bench.cpp
@@ -118,22 +118,22 @@ BENCHMARK(BasicBench_AdaURL_url_aggregator);
 
 #if ADA_url_whatwg_ENABLED
 
-#include <src/url.h>
+#include <upa/url.h>
 
 static void BasicBench_whatwg(benchmark::State &state) {
   volatile size_t success{};
   for (auto _ : state) {
     for (const std::pair<std::string, std::string> &url_strings :
          url_examples) {
-      whatwg::url base;
-      whatwg::url *base_ptr = nullptr;
+      upa::url base;
+      upa::url *base_ptr = nullptr;
       if (!url_strings.second.empty()) {
-        if (whatwg::success(base.parse(url_strings.second, nullptr))) {
+        if (upa::success(base.parse(url_strings.second, nullptr))) {
           base_ptr = &base;
         }
       }
-      whatwg::url url;
-      if (whatwg::success(url.parse(url_strings.first, base_ptr))) {
+      upa::url url;
+      if (upa::success(url.parse(url_strings.first, base_ptr))) {
         success++;
       }
     }
@@ -145,15 +145,15 @@ static void BasicBench_whatwg(benchmark::State &state) {
       collector.start();
       for (const std::pair<std::string, std::string> &url_strings :
            url_examples) {
-        whatwg::url base;
-        whatwg::url *base_ptr = nullptr;
+        upa::url base;
+        upa::url *base_ptr = nullptr;
         if (!url_strings.second.empty()) {
-          if (whatwg::success(base.parse(url_strings.second, nullptr))) {
+          if (upa::success(base.parse(url_strings.second, nullptr))) {
             base_ptr = &base;
           }
         }
-        whatwg::url url;
-        if (whatwg::success(url.parse(url_strings.first, base_ptr))) {
+        upa::url url;
+        if (upa::success(url.parse(url_strings.first, base_ptr))) {
           success++;
         }
       }


### PR DESCRIPTION
```
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
BasicBench_AdaURL_href              25454488 ns     25454481 ns           27 GHz=3.22868 cycle/byte=9.54974 cycles/url=829.483 instructions/byte=40.5726 instructions/cycle=4.24855 instructions/ns=13.7172 instructions/url=3.5241k ns/url=256.911 speed=341.319M/s time/byte=2.92981ns time/url=254.481ns url/s=3.92956M/s
BasicBench_AdaURL_aggregator_href   17160945 ns     17160122 ns           41 GHz=3.2277 cycle/byte=6.34475 cycles/url=551.1 instructions/byte=28.6196 instructions/cycle=4.51076 instructions/ns=14.5594 instructions/url=2.48588k ns/url=170.741 speed=506.295M/s time/byte=1.97513ns time/url=171.558ns url/s=5.82892M/s
BasicBench_whatwg                   43825708 ns     43824875 ns           16 GHz=3.22808 cycle/byte=16.1239 cycles/url=1.40051k instructions/byte=81.5094 instructions/cycle=5.0552 instructions/ns=16.3186 instructions/url=7.07984k ns/url=433.851 speed=198.246M/s time/byte=5.04425ns time/url=438.139ns url/s=2.28238M/s
BasicBench_CURL                    109123340 ns    109123167 ns            6 GHz=3.22762 cycle/byte=40.6542 cycles/url=3.53119k instructions/byte=194.381 instructions/cycle=4.78132 instructions/ns=15.4323 instructions/url=16.8838k ns/url=1094.05 speed=79.6173M/s time/byte=12.5601ns time/url=1090.96ns url/s=916.625k/s
BasicBench_ServoUrl                 62819280 ns     62816455 ns           11 GHz=3.22733 cycle/byte=23.298 cycles/url=2.02364k instructions/byte=115.133 instructions/cycle=4.94176 instructions/ns=15.9487 instructions/url=10.0004k ns/url=627.033 speed=138.309M/s time/byte=7.23018ns time/url=628.008ns url/s=1.59234M/s
```