### PR TITLE
Removing unnecessary inline qualify to pure virtual function

### DIFF
--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -111,8 +111,8 @@ struct url_base {
    * @return On failure, it returns zero.
    * @see https://url.spec.whatwg.org/#host-parsing
    */
-  virtual ada_really_inline size_t
-  parse_port(std::string_view view, bool check_trailing_content) noexcept = 0;
+  virtual size_t parse_port(std::string_view view,
+                            bool check_trailing_content) noexcept = 0;
 
   virtual ada_really_inline size_t parse_port(std::string_view view) noexcept {
     return this->parse_port(view, false);


### PR DESCRIPTION
As per the C++ specification, there is nothing preventing us from declaring a pure virtual function 'inline'. Nevertheless, some compilers, by static analysis, flags this with a warning. Furthermore, some people turn warnings into errors. And so you go from code that is legal, down to an error.

Note that there probably is no sense in this library to have the virtual function inline, so I am not defending the code as it appeared. It just seems that it was harmless as is.

Fixes https://github.com/ada-url/ada/issues/544