### PR TITLE
cmake: support disabling CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,65 +23,73 @@ add_subdirectory(src)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake)
 
 option(ADA_BENCHMARKS "Build benchmarks" OFF)
+option(ADA_TESTING "Build tests" ${BUILD_TESTING})
 
-include(cmake/CPM.cmake)
-# CPM requires git as an implicit dependency
-find_package(Git QUIET)
-# We use googletest in the tests
-if(Git_FOUND AND BUILD_TESTING)
-  CPMAddPackage(
-    NAME GTest
-    GITHUB_REPOSITORY google/googletest
-    VERSION 1.14.0
-    OPTIONS  "BUILD_GMOCK OFF" "INSTALL_GTEST OFF"
-  )
-endif()
-# We use simdjson in both the benchmarks and tests
-if(Git_FOUND AND (BUILD_TESTING OR ADA_BENCHMARKS))
-  CPMAddPackage("gh:simdjson/simdjson@3.3.0")
-endif()
-# We use Google Benchmark, but it does not build under several 32-bit systems.
-if(Git_FOUND AND ADA_BENCHMARKS AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
-  CPMAddPackage(
-    NAME benchmark
-    GITHUB_REPOSITORY google/benchmark
-    GIT_TAG f91b6b4
-    OPTIONS "BENCHMARK_ENABLE_TESTING OFF"
-            "BENCHMARK_ENABLE_INSTALL OFF"
-            "BENCHMARK_ENABLE_WERROR OFF"
-
-  )
-endif()
-
-if (BUILD_TESTING AND NOT EMSCRIPTEN)
-  if(Git_FOUND)
-    message(STATUS "The tests are enabled.")
-    add_subdirectory(tests)
+# There are cases where when embedding ada as a dependency for other CMake 
+# projects as submodules or subdirectories (via FetchContent) can lead to
+# errors due to CPM, so this is here to support disabling all the testing
+# and tooling for ada if one only wishes to use the ada library.
+if(ADA_TESTING OR ADA_BENCHMARKS OR ADA_TOOLS)
+  include(cmake/CPM.cmake)
+  # CPM requires git as an implicit dependency
+  find_package(Git QUIET)
+  # We use googletest in the tests
+  if(Git_FOUND AND ADA_TESTING)
+    CPMAddPackage(
+      NAME GTest
+      GITHUB_REPOSITORY google/googletest
+      VERSION 1.14.0
+      OPTIONS  "BUILD_GMOCK OFF" "INSTALL_GTEST OFF"
+    )
+  endif()
+  # We use simdjson in both the benchmarks and tests
+  if(Git_FOUND AND (ADA_TESTING OR ADA_BENCHMARKS))
+    CPMAddPackage("gh:simdjson/simdjson@3.3.0")
+  endif()
+  # We use Google Benchmark, but it does not build under several 32-bit systems.
+  if(Git_FOUND AND ADA_BENCHMARKS AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
+    CPMAddPackage(
+      NAME benchmark
+      GITHUB_REPOSITORY google/benchmark
+      GIT_TAG f91b6b4
+      OPTIONS "BENCHMARK_ENABLE_TESTING OFF"
+              "BENCHMARK_ENABLE_INSTALL OFF"
+              "BENCHMARK_ENABLE_WERROR OFF"
+  
+    )
+  endif()
+  
+  if (ADA_TESTING AND NOT EMSCRIPTEN)
+    if(Git_FOUND)
+      message(STATUS "The tests are enabled.")
+      add_subdirectory(tests)
+    else()
+      message(STATUS "The tests are disabled because git was not found.")
+    endif()
   else()
-    message(STATUS "The tests are disabled because git was not found.")
-  endif()
-else()
-  if(is_top_project)
-    message(STATUS "The tests are disabled.")
-  endif()
-endif(BUILD_TESTING AND NOT EMSCRIPTEN)
+    if(is_top_project)
+      message(STATUS "The tests are disabled.")
+    endif()
+  endif(ADA_TESTING AND NOT EMSCRIPTEN)
+  
+  If(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
+    if(Git_FOUND)
+      message(STATUS "Ada benchmarks enabled.")
+      add_subdirectory(benchmarks)
+    else()
+      message(STATUS "The benchmarks are disabled because git was not found.")
+    endif()
+  else(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
+    if(is_top_project)
+      message(STATUS "Ada benchmarks disabled. Set ADA_BENCHMARKS=ON to enable them.")
+    endif()
+  endif(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
+  
+  if (ADA_TESTING AND EMSCRIPTEN)
+    add_subdirectory(tests/wasm)
+  endif(ADA_TESTING AND EMSCRIPTEN)
+endif()
 
-If(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
-  if(Git_FOUND)
-    message(STATUS "Ada benchmarks enabled.")
-    add_subdirectory(benchmarks)
-  else()
-    message(STATUS "The benchmarks are disabled because git was not found.")
-  endif()
-else(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
-  if(is_top_project)
-    message(STATUS "Ada benchmarks disabled. Set ADA_BENCHMARKS=ON to enable them.")
-  endif()
-endif(ADA_BENCHMARKS AND NOT EMSCRIPTEN)
-
-if (BUILD_TESTING AND EMSCRIPTEN)
-  add_subdirectory(tests/wasm)
-endif(BUILD_TESTING AND EMSCRIPTEN)
 
 add_library(ada::ada ALIAS ada)
 

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -51,7 +51,7 @@ if (Python3_Interpreter_FOUND)
   target_link_libraries(ada-singleheader-source INTERFACE ada-singleheader-include-source)
   add_library(ada-singleheader-lib STATIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/ada.cpp>)
 
-  if (BUILD_TESTING)
+  if (ADA_TESTING)
     add_executable(demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/demo.cpp>)
     target_link_libraries(demo ada-singleheader-include-source)
 


### PR DESCRIPTION
When using ada as a library and embedding it in our project via
FetchContent, we've run into errors like this:

```
[253/1413] Generating ada.cpp, ada.h, ada_c.h, demo.cpp, demo.c, README.md
fatal: detected dubious ownership in repository at '/src/redpanda'
```

In our CI environment we've seen flaky HTTP issues as well:

```
CMake Error at build/_deps/ada-src/cmake/CPM.cmake:19 (file):
  file DOWNLOAD cannot compute hash on failed download
    status: [22;"HTTP response code said error"]
Call Stack (most recent call first):
  build/_deps/ada-src/CMakeLists.txt:27 (include)
CMake Error at build/_deps/ada-src/CMakeLists.txt:32 (CPMAddPackage):
  Unknown CMake command "CPMAddPackage".
```

Actually building just the library seems very simple and uses vanilla
cmake. CPM is only used for testing/benchmarking/etc. We've seen some of
the dubious ownership issues just including CPM (hacking around trying
to disable GIT failed to fix the issue).

To support our usecase, I've added a flag allowing disabling tests, the
default value is the value of BUILD_TESTING so hopefully nothing changes
for anyone.

I tested this via the following commands:

```
cmake -B build && cmake --build build
cmake -B build -DADA_BENCHMARKS=ON && cmake --build build
cmake -B build -DADA_TESTING=OFF -DADA_TOOLS=OFF -DADA_BENCHMARKS=OFF && cmake --build build
```

