### PR TITLE
optimizing is_ipv4

### DIFF
--- a/.github/workflows/visual_studio.yml
+++ b/.github/workflows/visual_studio.yml
@@ -28,22 +28,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON, shared: OFF}
-          - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON, shared: ON}
-          - {gen: Visual Studio 17 2022, arch: Win32, devchecks: ON, shared: OFF}
-          - {gen: Visual Studio 17 2022, arch: Win32, devchecks: ON, shared: ON}
+          - {gen: Visual Studio 17 2022, arch: x64, devchecks: OFF, shared: OFF, config: Release}
+          - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON, shared: OFF, config: Debug}
+          - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON, shared: ON, config: Debug}
+          - {gen: Visual Studio 17 2022, arch: Win32, devchecks: ON, shared: OFF, config: Debug}
+          - {gen: Visual Studio 17 2022, arch: Win32, devchecks: ON, shared: ON, config: Debug}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.6.0
     - name: Configure
       run: |
         cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
-    - name: Build Debug
-      run: cmake --build build --config Debug --verbose
-    - name: Run Debug tests
+    - name: Build
+      run: cmake --build build --config "${{matrix.config}}" --verbose
+    - name: Run  tests
       working-directory: build
       run: ctest -C Debug  --output-on-failure
-    - name: Build Release
-      run: cmake --build build --config Release --verbose
-    - name: Run Release tests
-      working-directory: build
-      run: ctest -C Release   --output-on-failure

--- a/.github/workflows/visual_studio.yml
+++ b/.github/workflows/visual_studio.yml
@@ -42,4 +42,4 @@ jobs:
       run: cmake --build build --config "${{matrix.config}}" --verbose
     - name: Run  tests
       working-directory: build
-      run: ctest -C Debug  --output-on-failure
+      run: ctest -C "${{matrix.config}}"  --output-on-failure

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -76,7 +76,9 @@ ada_really_inline bool begins_with(std::string_view view,
                                    std::string_view prefix);
 
 /**
- * Returns true if an input is an ipv4 address.
+ * Returns true if an input is an ipv4 address. It is assumed that the string
+ * does not contain uppercase ASCII characters (the input should have been
+ * lowered cased before calling this function) and is not empty.
  */
 ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept;
 

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -5,24 +5,33 @@ namespace ada::checkers {
 
 ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept {
   size_t last_dot = view.rfind('.');
-  if (last_dot == view.size() - 1) {
-    view.remove_suffix(1);
-    last_dot = view.rfind('.');
+  if (last_dot != std::string_view::npos) {
+    // We have at least one dot.
+    //
+    // If the address ends with a dot, we need to prune it (special case).
+    if (last_dot == view.size() - 1) {
+      view.remove_suffix(1);
+      last_dot = view.rfind('.');
+      if (last_dot != std::string_view::npos) {
+        view = view.substr(last_dot + 1);
+      }
+    } else {
+      // We have at least one dot and the address does not end with a dot.
+      view = view.substr(last_dot + 1);
+    }
   }
-  std::string_view number =
-      (last_dot == std::string_view::npos) ? view : view.substr(last_dot + 1);
-  if (number.empty()) {
+  if (view.empty()) {
     return false;
   }
   /** Optimization opportunity: we have basically identified the last number of
      the ipv4 if we return true here. We might as well parse it and have at
      least one number parsed when we get to parse_ipv4. */
-  if (std::all_of(number.begin(), number.end(), ada::checkers::is_digit)) {
+  if (std::all_of(view.begin(), view.end(), ada::checkers::is_digit)) {
     return true;
   }
-  return (checkers::has_hex_prefix(number) &&
-          std::all_of(number.begin() + 2, number.end(),
-                      ada::unicode::is_lowercase_hex));
+  return (checkers::has_hex_prefix(view) &&
+          (view.size() == 2 || std::all_of(view.begin() + 2, view.end(),
+                                           ada::unicode::is_lowercase_hex)));
 }
 
 // for use with path_signature, we include all characters that need percent

--- a/src/checkers.cpp
+++ b/src/checkers.cpp
@@ -4,6 +4,20 @@
 namespace ada::checkers {
 
 ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept {
+  // The string is not empty and does not contain upper case ASCII characters.
+  //
+  // Optimization. To be considered as a possible ipv4, the string must end
+  // with 'x' or a lowercase hex character.
+  // Most of the time, this will be false so this simple check will save a lot
+  // of effort.
+  const char last_char = view.back();
+  bool possible_ipv4 = (last_char >= '0' && last_char <= '9') ||
+                       (last_char >= 'a' && last_char <= 'f') ||
+                       last_char == 'x';
+  if (!possible_ipv4) {
+    return false;
+  }
+  // From the last character, find the last dot.
   size_t last_dot = view.rfind('.');
   if (last_dot != std::string_view::npos) {
     // We have at least one dot.
@@ -20,6 +34,8 @@ ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept {
       view = view.substr(last_dot + 1);
     }
   }
+  // We may have an empty result if the address ends with two dots (..).
+  // It is an unlikely case.
   if (view.empty()) {
     return false;
   }
@@ -29,9 +45,22 @@ ada_really_inline ada_constexpr bool is_ipv4(std::string_view view) noexcept {
   if (std::all_of(view.begin(), view.end(), ada::checkers::is_digit)) {
     return true;
   }
-  return (checkers::has_hex_prefix(view) &&
-          (view.size() == 2 || std::all_of(view.begin() + 2, view.end(),
-                                           ada::unicode::is_lowercase_hex)));
+  // It could be hex (0x), but not if there is a single character.
+  if(view.size() == 1) {
+    return false;
+  }
+  // It must start with 0x.
+  if(!std::equal(view.begin(), view.begin() + 2, "0x")) {
+    return false;
+  }
+  // We must allow "0x".
+  if(view.size() == 2) {
+    return true;
+  }
+  // We have 0x followed by some characters, we need to check that they are
+  // hexadecimals.
+  return std::all_of(view.begin() + 2, view.end(),
+                                       ada::unicode::is_lowercase_hex);
 }
 
 // for use with path_signature, we include all characters that need percent


### PR DESCRIPTION
This PR optimizes the is_ipv4 function by first checking the last character. Unless the last character is a hex number or the letter x, we can just return false immediately and save quite a bit of work.

The function was also rewritten with more safeguards.

LLVM 14, Apple M2.

Before:

```
BasicBench_AdaURL_href              24053490 ns     24053414 ns           29 GHz=3.38364 cycle/byte=9.37729 cycles/url=814.504 instructions/byte=38.9054 instructions/cycle=4.14889 instructions/ns=14.0383 instructions/url=3.37929k ns/url=240.719 speed=361.2M/s time/byte=2.76855ns time/url=240.474ns url/s=4.15845M/s
BasicBench_AdaURL_aggregator_href   16111354 ns     16111372 ns           43 GHz=3.48936 cycle/byte=6.19904 cycles/url=538.444 instructions/byte=27.773 instructions/cycle=4.48021 instructions/ns=15.6331 instructions/url=2.41234k ns/url=154.31 speed=539.252M/s time/byte=1.85442ns time/url=161.073ns url/s=6.20835M/s
```




After

```
BasicBench_AdaURL_href              24135053 ns     24135033 ns           30 GHz=3.39617 cycle/byte=9.33507 cycles/url=810.837 instructions/byte=38.7939 instructions/cycle=4.15571 instructions/ns=14.1135 instructions/url=3.3696k ns/url=238.751 speed=359.978M/s time/byte=2.77794ns time/url=241.29ns url/s=4.14439M/s
BasicBench_AdaURL_aggregator_href   15683330 ns     15683273 ns           44 GHz=3.3813 cycle/byte=6.09465 cycles/url=529.377 instructions/byte=27.3717 instructions/cycle=4.49111 instructions/ns=15.1858 instructions/url=2.37749k ns/url=156.56 speed=553.972M/s time/byte=1.80515ns time/url=156.794ns url/s=6.37781M/s
```
