### PR TITLE
Fix check segment_result range(for node issue #51514)

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -65,7 +65,7 @@ bool url::parse_ipv4(std::string_view input) {
       // We have the last value.
       // At this stage, ipv4 contains digit_count*8 bits.
       // So we have 32-digit_count*8 bits left.
-      if (segment_result > (uint64_t(1) << (32 - digit_count * 8))) {
+      if (segment_result >= (uint64_t(1) << (32 - digit_count * 8))) {
         return is_valid = false;
       }
       ipv4 <<= (32 - digit_count * 8);

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -898,7 +898,7 @@ bool url_aggregator::parse_ipv4(std::string_view input) {
       // We have the last value.
       // At this stage, ipv4 contains digit_count*8 bits.
       // So we have 32-digit_count*8 bits left.
-      if (segment_result > (uint64_t(1) << (32 - digit_count * 8))) {
+      if (segment_result >= (uint64_t(1) << (32 - digit_count * 8))) {
         return is_valid = false;
       }
       ipv4 <<= (32 - digit_count * 8);

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -399,6 +399,6 @@ TYPED_TEST(basic_tests, nodejs_50235) {
 
 // https://github.com/nodejs/node/issues/51514
 TYPED_TEST(basic_tests, nodejs_51514) {
-  auto out = ada::parse<ada::url>("http://1.1.1.256");
+  auto out = ada::parse<TypeParam>("http://1.1.1.256");
   ASSERT_FALSE(out);
 }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -396,3 +396,9 @@ TYPED_TEST(basic_tests, nodejs_50235) {
   ASSERT_EQ(out->get_href(), "http://test.com:5/path?param=1");
   SUCCEED();
 }
+
+// https://github.com/nodejs/node/issues/51514
+TYPED_TEST(basic_tests, nodejs_51514) {
+  auto out = ada::parse<ada::url>("http://1.1.1.256");
+  ASSERT_FALSE(out);
+}


### PR DESCRIPTION
Fix an intermittent issue identified by @danfuzz in https://github.com/nodejs/node/issues/51514

# Reproudction

## Code Example

```c++
#include "ada.cpp"
#include "ada.h"
#include <iostream>

int main(int, char *[]) {
  auto url = ada::parse<ada::url>("https://1.1.1.256");
  if (!url) {
    std::cout << "failure" << std::endl;
    return EXIT_FAILURE;
  }
  url->set_protocol("http");
  std::cout << url->get_protocol() << std::endl;
  std::cout << url->get_host() << std::endl;
  return EXIT_SUCCESS;
}
```

## Expected
Raise an error and stop parse.

![image](https://github.com/ada-url/ada/assets/42082890/5798c994-5d16-4a46-823c-4f4ee18dbcc6)


## Actual

Successfully parsed.

![image](https://github.com/ada-url/ada/assets/42082890/a2e4a016-7d5a-41f9-8c2e-b7688dbfe9c8)

# Reason

This is an edge case, `segment_result` should not be equal to the size of remaining bits.

https://github.com/ada-url/ada/blob/4814d2f62f8c0c4545c39bcbaad3451eceda2ab3/src/url.cpp#L64-L83
