### PR TITLE
exposing branch misses under macos

### DIFF
--- a/benchmarks/performancecounters/apple_arm_events.h
+++ b/benchmarks/performancecounters/apple_arm_events.h
@@ -1102,7 +1102,7 @@ struct AppleEvents {
         printf("%14s: %llu\n", alias->alias, val);
     }*/
     return performance_counters{
-        counters_0[counter_map[0]], counters_0[counter_map[3]],
+        counters_0[counter_map[0]], counters_0[counter_map[2]],
         counters_0[counter_map[2]], counters_0[counter_map[1]]};
   }
 };

--- a/benchmarks/performancecounters/event_counter.h
+++ b/benchmarks/performancecounters/event_counter.h
@@ -35,6 +35,8 @@ struct event_count {
   enum event_counter_types {
     CPU_CYCLES,
     INSTRUCTIONS,
+    BRANCH_MISSES=2,
+    BRANCH=4
   };
 
   double elapsed_sec() const {
@@ -49,7 +51,12 @@ struct event_count {
   double instructions() const {
     return static_cast<double>(event_counts[INSTRUCTIONS]);
   }
-
+  double branches() const {
+    return static_cast<double>(event_counts[BRANCH]);
+  }
+  double branch_misses() const {
+    return static_cast<double>(event_counts[BRANCH_MISSES]);
+  }
   event_count& operator=(const event_count& other) {
     this->elapsed = other.elapsed;
     this->event_counts = other.event_counts;

--- a/benchmarks/performancecounters/event_counter.h
+++ b/benchmarks/performancecounters/event_counter.h
@@ -35,8 +35,8 @@ struct event_count {
   enum event_counter_types {
     CPU_CYCLES,
     INSTRUCTIONS,
-    BRANCH_MISSES=2,
-    BRANCH=4
+    BRANCH_MISSES = 2,
+    BRANCH = 4
   };
 
   double elapsed_sec() const {
@@ -51,9 +51,7 @@ struct event_count {
   double instructions() const {
     return static_cast<double>(event_counts[INSTRUCTIONS]);
   }
-  double branches() const {
-    return static_cast<double>(event_counts[BRANCH]);
-  }
+  double branches() const { return static_cast<double>(event_counts[BRANCH]); }
   double branch_misses() const {
     return static_cast<double>(event_counts[BRANCH_MISSES]);
   }


### PR DESCRIPTION
In the future, benchmarks should track branch misses. This PR lays the foundation for this upgrade.