### PR TITLE
simplifies some verbose lines of code.

### DIFF
--- a/benchmarks/benchmark_header.h
+++ b/benchmarks/benchmark_header.h
@@ -32,7 +32,7 @@ bool file_exists(const char* filename) {
 }
 
 std::string read_file(std::string filename) {
-  constexpr std::size_t read_size = 4096;
+  constexpr size_t read_size = 4096;
   auto stream = std::ifstream(filename.c_str());
   stream.exceptions(std::ios_base::badbit);
   std::string out;

--- a/benchmarks/benchmark_header.h
+++ b/benchmarks/benchmark_header.h
@@ -32,11 +32,11 @@ bool file_exists(const char* filename) {
 }
 
 std::string read_file(std::string filename) {
-  constexpr auto read_size = std::size_t(4096);
+  constexpr std::size_t read_size = 4096;
   auto stream = std::ifstream(filename.c_str());
   stream.exceptions(std::ios_base::badbit);
-  auto out = std::string();
-  auto buf = std::string(read_size, '\0');
+  std::string out;
+  std::string buf(read_size, '\0');
   while (stream.read(&buf[0], read_size)) {
     out.append(buf, 0, size_t(stream.gcount()));
   }
@@ -45,8 +45,8 @@ std::string read_file(std::string filename) {
 }
 
 std::vector<std::string> split_string(const std::string& str) {
-  auto result = std::vector<std::string>{};
-  auto ss = std::stringstream{str};
+  std::vector<std::string> result;
+  std::stringstream ss{str};
   for (std::string line; std::getline(ss, line, '\n');) {
     std::string_view view = line;
     // Some parsers like boost/url will refuse to parse a URL with trailing

--- a/benchmarks/model_bench.cpp
+++ b/benchmarks/model_bench.cpp
@@ -21,11 +21,11 @@ bool file_exists(const char *filename) {
 }
 
 std::string read_file(std::string filename) {
-  constexpr auto read_size = std::size_t(4096);
-  auto stream = std::ifstream(filename.c_str());
+  constexpr std::size_t read_size = 4096;
+  std::ifstream stream(filename.c_str());
   stream.exceptions(std::ios_base::badbit);
-  auto out = std::string();
-  auto buf = std::string(read_size, '\0');
+  std::string out;
+  std::string buf(read_size, '\0');
   while (stream.read(&buf[0], read_size)) {
     out.append(buf, 0, size_t(stream.gcount()));
   }
@@ -35,7 +35,7 @@ std::string read_file(std::string filename) {
 
 std::vector<std::string> split_string(const std::string &str) {
   auto result = std::vector<std::string>{};
-  auto ss = std::stringstream{str};
+  std::stringstream ss{str};
   for (std::string line; std::getline(ss, line, '\n');) {
     std::string_view view = line;
     // Some parsers like boost/url will refuse to parse a URL with trailing

--- a/benchmarks/model_bench.cpp
+++ b/benchmarks/model_bench.cpp
@@ -21,7 +21,7 @@ bool file_exists(const char *filename) {
 }
 
 std::string read_file(std::string filename) {
-  constexpr std::size_t read_size = 4096;
+  constexpr size_t read_size = 4096;
   std::ifstream stream(filename.c_str());
   stream.exceptions(std::ios_base::badbit);
   std::string out;

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -304,7 +304,7 @@ inline void url_aggregator::append_base_pathname(const std::string_view input) {
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
 #if ADA_DEVELOPMENT_CHECKS
   // computing the expected password.
-  std::string path_expected = std::string(get_pathname());
+  std::string path_expected(get_pathname());
   path_expected.append(input);
 #endif  // ADA_DEVELOPMENT_CHECKS
   uint32_t ending_index = uint32_t(buffer.size());
@@ -374,7 +374,7 @@ inline void url_aggregator::append_base_username(const std::string_view input) {
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
 #if ADA_DEVELOPMENT_CHECKS
   // computing the expected password.
-  std::string username_expected = std::string(get_username());
+  std::string username_expected(get_username());
   username_expected.append(input);
 #endif  // ADA_DEVELOPMENT_CHECKS
   add_authority_slashes_if_needed();
@@ -404,7 +404,7 @@ inline void url_aggregator::append_base_username(const std::string_view input) {
     components.hash_start += difference;
   }
 #if ADA_DEVELOPMENT_CHECKS
-  std::string username_after = std::string(get_username());
+  std::string username_after(get_username());
   ADA_ASSERT_EQUAL(
       username_expected, username_after,
       "append_base_username problem after inserting " + std::string(input));
@@ -530,7 +530,7 @@ inline void url_aggregator::append_base_password(const std::string_view input) {
     components.hash_start += difference;
   }
 #if ADA_DEVELOPMENT_CHECKS
-  std::string password_after = std::string(get_password());
+  std::string password_after(get_password());
   ADA_ASSERT_EQUAL(
       password_expected, password_after,
       "append_base_password problem after inserting " + std::string(input));

--- a/src/ada_c.cpp
+++ b/src/ada_c.cpp
@@ -88,7 +88,7 @@ bool ada_can_parse(const char* input, size_t length) noexcept {
 
 bool ada_can_parse_with_base(const char* input, size_t input_length,
                              const char* base, size_t base_length) noexcept {
-  auto base_view = std::string_view(base, base_length);
+  std::string_view base_view(base, base_length);
   return ada::can_parse(std::string_view(input, input_length), &base_view);
 }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -373,7 +373,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
       }
     }
   } else {  // slow path
-    std::string _buffer = std::string(input);
+    std::string _buffer(input);
     // Next function is only valid if the input is ASCII and returns false
     // otherwise, but it seems that we always have ascii content so we do not
     // need to check the return value.

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -65,7 +65,7 @@ template <bool has_state_override>
       }
     }
   } else {  // slow path
-    std::string _buffer = std::string(input);
+    std::string _buffer(input);
     // Next function is only valid if the input is ASCII and returns false
     // otherwise, but it seems that we always have ascii content so we do not
     // need to check the return value.
@@ -521,7 +521,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     return false;
   }
 
-  std::string previous_host = std::string(get_hostname());
+  std::string previous_host(get_hostname());
   uint32_t previous_port = components.port;
 
   size_t host_end_pos = input.find('#');

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -119,7 +119,7 @@ TEST(wpt_tests, percent_encoding) {
         std::cout << "   comment: " << element.get_string() << std::endl;
       } else if (element.type() == ondemand::json_type::object) {
         ondemand::object object = element.get_object();
-        auto element_string = std::string(std::string_view(object.raw_json()));
+        std::string element_string(std::string_view(object.raw_json()));
         object.reset();
 
         // We might want to decode the strings into UTF-8, but some of the


### PR DESCRIPTION
Patterns such as

```
auto out = std::string();
```

Are probably best avoided and replaced with...

```
std::string out;
```

This PR makes a few such changes.
