### PR TITLE
Documenting hashing technique

### DIFF
--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -24,14 +24,17 @@ constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
 
 /****
  * In is_special, get_scheme_type, and get_special_port, we
- * use a standard hashing technique to find the index of the scheme in the
- * is_special_list. The hashing technique is based on the size of the scheme
- * and the first character of the scheme. It ensures that we do at most one
- * string comparison per call. If the protocol is predictible (e.g., it is
- * always "http"), we can get a better average performance by using a a
- * simpler approach where we loop and compare scheme with all possible
- * protocol. In this instance, we choose a potentially slightly lower
- * best-case performance for a better worst-case performance.
+ * use a standard hashing technique to find the index of the scheme in
+ * the is_special_list. The hashing technique is based on the size of
+ * the scheme and the first character of the scheme. It ensures that we
+ * do at most one string comparison per call. If the protocol is
+ * predictible (e.g., it is always "http"), we can get a better average
+ * performance by using a simpler approach where we loop and compare
+ * scheme with all possible protocols starting with the most likely
+ * protocol. Doing multiple comparisons may have a poor worst case
+ * performance, however. In this instance, we choose a potentially slightly
+ * lower best-case performance for a better worst-case performance.
+ * We can revisit this choice at any time.
  *
  * Reference:
  * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -42,7 +42,6 @@ constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
  * Reference: https://github.com/ada-url/ada/issues/617
  ****/
 
-
 ada_really_inline constexpr bool is_special(std::string_view scheme) {
   if (scheme.empty()) {
     return false;

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -32,9 +32,9 @@ constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
  * performance by using a simpler approach where we loop and compare
  * scheme with all possible protocols starting with the most likely
  * protocol. Doing multiple comparisons may have a poor worst case
- * performance, however. In this instance, we choose a potentially slightly
- * lower best-case performance for a better worst-case performance.
- * We can revisit this choice at any time.
+ * performance, however. In this instance, we choose a potentially
+ * slightly lower best-case performance for a better worst-case
+ * performance. We can revisit this choice at any time.
  *
  * Reference:
  * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -26,6 +26,18 @@ ada_really_inline constexpr bool is_special(std::string_view scheme) {
   if (scheme.empty()) {
     return false;
   }
+  /**
+   * We use a standard hashing technique to find the index of the scheme in the
+   * is_special_list. The hashing technique is based on the size of the scheme
+   * and the first character of the scheme. It ensures that we do at most one
+   * string comparison per call. If the protocol is predictible (e.g., it is
+   * always "http"), we can get a better average performance by using a a
+   * simpler approach where we loop and compare scheme with all possible
+   * protocol. In this instance, we choose a potentially slightly lower
+   * best-case performance for a better worst-case performance. Reference:
+   * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
+   * gems 17 (2000).
+   */
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
   return (target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1));
@@ -34,6 +46,18 @@ constexpr uint16_t get_special_port(std::string_view scheme) noexcept {
   if (scheme.empty()) {
     return 0;
   }
+  /**
+   * We use a standard hashing technique to find the index of the scheme in the
+   * is_special_list. The hashing technique is based on the size of the scheme
+   * and the first character of the scheme. It ensures that we do at most one
+   * string comparison per call. If the protocol is predictible (e.g., it is
+   * always "http"), we can get a better average performance by using a a
+   * simpler approach where we loop and compare scheme with all possible
+   * protocol. In this instance, we choose a potentially slightly lower
+   * best-case performance for a better worst-case performance. Reference:
+   * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
+   * gems 17 (2000).
+   */
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
   if ((target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1))) {
@@ -49,6 +73,18 @@ constexpr ada::scheme::type get_scheme_type(std::string_view scheme) noexcept {
   if (scheme.empty()) {
     return ada::scheme::NOT_SPECIAL;
   }
+  /**
+   * We use a standard hashing technique to find the index of the scheme in the
+   * is_special_list. The hashing technique is based on the size of the scheme
+   * and the first character of the scheme. It ensures that we do at most one
+   * string comparison per call. If the protocol is predictible (e.g., it is
+   * always "http"), we can get a better average performance by using a a
+   * simpler approach where we loop and compare scheme with all possible
+   * protocol. In this instance, we choose a potentially slightly lower
+   * best-case performance for a better worst-case performance. Reference:
+   * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
+   * gems 17 (2000).
+   */
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
   if ((target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1))) {

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -23,6 +23,7 @@ constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
 }  // namespace details
 
 /****
+ * @private
  * In is_special, get_scheme_type, and get_special_port, we
  * use a standard hashing technique to find the index of the scheme in
  * the is_special_list. The hashing technique is based on the size of

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -37,8 +37,8 @@ constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
  * performance. We can revisit this choice at any time.
  *
  * Reference:
- * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
- * gems 17 (2000).
+ * Schmidt, Douglas C. "Gperf: A perfect hash function generator."
+ * More C++ gems 17 (2000).
  *
  * Reference: https://en.wikipedia.org/wiki/Perfect_hash_function
  *

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -22,22 +22,31 @@ constexpr std::string_view is_special_list[] = {"http", " ",   "https", "ws",
 constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
 }  // namespace details
 
+/****
+ * In is_special, get_scheme_type, and get_special_port, we
+ * use a standard hashing technique to find the index of the scheme in the
+ * is_special_list. The hashing technique is based on the size of the scheme
+ * and the first character of the scheme. It ensures that we do at most one
+ * string comparison per call. If the protocol is predictible (e.g., it is
+ * always "http"), we can get a better average performance by using a a
+ * simpler approach where we loop and compare scheme with all possible
+ * protocol. In this instance, we choose a potentially slightly lower
+ * best-case performance for a better worst-case performance.
+ *
+ * Reference:
+ * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
+ * gems 17 (2000).
+ *
+ * Reference: https://en.wikipedia.org/wiki/Perfect_hash_function
+ *
+ * Reference: https://github.com/ada-url/ada/issues/617
+ ****/
+
+
 ada_really_inline constexpr bool is_special(std::string_view scheme) {
   if (scheme.empty()) {
     return false;
   }
-  /**
-   * We use a standard hashing technique to find the index of the scheme in the
-   * is_special_list. The hashing technique is based on the size of the scheme
-   * and the first character of the scheme. It ensures that we do at most one
-   * string comparison per call. If the protocol is predictible (e.g., it is
-   * always "http"), we can get a better average performance by using a a
-   * simpler approach where we loop and compare scheme with all possible
-   * protocol. In this instance, we choose a potentially slightly lower
-   * best-case performance for a better worst-case performance. Reference:
-   * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
-   * gems 17 (2000).
-   */
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
   return (target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1));
@@ -46,18 +55,6 @@ constexpr uint16_t get_special_port(std::string_view scheme) noexcept {
   if (scheme.empty()) {
     return 0;
   }
-  /**
-   * We use a standard hashing technique to find the index of the scheme in the
-   * is_special_list. The hashing technique is based on the size of the scheme
-   * and the first character of the scheme. It ensures that we do at most one
-   * string comparison per call. If the protocol is predictible (e.g., it is
-   * always "http"), we can get a better average performance by using a a
-   * simpler approach where we loop and compare scheme with all possible
-   * protocol. In this instance, we choose a potentially slightly lower
-   * best-case performance for a better worst-case performance. Reference:
-   * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
-   * gems 17 (2000).
-   */
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
   if ((target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1))) {
@@ -73,18 +70,6 @@ constexpr ada::scheme::type get_scheme_type(std::string_view scheme) noexcept {
   if (scheme.empty()) {
     return ada::scheme::NOT_SPECIAL;
   }
-  /**
-   * We use a standard hashing technique to find the index of the scheme in the
-   * is_special_list. The hashing technique is based on the size of the scheme
-   * and the first character of the scheme. It ensures that we do at most one
-   * string comparison per call. If the protocol is predictible (e.g., it is
-   * always "http"), we can get a better average performance by using a a
-   * simpler approach where we loop and compare scheme with all possible
-   * protocol. In this instance, we choose a potentially slightly lower
-   * best-case performance for a better worst-case performance. Reference:
-   * Schmidt, Douglas C. "Gperf: A perfect hash function generator." More C++
-   * gems 17 (2000).
-   */
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
   if ((target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1))) {


### PR DESCRIPTION
As remarked by @the-moisrex in issue 617, [Premature optimiztion](https://github.com/ada-url/ada/issues/617), the hashing technique to identify the protocol is unnecessary if the protocol string is predictable. By simply testing all six possible strings, starting from the most probable, it is likely that you can often get better performance in many practical cases.

It is a trade-off between best average or best-case performance and worst-case performance. A naive approach, in the worst case, may need to do six different string comparisons which could be potentially expensive. We made the choice to go with an option that is slightly less optimal in the case where we can predict, at compile time, the protocol, but has the benefit of having well understood worst-case performance. It is a good old "O(1)" performance vs "O(N)" performance where N is not too large.

This trade-off can be revisited at any time. It is worth documenting it in the code, however. This is what this PR does.