### PR TITLE
simplifying hashing routine

### DIFF
--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -52,7 +52,7 @@ ada_really_inline constexpr bool is_special(std::string_view scheme) {
   }
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
-  return (target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1));
+  return target == scheme;
 }
 constexpr uint16_t get_special_port(std::string_view scheme) noexcept {
   if (scheme.empty()) {
@@ -60,7 +60,7 @@ constexpr uint16_t get_special_port(std::string_view scheme) noexcept {
   }
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
-  if ((target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1))) {
+  if (target == scheme) {
     return details::special_ports[hash_value];
   } else {
     return 0;
@@ -75,7 +75,7 @@ constexpr ada::scheme::type get_scheme_type(std::string_view scheme) noexcept {
   }
   int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
   const std::string_view target = details::is_special_list[hash_value];
-  if ((target[0] == scheme[0]) && (target.substr(1) == scheme.substr(1))) {
+  if (target == scheme) {
     return ada::scheme::type(hash_value);
   } else {
     return ada::scheme::NOT_SPECIAL;


### PR DESCRIPTION
This is mostly performance neutral, but it makes the code more elegant. To illustrate, consider the `is_special` function.

```C++
constexpr std::string_view is_special_list[] = {"http", " ",   "https", "ws",
                                                "ftp",  "wss", "file",  " "};
bool is_special(std::string_view scheme) {
   if (scheme.empty()) {
     return false;
  }
  int hash_value = (2 * scheme.size() + (unsigned)(scheme[0])) & 7;
  const std::string_view target = is_special_list[hash_value];
  return  target == scheme;
}
```

Under ARM64, this might compile to...

```asm
is_special(std::basic_string_view<char, std::char_traits<char> >): // @is_special(std::basic_string_view<char, std::char_traits<char> >)
        cbz     x0, . NOT_SPECIAL // If the string is empty return not special
        ldrb    w8, [x1]  // load into w8 the first character from the provided std::string_view
        mov     x2, x0   // move the provided string length to register 2
        adrp    x9, is_special_list// grab the address of the is_special_list array
        add     x9, x9, :lo12:is_special_list
        add     w8, w8, w2, lsl #1  // compute  2* first character  + string length and store in register 8
        and     x8, x8, #0x7 // zero everything but the least significant 3 bits in register 8
        add     x8, x9, x8, lsl #4
        ldr     x9, [x8]   // load the length of is_special_list[hash_value] into register 9
        cmp     x9, x0 // compare the length of the input with the length of is_special_list[hash_value]
        b.ne    .NOT_SPECIAL // if the differ, not special
        stp     x29, x30, [sp, #-16]!           // next few instructions call the binary comparison function between our input and is_special_list[hash_value]
        mov     x29, sp
        ldr     x0, [x8, #8]
        bl      bcmp
        cmp     w0, #0
        cset    w0, eq
        ldp     x29, x30, [sp], #16             

```

Importantly, the hash function accounts for only two instructions : one addition and one bitwise and. The bulk of the cost is the call to the string comparison function.

```
        add     w8, w8, w2, lsl #1  // compute  2* first character  + string length and store in register 8
        and     x8, x8, #0x7 // zero everything but the least significant 3 bits in register 8
```