### PR TITLE
chore: update github checkout workflow

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -24,7 +24,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.5.2
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: start docker
         run: |
           docker run -w /src -dit --name alpine -v $PWD:/src alpine:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    
+
     runs-on: ubuntu-latest
-    
+
     permissions:
       actions: read
       contents: read
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@5bbc3ba658137598168acb2ab73b21c432dd411b # v4.2.5

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Install theme
         run: ./tools/prepare-doxygen.sh
       - uses: mattnotmitt/doxygen-action@e0c8cd4cd05e28b88e723b25b30188ecf2505b40 # edge

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -20,11 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
       - name: Verify
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
       - name: Configure
-        run: emcmake  cmake -B buildwasm -D ADA_TOOLS=OFF
+        run: emcmake cmake -B buildwasm -D ADA_TOOLS=OFF
       - name: Build
         run: cmake --build buildwasm
       - name: Test

--- a/.github/workflows/lint_and_format_check.yml
+++ b/.github/workflows/lint_and_format_check.yml
@@ -24,7 +24,7 @@ jobs:
   lint-and-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Install clang-format
         run: |

--- a/.github/workflows/macos_install.yml
+++ b/.github/workflows/macos_install.yml
@@ -29,7 +29,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Prepare
         run: cmake -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
       - name: Build

--- a/.github/workflows/release-script-tests.yml
+++ b/.github/workflows/release-script-tests.yml
@@ -1,7 +1,7 @@
 name: Release Script Tests
 
 on:
-  # workflow_call is used to indicate that a workflow can be called by another workflow. 
+  # workflow_call is used to indicate that a workflow can be called by another workflow.
   workflow_call:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -26,7 +26,7 @@ jobs:
         working-directory: ./tools/release
 
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Prepare Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0

--- a/.github/workflows/release_create.yml
+++ b/.github/workflows/release_create.yml
@@ -1,4 +1,4 @@
-name: Release Create 
+name: Release Create
 
 on:
   pull_request:
@@ -11,16 +11,16 @@ jobs:
   check-release-conditions:
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.merged == true && 
-      github.event.pull_request.base.ref == 'main' && 
-      startsWith(github.event.pull_request.head.ref, 'release/v') && 
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      startsWith(github.event.pull_request.head.ref, 'release/v') &&
       startsWith(github.event.pull_request.user.login, 'github-actions')
-  
+
     steps:
       - name: Check release conditions
-        run: | 
+        run: |
           echo "All conditions have been met!"
-          
+
   release-script-test:
     needs: check-release-conditions
     uses: ./.github/workflows/release-script-tests.yml
@@ -31,18 +31,18 @@ jobs:
     needs: release-script-test
     runs-on: ubuntu-latest
     if: ${{ needs.release-script-test.result == 'success' }}
-      
+
     env:
       NEXT_RELEASE_TAG: ${{ github.event.pull_request.head.ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Prepare Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           cache: 'pip' # caching pip dependencies
-      
+
       - name: Install dependencies
         run: pip install -r ./tools/release/requirements.txt
 
@@ -56,6 +56,6 @@ jobs:
 
       - name: Amalgamation
         run: ./singleheader/amalgamate.py
-      
+
       - name: "Create release"
         run: ./tools/release/create_release.py

--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -1,4 +1,4 @@
-name: Release Prepare 
+name: Release Prepare
 
 on:
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
     env:
       CXX: clang++-14
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Prepare Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r ./tools/release/requirements.txt
-        
+
       - name: Update source code versions
         run: ./tools/release/update_versions.py
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           persist-credentials: false
 

--- a/.github/workflows/ubuntu-release.yml
+++ b/.github/workflows/ubuntu-release.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         cxx: [g++-12, clang++-14]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/ubuntu-s390x.yml
+++ b/.github/workflows/ubuntu-s390x.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: uraimo/run-on-arch-action@517085f0367c8256bcfa753e3e13e1550af09954 # v2.7.1
         name: Test
         id: runcmd

--- a/.github/workflows/ubuntu-sanitized.yml
+++ b/.github/workflows/ubuntu-sanitized.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         shared: [ON, OFF]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/ubuntu-undef.yml
+++ b/.github/workflows/ubuntu-undef.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         shared: [ON, OFF]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
         shared: [ON, OFF]
         cxx: [g++-12, clang++-14]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/ubuntu_install.yml
+++ b/.github/workflows/ubuntu_install.yml
@@ -29,7 +29,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/ubuntu_old.yml
+++ b/.github/workflows/ubuntu_old.yml
@@ -28,7 +28,7 @@ jobs:
         shared: [ON, OFF]
         cxx: [g++-9, clang++-10]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/ubuntu_pedantic.yml
+++ b/.github/workflows/ubuntu_pedantic.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         shared: [ON, OFF]
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare

--- a/.github/workflows/visual_studio.yml
+++ b/.github/workflows/visual_studio.yml
@@ -34,7 +34,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: Win32, devchecks: ON, shared: OFF, config: Debug}
           - {gen: Visual Studio 17 2022, arch: Win32, devchecks: ON, shared: ON, config: Debug}
     steps:
-    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - name: Configure
       run: |
         cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build

--- a/.github/workflows/visual_studio_clang.yml
+++ b/.github/workflows/visual_studio_clang.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - {gen: Visual Studio 17 2022, arch: x64, devchecks: ON}
     steps:
-    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - name: Configure
       run: |
         cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -T ClangCL -B build

--- a/.github/workflows/wpt-updater.yml
+++ b/.github/workflows/wpt-updater.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Fetch tests
         run: tools/update-wpt.sh
       - name: Open pull request


### PR DESCRIPTION
This is required since Node.js 16 is now deprecated