### PR TITLE
prevent missing python warning when format feature not requested

### DIFF
--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,37 +1,41 @@
-find_program(PYTHON_EXECUTABLE python3 python)
-
-if(NOT PYTHON_EXECUTABLE)
-  message(WARNING "Python not found. Skipping lint and format checks.")
+if(NOT DEFINED ENV{LINT_AND_FORMAT_CHECK} AND NOT DEFINED ENV{FORMAT_ENABLED} )
+  # empty early exit, do not look for python
 else()
-  set(LINT_AND_FORMAT_SCRIPT_PATH ${CMAKE_SOURCE_DIR}/tools/lint_and_format.py)
+  find_program(PYTHON_EXECUTABLE python3 python)
 
-  # Should run on CI
-  if(DEFINED ENV{LINT_AND_FORMAT_CHECK})
-    message(STATUS "Checking code with clang-format...")
-    execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} ${LINT_AND_FORMAT_SCRIPT_PATH} check
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      RESULT_VARIABLE clang_check_result
-    )
-
-    if(clang_check_result)
-      message(FATAL_ERROR "Clang-format check failed with error code ${clang_check_result}")
-    endif()
-
+  if(NOT PYTHON_EXECUTABLE)
+    message(WARNING "Python not found. Skipping lint and format checks.")
   else()
-    if(DEFINED ENV{FORMAT_ENABLED})
-      message(STATUS "Formatting code with clang-format...")
+    set(LINT_AND_FORMAT_SCRIPT_PATH ${CMAKE_SOURCE_DIR}/tools/lint_and_format.py)
+
+    # Should run on CI
+    if(DEFINED ENV{LINT_AND_FORMAT_CHECK})
+      message(STATUS "Checking code with clang-format...")
       execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} ${LINT_AND_FORMAT_SCRIPT_PATH} format
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        RESULT_VARIABLE clang_format_result
+              COMMAND ${PYTHON_EXECUTABLE} ${LINT_AND_FORMAT_SCRIPT_PATH} check
+              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+              RESULT_VARIABLE clang_check_result
       )
 
-      if(clang_format_result)
-        message(FATAL_ERROR "Clang-format format failed with error code ${clang_check_result}")
+      if(clang_check_result)
+        message(FATAL_ERROR "Clang-format check failed with error code ${clang_check_result}")
       endif()
+
     else()
-      message(STATUS "Code formatting is not enabled.")
+      if(DEFINED ENV{FORMAT_ENABLED})
+        message(STATUS "Formatting code with clang-format...")
+        execute_process(
+                COMMAND ${PYTHON_EXECUTABLE} ${LINT_AND_FORMAT_SCRIPT_PATH} format
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                RESULT_VARIABLE clang_format_result
+        )
+
+        if(clang_format_result)
+          message(FATAL_ERROR "Clang-format format failed with error code ${clang_check_result}")
+        endif()
+      else()
+        message(STATUS "Code formatting is not enabled.")
+      endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
When consuming this library through fetch-content, cmake warns about missing python on my system.