### PR TITLE
optimize has_tabs_or_newline for NEON

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -243,7 +243,7 @@ ada_really_inline size_t find_next_host_delimiter_special(
     uint8x16_t lowpart = vqtbl1q_u8(low_mask, vandq_u8(word, fmask));
     uint8x16_t highpart = vqtbl1q_u8(high_mask, vshrq_n_u8(word, 4));
     uint8x16_t classify = vandq_u8(lowpart, highpart);
-    if (vmaxvq_u8(classify) != 0) {
+    if (vmaxvq_u32(vreinterpretq_u32_u8(classify)) != 0) {
       uint8x16_t is_zero = vceqq_u8(classify, zero);
       uint16_t is_non_zero = ~to_bitmask(is_zero);
       return i + trailing_zeroes(is_non_zero);
@@ -256,7 +256,7 @@ ada_really_inline size_t find_next_host_delimiter_special(
     uint8x16_t lowpart = vqtbl1q_u8(low_mask, vandq_u8(word, fmask));
     uint8x16_t highpart = vqtbl1q_u8(high_mask, vshrq_n_u8(word, 4));
     uint8x16_t classify = vandq_u8(lowpart, highpart);
-    if (vmaxvq_u8(classify) != 0) {
+    if (vmaxvq_u32(vreinterpretq_u32_u8(classify)) != 0) {
       uint8x16_t is_zero = vceqq_u8(classify, zero);
       uint16_t is_non_zero = ~to_bitmask(is_zero);
       return view.length() - 16 + trailing_zeroes(is_non_zero);
@@ -381,7 +381,7 @@ ada_really_inline size_t find_next_host_delimiter(std::string_view view,
     uint8x16_t lowpart = vqtbl1q_u8(low_mask, vandq_u8(word, fmask));
     uint8x16_t highpart = vqtbl1q_u8(high_mask, vshrq_n_u8(word, 4));
     uint8x16_t classify = vandq_u8(lowpart, highpart);
-    if (vmaxvq_u8(classify) != 0) {
+    if (vmaxvq_u32(vreinterpretq_u32_u8(classify)) != 0) {
       uint8x16_t is_zero = vceqq_u8(classify, zero);
       uint16_t is_non_zero = ~to_bitmask(is_zero);
       return i + trailing_zeroes(is_non_zero);
@@ -394,7 +394,7 @@ ada_really_inline size_t find_next_host_delimiter(std::string_view view,
     uint8x16_t lowpart = vqtbl1q_u8(low_mask, vandq_u8(word, fmask));
     uint8x16_t highpart = vqtbl1q_u8(high_mask, vshrq_n_u8(word, 4));
     uint8x16_t classify = vandq_u8(lowpart, highpart);
-    if (vmaxvq_u8(classify) != 0) {
+    if (vmaxvq_u32(vreinterpretq_u32_u8(classify)) != 0) {
       uint8x16_t is_zero = vceqq_u8(classify, zero);
       uint16_t is_non_zero = ~to_bitmask(is_zero);
       return view.length() - 16 + trailing_zeroes(is_non_zero);

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -72,7 +72,7 @@ ada_really_inline bool has_tabs_or_newline(
    * credit for algorithmic idea: @aqrit, credit for description:
    * @DenisYaroshevskiy
    */
-  static uint8_t rnt_array[16] = {1, 0,  0, 0, 0,  0, 0, 0,
+  static uint8_t rnt_array[16] = {1, 0, 0,  0, 0, 0,  0, 0,
                                   0, 9, 10, 0, 0, 13, 0, 0};
   const uint8x16_t rnt = vld1q_u8(rnt_array);
   // m['0xd', '0xa', '0x9']

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -73,7 +73,7 @@ ada_really_inline bool has_tabs_or_newline(
    * @DenisYaroshevskiy
    */
   static uint8_t rnt_array[16] = {1, 0,  0, 0, 0,  0, 0, 0,
-                                  9, 10, 0, 0, 13, 0, 0, 0};
+                                  0, 9, 10, 0, 0, 13, 0, 0};
   const uint8x16_t rnt = vld1q_u8(rnt_array);
   // m['0xd', '0xa', '0x9']
   uint8x16_t running{0};

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -60,6 +60,7 @@ ada_really_inline bool has_tabs_or_newline(
   }
   // fast path for long strings (expected to be common)
   size_t i = 0;
+  // credit: aqrit
   static uint8_t rnt_array[16] = {1, 0,  0, 0, 0,  0, 0, 0,
                                   9, 10, 0, 0, 13, 0, 0, 0};
   const uint8x16_t rnt = vld1q_u8(rnt_array);

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -60,7 +60,18 @@ ada_really_inline bool has_tabs_or_newline(
   }
   // fast path for long strings (expected to be common)
   size_t i = 0;
-  // credit: aqrit
+  /**
+   * The fastest way to check for `\t` (==9), '\n'(== 10) and `\r` (==13) relies
+   * on table lookup instruction. We notice that these are all unique numbers
+   * between 0..15. Let's prepare a special register, where we put '\t' in the
+   * 9th position, '\n' - 10th and '\r' - 13th. Then we shuffle this register by
+   * input register. If the input had `\t` in position X then this shuffled
+   * register will also have '\t' in that position. Comparing input with this
+   * shuffled register will mark us all interesting characters in the input.
+   *
+   * credit for algorithmic idea: @aqrit, credit for description:
+   * @DenisYaroshevskiy
+   */
   static uint8_t rnt_array[16] = {1, 0,  0, 0, 0,  0, 0, 0,
                                   9, 10, 0, 0, 13, 0, 0, 0};
   const uint8x16_t rnt = vld1q_u8(rnt_array);

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -87,7 +87,7 @@ ada_really_inline bool has_tabs_or_newline(
         vld1q_u8((const uint8_t*)user_input.data() + user_input.length() - 16);
     running = vorrq_u8(running, vceqq_u8(vqtbl1q_u8(rnt, word), word));
   }
-  return vmaxvq_u8(running) != 0;
+  return vmaxvq_u32(vreinterpretq_u32_u8(running)) != 0;
 }
 #elif ADA_SSE2
 ada_really_inline bool has_tabs_or_newline(


### PR DESCRIPTION
@DenisYaroshevskiy suggested this optimization. He meant it for x64, but we do not currently support runtime dispatching nor do we expect our users to compile for a specific hardware, so we are limited to SSE2, which is not powerful enough for this trick.

On Apple M2, using `benchdata`. I repeat the benchmarks twice. 

Before:

```
BasicBench_AdaURL_href              24067654 ns     24065069 ns           29 GHz=3.50365 cycle/byte=9.4421 cycles/url=820.133 instructions/byte=40.1304 instructions/cycle=4.25016 instructions/ns=14.8911 instructions/url=3.4857k ns/url=234.079 speed=361.025M/s time/byte=2.76989ns time/url=240.591ns url/s=4.15644M/s
BasicBench_AdaURL_aggregator_href   16092015 ns     16089636 ns           44 GHz=3.50451 cycle/byte=6.29615 cycles/url=546.879 instructions/byte=28.065 instructions/cycle=4.45749 instructions/ns=15.6213 instructions/url=2.43771k ns/url=156.05 speed=539.981M/s time/byte=1.85192ns time/url=160.856ns url/s=6.21673M/s
```

```
BasicBench_AdaURL_href              23550776 ns     23549200 ns           30 GHz=3.40822 cycle/byte=9.29203 cycles/url=807.098 instructions/byte=40.2779 instructions/cycle=4.33467 instructions/ns=14.7735 instructions/url=3.49851k ns/url=236.81 speed=368.934M/s time/byte=2.71051ns time/url=235.433ns url/s=4.24749M/s
BasicBench_AdaURL_aggregator_href   16198858 ns     16197000 ns           43 GHz=3.49614 cycle/byte=6.38115 cycles/url=554.262 instructions/byte=28.249 instructions/cycle=4.42694 instructions/ns=15.4772 instructions/url=2.45368k ns/url=158.535 speed=536.401M/s time/byte=1.86428ns time/url=161.93ns url/s=6.17553M/s
```

After

```
BasicBench_AdaURL_href              24435351 ns     24317655 ns           29 GHz=3.49896 cycle/byte=9.30687 cycles/url=808.387 instructions/byte=40.1032 instructions/cycle=4.30899 instructions/ns=15.077 instructions/url=3.48333k ns/url=231.036 speed=357.275M/s time/byte=2.79896ns time/url=243.116ns url/s=4.11327M/s
BasicBench_AdaURL_aggregator_href   16043040 ns     16042409 ns           44 GHz=3.47943 cycle/byte=6.27539 cycles/url=545.075 instructions/byte=27.8984 instructions/cycle=4.44569 instructions/ns=15.4685 instructions/url=2.42323k ns/url=156.656 speed=541.57M/s time/byte=1.84648ns time/url=160.384ns url/s=6.23504M/s
```

```
BasicBench_AdaURL_href              24023714 ns     23998931 ns           29 GHz=3.45169 cycle/byte=9.32467 cycles/url=809.934 instructions/byte=40.0756 instructions/cycle=4.2978 instructions/ns=14.8347 instructions/url=3.48093k ns/url=234.648 speed=362.02M/s time/byte=2.76228ns time/url=239.929ns url/s=4.16789M/s
BasicBench_AdaURL_aggregator_href   16024929 ns     16024568 ns           44 GHz=3.5045 cycle/byte=6.27804 cycles/url=545.306 instructions/byte=27.8983 instructions/cycle=4.4438 instructions/ns=15.5733 instructions/url=2.42323k ns/url=155.602 speed=542.173M/s time/byte=1.84443ns time/url=160.206ns url/s=6.24198M/s
```


It seems that this can reduce the number of instructions by maybe 1%. The speed gain is similarly small.