### PR TITLE
Add can_parse to benchmarks

### DIFF
--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -89,7 +89,6 @@ auto BasicBench_AdaURL_aggregator_href =
     BasicBench_AdaURL<PARSE_AND_HREF, ada::url_aggregator>;
 BENCHMARK(BasicBench_AdaURL_aggregator_href);
 
-
 static void BasicBench_AdaURL_CanParse(benchmark::State& state) {
   // volatile to prevent optimizations.
   volatile size_t success = 0;

--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -89,6 +89,68 @@ auto BasicBench_AdaURL_aggregator_href =
     BasicBench_AdaURL<PARSE_AND_HREF, ada::url_aggregator>;
 BENCHMARK(BasicBench_AdaURL_aggregator_href);
 
+
+static void BasicBench_AdaURL_CanParse(benchmark::State& state) {
+  // volatile to prevent optimizations.
+  volatile size_t success = 0;
+  volatile size_t href_size = 0;
+
+  for (auto _ : state) {
+    for (std::string& url_string : url_examples) {
+      bool can_parse = ada::can_parse(url_string);
+      if (can_parse) {
+        success++;
+      }
+    }
+  }
+  if (collector.has_events()) {
+    event_aggregate aggregate{};
+    for (size_t i = 0; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      for (std::string& url_string : url_examples) {
+        bool can_parse = ada::can_parse(url_string);
+        if (can_parse) {
+          success++;
+        }
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["cycles/url"] =
+        aggregate.best.cycles() / std::size(url_examples);
+    state.counters["instructions/url"] =
+        aggregate.best.instructions() / std::size(url_examples);
+    state.counters["instructions/cycle"] =
+        aggregate.best.instructions() / aggregate.best.cycles();
+    state.counters["instructions/byte"] =
+        aggregate.best.instructions() / url_examples_bytes;
+    state.counters["instructions/ns"] =
+        aggregate.best.instructions() / aggregate.best.elapsed_ns();
+    state.counters["GHz"] =
+        aggregate.best.cycles() / aggregate.best.elapsed_ns();
+    state.counters["ns/url"] =
+        aggregate.best.elapsed_ns() / std::size(url_examples);
+    state.counters["cycle/byte"] = aggregate.best.cycles() / url_examples_bytes;
+  }
+  (void)success;
+  state.counters["time/byte"] = benchmark::Counter(
+      url_examples_bytes, benchmark::Counter::kIsIterationInvariantRate |
+                              benchmark::Counter::kInvert);
+  state.counters["time/url"] =
+      benchmark::Counter(double(std::size(url_examples)),
+                         benchmark::Counter::kIsIterationInvariantRate |
+                             benchmark::Counter::kInvert);
+  state.counters["speed"] = benchmark::Counter(
+      url_examples_bytes, benchmark::Counter::kIsIterationInvariantRate);
+  state.counters["url/s"] =
+      benchmark::Counter(double(std::size(url_examples)),
+                         benchmark::Counter::kIsIterationInvariantRate);
+}
+
+BENCHMARK(BasicBench_AdaURL_CanParse);
+
 #if ADA_url_whatwg_ENABLED
 size_t count_whatwg_invalid() {
   size_t how_many = 0;

--- a/benchmarks/benchmark_template.cpp
+++ b/benchmarks/benchmark_template.cpp
@@ -92,7 +92,6 @@ BENCHMARK(BasicBench_AdaURL_aggregator_href);
 static void BasicBench_AdaURL_CanParse(benchmark::State& state) {
   // volatile to prevent optimizations.
   volatile size_t success = 0;
-  volatile size_t href_size = 0;
 
   for (auto _ : state) {
     for (std::string& url_string : url_examples) {


### PR DESCRIPTION
Relates to: https://github.com/ada-url/ada/issues/377

```
Load Average: 0.06, 0.09, 0.09
ada spec: Ada follows whatwg/url
bad urls: ---------------------
ada---count of bad URLs       26
servo/url---count of bad URLs 26
whatwg---count of bad URLs    26
-------------------------------

bytes/URL: 86.859205
curl : OMITTED
input bytes: 8688092
number of URLs: 100025
performance counters: Enabled
rust version : 1.76.0
zuri : OMITTED
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
BasicBench_AdaURL_href              30362199 ns     30356773 ns           23 GHz=4.29081 cycle/byte=14.8176 cycles/url=1.28704k instructions/byte=34.4159 instructions/cycle=2.32264 instructions/ns=9.96599 instructions/url=2.98933k ns/url=299.954 speed=286.199M/s time/byte=3.49407ns time/url=303.492ns url/s=3.29498M/s
BasicBench_AdaURL_aggregator_href   19152527 ns     19150861 ns           36 GHz=4.26512 cycle/byte=9.37811 cycles/url=814.575 instructions/byte=23.009 instructions/cycle=2.45349 instructions/ns=10.4644 instructions/url=1.99855k ns/url=190.985 speed=453.666M/s time/byte=2.20427ns time/url=191.461ns url/s=5.223M/s
BasicBench_AdaURL_CanParse          19546808 ns     19545551 ns           36 GHz=4.29825 cycle/byte=9.54439 cycles/url=829.018 instructions/byte=23.5847 instructions/cycle=2.47105 instructions/ns=10.6212 instructions/url=2.04855k ns/url=192.874 speed=444.505M/s time/byte=2.24969ns time/url=195.407ns url/s=5.11753M/s
BasicBench_whatwg                   52564561 ns     52559116 ns           13 GHz=4.26788 cycle/byte=25.6363 cycles/url=2.22675k instructions/byte=68.8033 instructions/cycle=2.68382 instructions/ns=11.4542 instructions/url=5.9762k ns/url=521.746 speed=165.301M/s time/byte=6.04956ns time/url=525.46ns url/s=1.9031M/s
BasicBench_ServoUrl                 81868634 ns     81861762 ns            8 GHz=4.28335 cycle/byte=40.2365 cycles/url=3.49491k instructions/byte=108.216 instructions/cycle=2.6895 instructions/ns=11.5201 instructions/url=9.39957k ns/url=815.93 speed=106.131M/s time/byte=9.42229ns time/url=818.413ns url/s=1.22188M/s
``` 