### PR TITLE
perf: improve has_tabs_or_newline performance

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -273,6 +273,7 @@ if(RUST_FOUND)
 
   # Check if servo-url target was created successfully
   if(TARGET servo-url)
+    message(STATUS "servo-url target was created. Linking benchmarks and servo-url.")
     target_link_libraries(bench PRIVATE servo-url)
     target_compile_definitions(bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
 
@@ -287,8 +288,6 @@ if(RUST_FOUND)
 
     target_link_libraries(wpt_bench PRIVATE servo-url)
     target_compile_definitions(wpt_bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
-  else()
-    message(WARNING "servo-url target was not created. Skipping linking benchmarks and servo-url.")
   endif()
 else()
   message(STATUS "Rust/Cargo is unavailable." )

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -16,6 +16,10 @@ ADA_POP_DISABLE_WARNINGS
 
 namespace ada::unicode {
 
+constexpr bool is_tabs_or_newline(char c) noexcept {
+  return c == '\r' || c == '\n' || c == '\t';
+}
+
 constexpr uint64_t broadcast(uint8_t v) noexcept {
   return 0x101010101010101ull * v;
 }
@@ -50,13 +54,8 @@ ada_really_inline bool has_tabs_or_newline(
     std::string_view user_input) noexcept {
   // first check for short strings in which case we do it naively.
   if (user_input.size() < 16) {  // slow path
-    for (size_t i = 0; i < user_input.size(); i++) {
-      if (user_input[i] == '\r' || user_input[i] == '\n' ||
-          user_input[i] == '\t') {
-        return true;
-      }
-    }
-    return false;
+    return std::any_of(user_input.begin(), user_input.end(),
+                       is_tabs_or_newline);
   }
   // fast path for long strings (expected to be common)
   size_t i = 0;
@@ -94,13 +93,8 @@ ada_really_inline bool has_tabs_or_newline(
     std::string_view user_input) noexcept {
   // first check for short strings in which case we do it naively.
   if (user_input.size() < 16) {  // slow path
-    for (size_t i = 0; i < user_input.size(); i++) {
-      if (user_input[i] == '\r' || user_input[i] == '\n' ||
-          user_input[i] == '\t') {
-        return true;
-      }
-    }
-    return false;
+    return std::any_of(user_input.begin(), user_input.end(),
+                       is_tabs_or_newline);
   }
   // fast path for long strings (expected to be common)
   size_t i = 0;


### PR DESCRIPTION
This seems to slightly reduce the instruction count for `url_aggregator`, but please run local benchmarks to verify

Before:
- ada_url -> instructions/url=2.55753k
- ada_url_aggregator -> instructions/url=2.76077k

After:
- ada_url -> instructions/url=2.55742k
- ada_url_aggregator -> instructions/url=2.76044k