### PR TITLE
refactor(ada_c/ada_free_owned_string): remove unused code

### DIFF
--- a/src/ada_c.cpp
+++ b/src/ada_c.cpp
@@ -125,8 +125,6 @@ ada_owned_string ada_get_origin(ada_url result) noexcept {
 
 void ada_free_owned_string(ada_owned_string owned) noexcept {
   delete[] owned.data;
-  owned.data = nullptr;
-  owned.length = 0;
 }
 
 ada_string ada_get_href(ada_url result) noexcept {


### PR DESCRIPTION
Setting parameters of an object passed by value [do nothing even at GCC Og level](https://godbolt.org/z/M8exqe8oh)