### PR TITLE
build: use fixed version for run-on-arch-action

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -28,7 +28,7 @@ jobs:
         shared: [OFF]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@b0ffb25eb00af00468375982384441f063da1741 # v2.7.2
         name: Build and Test
         id: runcmd
         env:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,17 +21,17 @@ jobs:
     steps:
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@b07cc908abf97529a95a4dd9b3d152bf4f101e71 # master
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
          oss-fuzz-project-name: 'ada-url'
          language: c++
          sanitizer: ${{ matrix.sanitizer }}
       - name: Run Fuzzers (${{ matrix.sanitizer }})
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@b07cc908abf97529a95a4dd9b3d152bf4f101e71 # master
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
          oss-fuzz-project-name: 'ada-url'
          language: c++
-         fuzz-seconds: 300
+         fuzz-seconds: 600
          sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
Fixes https://github.com/ada-url/ada/security/code-scanning/97