### PR TITLE
feat: add `url_search_params_reset` api

### DIFF
--- a/fuzz/url_search_params.cc
+++ b/fuzz/url_search_params.cc
@@ -48,5 +48,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     entries.next();
   }
 
+  // This is testing a private method used only for C API.
+  std::string resetted_value = fdp.ConsumeRandomLengthString(256);
+  search_params.reset(resetted_value);
+
   return 0;
 }

--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -22,6 +22,11 @@ namespace ada {
 template <typename T, ada::url_search_params_iter_type Type>
 url_search_params url_search_params_iter<T, Type>::EMPTY;
 
+inline void url_search_params::reset(std::string_view input) {
+  params.clear();
+  initialize(input);
+}
+
 inline void url_search_params::initialize(std::string_view input) {
   if (!input.empty() && input.front() == '?') {
     input.remove_prefix(1);

--- a/include/ada/url_search_params.h
+++ b/include/ada/url_search_params.h
@@ -130,6 +130,14 @@ struct url_search_params {
   inline auto back() const { return params.back(); }
   inline auto operator[](size_t index) const { return params[index]; }
 
+  /**
+   * @private
+   * Used to reset the search params to a new input.
+   * Used primarily for C API.
+   * @param input
+   */
+  void reset(std::string_view input);
+
  private:
   typedef std::pair<std::string, std::string> key_value_pair;
   std::vector<key_value_pair> params{};

--- a/include/ada_c.h
+++ b/include/ada_c.h
@@ -151,6 +151,8 @@ ada_string ada_search_params_get(ada_url_search_params result, const char* key,
                                  size_t key_length);
 ada_strings ada_search_params_get_all(ada_url_search_params result,
                                       const char* key, size_t key_length);
+void ada_search_params_reset(ada_url_search_params result, const char* input,
+                             size_t length);
 ada_url_search_params_keys_iter ada_search_params_get_keys(
     ada_url_search_params result);
 ada_url_search_params_values_iter ada_search_params_get_values(

--- a/src/ada_c.cpp
+++ b/src/ada_c.cpp
@@ -503,6 +503,15 @@ void ada_search_params_sort(ada_url_search_params result) {
   }
 }
 
+void ada_search_params_reset(ada_url_search_params result, const char* input,
+                             size_t length) {
+  ada::result<ada::url_search_params>& r =
+      *(ada::result<ada::url_search_params>*)result;
+  if (r) {
+    r->reset(std::string_view(input, length));
+  }
+}
+
 void ada_search_params_append(ada_url_search_params result, const char* key,
                               size_t key_length, const char* value,
                               size_t value_length) {

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -259,6 +259,21 @@ TEST(ada_c, ada_get_scheme_type) {
   SUCCEED();
 }
 
+TEST(ada_c, ada_search_params_reset) {
+  ada_url_search_params out;
+
+  std::string_view input = "a=b&c=d&c=e&f=g";
+  out = ada_parse_search_params(input.data(), input.size());
+  ASSERT_EQ(ada_search_params_size(out), 4);
+
+  std::string_view resetted_value = "a=b";
+  ada_search_params_reset(out, resetted_value.data(), resetted_value.size());
+  ASSERT_EQ(ada_search_params_size(out), 1);
+
+  ada_free_search_params(out);
+  SUCCEED();
+}
+
 TEST(ada_c, ada_url_search_params) {
   std::string_view input;
   ada_url_search_params out;


### PR DESCRIPTION
Adds a new API to reuse the existing std::vector.

Usage:

```c
TEST(ada_c, ada_search_params_reset) {
  ada_url_search_params out;

  std::string_view input = "a=b&c=d&c=e&f=g";
  out = ada_parse_search_params(input.data(), input.size());
  ASSERT_EQ(ada_search_params_size(out), 4);

  std::string_view resetted_value = "a=b";
  ada_search_params_reset(out, resetted_value.data(), resetted_value.size());
  ASSERT_EQ(ada_search_params_size(out), 1);

  ada_free_search_params(out);
  SUCCEED();
}
```

Fixes https://github.com/ada-url/ada/issues/699