### PR TITLE
check template arguments with constexpr

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -428,7 +428,7 @@ bool percent_encode(const std::string_view input, const uint8_t character_set[],
     ada_log("percent_encode encoding not needed.");
     return false;
   }
-  if (!append) {
+  if constexpr (!append) {
     out.clear();
   }
   ada_log("percent_encode appending ", std::distance(input.begin(), pointer),

--- a/src/url-setters.cpp
+++ b/src/url-setters.cpp
@@ -37,7 +37,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
     // Note: the 'found_colon' value is true if and only if a colon was
     // encountered while not inside brackets.
     if (found_colon) {
-      if (override_hostname) {
+      if constexpr (override_hostname) {
         return false;
       }
       std::string_view buffer = new_host.substr(location + 1);

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -336,7 +336,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
    *http, https), in which case, we can go really fast.
    **/
   if (is_input_special) {  // fast path!!!
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // If url's scheme is not a special scheme and buffer is a special scheme,
       // then return.
       if (is_special() != is_input_special) {
@@ -360,7 +360,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
 
     type = parsed_type;
 
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // This is uncommon.
       uint16_t urls_scheme_port = get_special_port();
 
@@ -380,7 +380,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
     // bool is_ascii =
     unicode::to_lower_ascii(_buffer.data(), _buffer.size());
 
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // If url's scheme is a special scheme and buffer is not a special scheme,
       // then return. If url's scheme is not a special scheme and buffer is a
       // special scheme, then return.
@@ -404,7 +404,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
 
     set_scheme(std::move(_buffer));
 
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // This is uncommon.
       uint16_t urls_scheme_port = get_special_port();
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -27,7 +27,7 @@ template <bool has_state_override>
    *http, https), in which case, we can go really fast.
    **/
   if (is_input_special) {  // fast path!!!
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // If url's scheme is not a special scheme and buffer is a special scheme,
       // then return.
       if (is_special() != is_input_special) {
@@ -52,7 +52,7 @@ template <bool has_state_override>
     type = parsed_type;
     set_scheme_from_view_with_colon(input_with_colon);
 
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // This is uncommon.
       uint16_t urls_scheme_port = get_special_port();
 
@@ -69,7 +69,7 @@ template <bool has_state_override>
     // need to check the return value.
     unicode::to_lower_ascii(_buffer.data(), _buffer.size());
 
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // If url's scheme is a special scheme and buffer is not a special scheme,
       // then return. If url's scheme is not a special scheme and buffer is a
       // special scheme, then return.
@@ -94,7 +94,7 @@ template <bool has_state_override>
 
     set_scheme(_buffer);
 
-    if (has_state_override) {
+    if constexpr (has_state_override) {
       // This is uncommon.
       uint16_t urls_scheme_port = get_special_port();
 
@@ -539,7 +539,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // Note: the 'found_colon' value is true if and only if a colon was
     // encountered while not inside brackets.
     if (found_colon) {
-      if (override_hostname) {
+      if constexpr (override_hostname) {
         return false;
       }
       std::string_view sub_buffer = new_host.substr(location + 1);


### PR DESCRIPTION
It seems we forgot to check them using `constexpr`

## Before

```
BasicBench_AdaURL_url                202523 ns       201802 ns         3461 GHz=4.79069 cycle/byte=44.3605 cycles/url=1.07173k instructions/byte=111.316 instructions/cycle=2.50935 instructions/ns=12.0215 instructions/url=2.68935k ns/url=223.711 speed=102.001M/s time/byte=9.80384ns time/url=236.857ns url/s=4.22195M/s
BasicBench_AdaURL_url_aggregator     166170 ns       166133 ns         4221 GHz=4.79185 cycle/byte=36.7923 cycles/url=888.888 instructions/byte=113.701 instructions/cycle=3.09034 instructions/ns=14.8085 instructions/url=2.74697k ns/url=185.5 speed=123.901M/s time/byte=8.07096ns time/url=194.991ns url/s=5.12843M/s
```

## After

```
BasicBench_AdaURL_url                194068 ns       194060 ns         3588 GHz=4.79139 cycle/byte=44.2933 cycles/url=1.07011k instructions/byte=111.334 instructions/cycle=2.51357 instructions/ns=12.0435 instructions/url=2.6898k ns/url=223.34 speed=106.07M/s time/byte=9.42769ns time/url=227.77ns url/s=4.3904M/s
BasicBench_AdaURL_url_aggregator     160928 ns       160918 ns         4346 GHz=4.79164 cycle/byte=36.0423 cycles/url=870.768 instructions/byte=113.71 instructions/cycle=3.15491 instructions/ns=15.1172 instructions/url=2.7472k ns/url=181.727 speed=127.916M/s time/byte=7.81761ns time/url=188.871ns url/s=5.29463M/s
```