### PR TITLE
convert more functions to constexpr

### DIFF
--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -148,19 +148,19 @@ inline void url::update_base_port(std::optional<uint16_t> input) {
   port = input;
 }
 
-inline void url::clear_pathname() { path.clear(); }
+constexpr void url::clear_pathname() { path.clear(); }
 
-inline void url::clear_search() { query = std::nullopt; }
+constexpr void url::clear_search() { query = std::nullopt; }
 
-[[nodiscard]] inline bool url::has_hash() const noexcept {
+[[nodiscard]] constexpr bool url::has_hash() const noexcept {
   return hash.has_value();
 }
 
-[[nodiscard]] inline bool url::has_search() const noexcept {
+[[nodiscard]] constexpr bool url::has_search() const noexcept {
   return query.has_value();
 }
 
-inline void url::set_protocol_as_file() { type = ada::scheme::type::FILE; }
+constexpr void url::set_protocol_as_file() { type = ada::scheme::type::FILE; }
 
 inline void url::set_scheme(std::string &&new_scheme) noexcept {
   type = ada::scheme::get_scheme_type(new_scheme);
@@ -170,12 +170,12 @@ inline void url::set_scheme(std::string &&new_scheme) noexcept {
   }
 }
 
-inline void url::copy_scheme(ada::url &&u) noexcept {
+constexpr void url::copy_scheme(ada::url &&u) noexcept {
   non_special_scheme = u.non_special_scheme;
   type = u.type;
 }
 
-inline void url::copy_scheme(const ada::url &u) {
+constexpr void url::copy_scheme(const ada::url &u) {
   non_special_scheme = u.non_special_scheme;
   type = u.type;
 }

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -149,7 +149,7 @@ struct url : url_base {
    * @return a newly allocated string.
    * @see https://url.spec.whatwg.org/#dom-url-pathname
    */
-  [[nodiscard]] std::string_view get_pathname() const noexcept;
+  [[nodiscard]] constexpr std::string_view get_pathname() const noexcept;
 
   /**
    * Compute the pathname length in bytes without instantiating a view or a
@@ -283,9 +283,9 @@ struct url : url_base {
   [[nodiscard]] ada_really_inline ada::url_components get_components()
       const noexcept;
   /** @return true if the URL has a hash component */
-  [[nodiscard]] inline bool has_hash() const noexcept override;
+  [[nodiscard]] constexpr bool has_hash() const noexcept override;
   /** @return true if the URL has a search component */
-  [[nodiscard]] inline bool has_search() const noexcept override;
+  [[nodiscard]] constexpr bool has_search() const noexcept override;
 
  private:
   friend ada::url ada::parser::parse_url<ada::url>(std::string_view,
@@ -362,12 +362,6 @@ struct url : url_base {
   }
 
   /**
-   * Take the scheme from another URL. The scheme string is copied from the
-   * provided url.
-   */
-  inline void copy_scheme(const ada::url &u);
-
-  /**
    * Parse the host from the provided input. We assume that
    * the input does not contain spaces or tabs. Control
    * characters and spaces are not trimmed (they should have
@@ -380,9 +374,9 @@ struct url : url_base {
   template <bool has_state_override = false>
   [[nodiscard]] ada_really_inline bool parse_scheme(std::string_view input);
 
-  inline void clear_pathname() override;
-  inline void clear_search() override;
-  inline void set_protocol_as_file();
+  constexpr void clear_pathname() override;
+  constexpr void clear_search() override;
+  constexpr void set_protocol_as_file();
 
   /**
    * Parse the path from the provided input.
@@ -407,7 +401,13 @@ struct url : url_base {
    * Take the scheme from another URL. The scheme string is moved from the
    * provided url.
    */
-  inline void copy_scheme(ada::url &&u) noexcept;
+  constexpr void copy_scheme(ada::url &&u) noexcept;
+
+  /**
+   * Take the scheme from another URL. The scheme string is copied from the
+   * provided url.
+   */
+  constexpr void copy_scheme(const ada::url &u);
 
 };  // struct url
 

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -412,7 +412,7 @@ inline void url_aggregator::append_base_username(const std::string_view input) {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void url_aggregator::clear_password() {
+constexpr void url_aggregator::clear_password() {
   ada_log("url_aggregator::clear_password ", to_string(), "\n", to_diagram());
   ADA_ASSERT_TRUE(validate());
   if (!has_password()) {
@@ -634,7 +634,7 @@ inline void url_aggregator::clear_hash() {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void url_aggregator::clear_pathname() {
+constexpr void url_aggregator::clear_pathname() {
   ada_log("url_aggregator::clear_pathname");
   ADA_ASSERT_TRUE(validate());
   uint32_t ending_index = uint32_t(buffer.size());
@@ -669,7 +669,7 @@ inline void url_aggregator::clear_pathname() {
   ada_log("url_aggregator::clear_pathname completed, running checks... ok");
 }
 
-inline void url_aggregator::clear_hostname() {
+constexpr void url_aggregator::clear_hostname() {
   ada_log("url_aggregator::clear_hostname");
   ADA_ASSERT_TRUE(validate());
   if (!has_authority()) {
@@ -706,22 +706,22 @@ inline void url_aggregator::clear_hostname() {
   ADA_ASSERT_TRUE(validate());
 }
 
-[[nodiscard]] inline bool url_aggregator::has_hash() const noexcept {
+[[nodiscard]] constexpr bool url_aggregator::has_hash() const noexcept {
   ada_log("url_aggregator::has_hash");
   return components.hash_start != url_components::omitted;
 }
 
-[[nodiscard]] inline bool url_aggregator::has_search() const noexcept {
+[[nodiscard]] constexpr bool url_aggregator::has_search() const noexcept {
   ada_log("url_aggregator::has_search");
   return components.search_start != url_components::omitted;
 }
 
-ada_really_inline bool url_aggregator::has_credentials() const noexcept {
+constexpr bool url_aggregator::has_credentials() const noexcept {
   ada_log("url_aggregator::has_credentials");
   return has_non_empty_username() || has_non_empty_password();
 }
 
-inline bool url_aggregator::cannot_have_credentials_or_port() const {
+constexpr bool url_aggregator::cannot_have_credentials_or_port() const {
   ada_log("url_aggregator::cannot_have_credentials_or_port");
   return type == ada::scheme::type::FILE ||
          components.host_start == components.host_end;
@@ -732,7 +732,7 @@ url_aggregator::get_components() const noexcept {
   return components;
 }
 
-[[nodiscard]] inline bool ada::url_aggregator::has_authority() const noexcept {
+[[nodiscard]] constexpr bool ada::url_aggregator::has_authority() const noexcept {
   ada_log("url_aggregator::has_authority");
   // Performance: instead of doing this potentially expensive check, we could
   // have a boolean in the struct.
@@ -767,28 +767,28 @@ inline void ada::url_aggregator::add_authority_slashes_if_needed() noexcept {
   ADA_ASSERT_TRUE(validate());
 }
 
-inline void ada::url_aggregator::reserve(uint32_t capacity) {
+constexpr void ada::url_aggregator::reserve(uint32_t capacity) {
   buffer.reserve(capacity);
 }
 
-inline bool url_aggregator::has_non_empty_username() const noexcept {
+constexpr bool url_aggregator::has_non_empty_username() const noexcept {
   ada_log("url_aggregator::has_non_empty_username");
   return components.protocol_end + 2 < components.username_end;
 }
 
-inline bool url_aggregator::has_non_empty_password() const noexcept {
+constexpr bool url_aggregator::has_non_empty_password() const noexcept {
   ada_log("url_aggregator::has_non_empty_password");
   return components.host_start - components.username_end > 0;
 }
 
-inline bool url_aggregator::has_password() const noexcept {
+constexpr bool url_aggregator::has_password() const noexcept {
   ada_log("url_aggregator::has_password");
   // This function does not care about the length of the password
   return components.host_start > components.username_end &&
          buffer[components.username_end] == ':';
 }
 
-inline bool url_aggregator::has_empty_hostname() const noexcept {
+constexpr bool url_aggregator::has_empty_hostname() const noexcept {
   if (!has_hostname()) {
     return false;
   }
@@ -801,18 +801,18 @@ inline bool url_aggregator::has_empty_hostname() const noexcept {
   return components.username_end != components.host_start;
 }
 
-inline bool url_aggregator::has_hostname() const noexcept {
+constexpr bool url_aggregator::has_hostname() const noexcept {
   return has_authority();
 }
 
-inline bool url_aggregator::has_port() const noexcept {
+constexpr bool url_aggregator::has_port() const noexcept {
   ada_log("url_aggregator::has_port");
   // A URL cannot have a username/password/port if its host is null or the empty
   // string, or its scheme is "file".
   return has_hostname() && components.pathname_start != components.host_end;
 }
 
-[[nodiscard]] inline bool url_aggregator::has_dash_dot() const noexcept {
+[[nodiscard]] constexpr bool url_aggregator::has_dash_dot() const noexcept {
   // If url's host is null, url does not have an opaque path, url's path's size
   // is greater than 1, and url's path[0] is the empty string, then append
   // U+002F (/) followed by U+002E (.) to output.
@@ -844,7 +844,7 @@ inline bool url_aggregator::has_port() const noexcept {
          buffer[components.host_end + 1] == '.';
 }
 
-[[nodiscard]] inline std::string_view url_aggregator::get_href() const noexcept
+[[nodiscard]] constexpr std::string_view url_aggregator::get_href() const noexcept
     ada_lifetime_bound {
   ada_log("url_aggregator::get_href");
   return buffer;
@@ -889,7 +889,7 @@ ada_really_inline size_t url_aggregator::parse_port(
   return consumed;
 }
 
-inline void url_aggregator::set_protocol_as_file() {
+constexpr void url_aggregator::set_protocol_as_file() {
   ada_log("url_aggregator::set_protocol_as_file ");
   ADA_ASSERT_TRUE(validate());
   type = ada::scheme::type::FILE;

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -57,7 +57,7 @@ struct url_aggregator : url_base {
    * @see https://url.spec.whatwg.org/#dom-url-href
    * @see https://url.spec.whatwg.org/#concept-url-serializer
    */
-  [[nodiscard]] inline std::string_view get_href() const noexcept
+  [[nodiscard]] constexpr std::string_view get_href() const noexcept
       ada_lifetime_bound;
   /**
    * The username getter steps are to return this's URL's username.
@@ -114,7 +114,7 @@ struct url_aggregator : url_base {
    * @return a lightweight std::string_view.
    * @see https://url.spec.whatwg.org/#dom-url-pathname
    */
-  [[nodiscard]] std::string_view get_pathname() const noexcept
+  [[nodiscard]] constexpr std::string_view get_pathname() const noexcept
       ada_lifetime_bound;
   /**
    * Compute the pathname length in bytes without instantiating a view or a
@@ -144,7 +144,7 @@ struct url_aggregator : url_base {
    * A URL includes credentials if its username or password is not the empty
    * string.
    */
-  [[nodiscard]] ada_really_inline bool has_credentials() const noexcept;
+  [[nodiscard]] ada_really_inline constexpr bool has_credentials() const noexcept;
 
   /**
    * Useful for implementing efficient serialization for the URL.
@@ -183,24 +183,24 @@ struct url_aggregator : url_base {
    * @return true if the URL is valid, otherwise return true of the offsets are
    * possible.
    */
-  [[nodiscard]] bool validate() const noexcept;
+  [[nodiscard]] constexpr bool validate() const noexcept;
 
   /** @return true if it has an host but it is the empty string */
-  [[nodiscard]] inline bool has_empty_hostname() const noexcept;
+  [[nodiscard]] constexpr bool has_empty_hostname() const noexcept;
   /** @return true if it has a host (included an empty host) */
-  [[nodiscard]] inline bool has_hostname() const noexcept;
+  [[nodiscard]] constexpr bool has_hostname() const noexcept;
   /** @return true if the URL has a non-empty username */
-  [[nodiscard]] inline bool has_non_empty_username() const noexcept;
+  [[nodiscard]] constexpr bool has_non_empty_username() const noexcept;
   /** @return true if the URL has a non-empty password */
-  [[nodiscard]] inline bool has_non_empty_password() const noexcept;
+  [[nodiscard]] constexpr bool has_non_empty_password() const noexcept;
   /** @return true if the URL has a (non default) port */
-  [[nodiscard]] inline bool has_port() const noexcept;
+  [[nodiscard]] constexpr bool has_port() const noexcept;
   /** @return true if the URL has a password */
-  [[nodiscard]] inline bool has_password() const noexcept;
+  [[nodiscard]] constexpr bool has_password() const noexcept;
   /** @return true if the URL has a hash component */
-  [[nodiscard]] inline bool has_hash() const noexcept override;
+  [[nodiscard]] constexpr bool has_hash() const noexcept override;
   /** @return true if the URL has a search component */
-  [[nodiscard]] inline bool has_search() const noexcept override;
+  [[nodiscard]] constexpr bool has_search() const noexcept override;
 
   inline void clear_port();
   inline void clear_hash();
@@ -233,7 +233,7 @@ struct url_aggregator : url_base {
    * To optimize performance, you may indicate how much memory to allocate
    * within this instance.
    */
-  inline void reserve(uint32_t capacity);
+  constexpr void reserve(uint32_t capacity);
 
   ada_really_inline size_t parse_port(
       std::string_view view, bool check_trailing_content) noexcept override;
@@ -268,7 +268,7 @@ struct url_aggregator : url_base {
    * A URL cannot have a username/password/port if its host is null or the empty
    * string, or its scheme is "file".
    */
-  [[nodiscard]] inline bool cannot_have_credentials_or_port() const;
+  [[nodiscard]] constexpr bool cannot_have_credentials_or_port() const;
 
   template <bool override_hostname = false>
   bool set_host_or_hostname(std::string_view input);
@@ -290,10 +290,10 @@ struct url_aggregator : url_base {
   inline void update_base_port(uint32_t input);
   inline void append_base_pathname(std::string_view input);
   [[nodiscard]] inline uint32_t retrieve_base_port() const;
-  inline void clear_hostname();
-  inline void clear_password();
-  inline void clear_pathname() override;
-  [[nodiscard]] inline bool has_dash_dot() const noexcept;
+  constexpr void clear_hostname();
+  constexpr void clear_password();
+  constexpr void clear_pathname() override;
+  [[nodiscard]] constexpr bool has_dash_dot() const noexcept;
   void delete_dash_dot();
   inline void consume_prepared_path(std::string_view input);
   template <bool has_state_override = false>
@@ -301,8 +301,8 @@ struct url_aggregator : url_base {
       std::string_view input);
   ada_really_inline uint32_t replace_and_resize(uint32_t start, uint32_t end,
                                                 std::string_view input);
-  [[nodiscard]] inline bool has_authority() const noexcept;
-  inline void set_protocol_as_file();
+  [[nodiscard]] constexpr bool has_authority() const noexcept;
+  constexpr void set_protocol_as_file();
   inline void set_scheme(std::string_view new_scheme) noexcept;
   /**
    * Fast function to set the scheme from a view with a colon in the

--- a/include/ada/url_base-inl.h
+++ b/include/ada/url_base-inl.h
@@ -21,7 +21,7 @@
 
 namespace ada {
 
-[[nodiscard]] ada_really_inline bool url_base::is_special() const noexcept {
+[[nodiscard]] ada_really_inline constexpr bool url_base::is_special() const noexcept {
   return type != ada::scheme::NOT_SPECIAL;
 }
 

--- a/include/ada/url_base.h
+++ b/include/ada/url_base.h
@@ -68,7 +68,7 @@ struct url_base {
    * A URL is special if its scheme is a special scheme. A URL is not special if
    * its scheme is not a special scheme.
    */
-  [[nodiscard]] ada_really_inline bool is_special() const noexcept;
+  [[nodiscard]] ada_really_inline constexpr bool is_special() const noexcept;
 
   /**
    * The origin getter steps are to return the serialization of this's URL's

--- a/include/ada/url_components.h
+++ b/include/ada/url_components.h
@@ -67,7 +67,7 @@ struct url_components {
    * @return true if the offset values are
    *  consistent with a possible URL string
    */
-  [[nodiscard]] bool check_offset_consistency() const noexcept;
+  [[nodiscard]] constexpr bool check_offset_consistency() const noexcept;
 
   /**
    * Converts a url_components to JSON stringified version.

--- a/src/url-getters.cpp
+++ b/src/url-getters.cpp
@@ -62,7 +62,7 @@ namespace ada {
   return host.value_or("");
 }
 
-[[nodiscard]] std::string_view url::get_pathname() const noexcept {
+[[nodiscard]] constexpr std::string_view url::get_pathname() const noexcept {
   return path;
 }
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -723,7 +723,7 @@ bool url_aggregator::set_hostname(const std::string_view input) {
   return helpers::substring(buffer, start, components.host_end);
 }
 
-[[nodiscard]] std::string_view url_aggregator::get_pathname() const noexcept
+[[nodiscard]] constexpr std::string_view url_aggregator::get_pathname() const noexcept
     ada_lifetime_bound {
   ada_log("url_aggregator::get_pathname pathname_start = ",
           components.pathname_start, " buffer.size() = ", buffer.size(),
@@ -1377,7 +1377,7 @@ bool url_aggregator::parse_opaque_host(std::string_view input) {
   return answer;
 }
 
-[[nodiscard]] bool url_aggregator::validate() const noexcept {
+[[nodiscard]] constexpr bool url_aggregator::validate() const noexcept {
   if (!is_valid) {
     return true;
   }

--- a/src/url_components.cpp
+++ b/src/url_components.cpp
@@ -7,7 +7,7 @@
 
 namespace ada {
 
-[[nodiscard]] bool url_components::check_offset_consistency() const noexcept {
+[[nodiscard]] constexpr bool url_components::check_offset_consistency() const noexcept {
   /**
    * https://user:pass@example.com:1234/foo/bar?baz#quux
    *       |     |    |          | ^^^^|       |   |


### PR DESCRIPTION
## Before
```
BasicBench_AdaURL_url                201873 ns       201789 ns         3606 GHz=4.79146 cycle/byte=44.5044 cycles/url=1.07521k instructions/byte=111.317 instructions/cycle=2.50126 instructions/ns=11.9847 instructions/url=2.68938k ns/url=224.401 speed=102.008M/s time/byte=9.80319ns time/url=236.842ns url/s=4.22223M/s

```

## After
```
BasicBench_AdaURL_url                195539 ns       195521 ns         3472 GHz=4.79119 cycle/byte=44.3816 cycles/url=1.07224k instructions/byte=111.317 instructions/cycle=2.50818 instructions/ns=12.0171 instructions/url=2.68937k ns/url=223.795 speed=105.278M/s time/byte=9.49867ns time/url=229.484ns url/s=4.3576M/s
```