### PR TITLE
reduce has_authority check overhead

### DIFF
--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -220,6 +220,7 @@ struct url_aggregator : url_base {
 
   std::string buffer{};
   url_components components{};
+  bool has_authority{false};
 
   /**
    * Returns true if neither the search, nor the hash nor the pathname
@@ -302,7 +303,6 @@ struct url_aggregator : url_base {
       std::string_view input);
   ada_really_inline uint32_t replace_and_resize(uint32_t start, uint32_t end,
                                                 std::string_view input);
-  [[nodiscard]] constexpr bool has_authority() const noexcept;
   constexpr void set_protocol_as_file();
   inline void set_scheme(std::string_view new_scheme) noexcept;
   /**

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -316,7 +316,8 @@ bool url_aggregator::set_pathname(const std::string_view input) {
   }
   clear_pathname();
   parse_path(input);
-  if (get_pathname().starts_with("//") && !has_authority() && !has_dash_dot()) {
+  if (get_pathname().starts_with("//") && !has_authority && !has_dash_dot()) {
+    has_authority = true;
     buffer.insert(components.pathname_start, "/.");
     components.pathname_start += 2;
   }
@@ -358,7 +359,7 @@ ada_really_inline void url_aggregator::parse_path(std::string_view input) {
   } else {
     // Non-special URLs with an empty host can have their paths erased
     // Path-only URLs cannot have their paths erased
-    if (components.host_start == components.host_end && !has_authority()) {
+    if (components.host_start == components.host_end && !has_authority) {
       update_base_pathname("/");
     }
   }


### PR DESCRIPTION
We are never setting has_authority to false. I am not sure if we should or not. Let's merge this once we are sure.

## Before

```
BasicBench_AdaURL_url                206796 ns       206701 ns         3421 GHz=4.59137 cycle/byte=44.7268 cycles/url=1.08058k instructions/byte=110.33 instructions/cycle=2.46674 instructions/ns=11.3257 instructions/url=2.66552k ns/url=235.351 speed=99.5835M/s time/byte=10.0418ns time/url=242.607ns url/s=4.1219M/s
BasicBench_AdaURL_url_aggregator     177953 ns       177597 ns         4035 GHz=4.49142 cycle/byte=36.2755 cycles/url=876.401 instructions/byte=113.032 instructions/cycle=3.11593 instructions/ns=13.995 instructions/url=2.73081k ns/url=195.128 speed=115.903M/s time/byte=8.62789ns time/url=208.447ns url/s=4.79739M/s
```

## After

```
BasicBench_AdaURL_url                200141 ns       199923 ns         3485 GHz=4.5919 cycle/byte=42.8454 cycles/url=1.03513k instructions/byte=110.222 instructions/cycle=2.57254 instructions/ns=11.8129 instructions/url=2.66291k ns/url=225.425 speed=102.96M/s time/byte=9.71253ns time/url=234.651ns url/s=4.26165M/s
BasicBench_AdaURL_url_aggregator     175378 ns       175344 ns         3969 GHz=4.59219 cycle/byte=37.1822 cycles/url=898.308 instructions/byte=112.236 instructions/cycle=3.01854 instructions/ns=13.8617 instructions/url=2.71158k ns/url=195.616 speed=117.392M/s time/byte=8.51846ns time/url=205.803ns url/s=4.85902M/s
```