### PR TITLE
avoid network access by default

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -38,6 +38,6 @@ jobs:
             ln -s -f /usr/bin/gcc-12 /usr/bin/gcc
             ln -s -f /usr/bin/g++-12 /usr/bin/g++
           run: |
-            cmake -DCMAKE_CXX_STANDARD=20 -B build
+            cmake -DCMAKE_CXX_STANDARD=20 -D ADA_TESTING=ON -B build
             cmake --build build
             ctest --test-dir build

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -36,7 +36,7 @@ jobs:
           ./alpine.sh apk add build-base cmake g++ linux-headers git bash icu-dev
       - name: cmake
         run: |
-          ./alpine.sh cmake -DADA_BENCHMARKS=ON -B build_for_alpine
+          ./alpine.sh cmake -D ADA_TESTING=ON -DADA_BENCHMARKS=ON -B build_for_alpine
       - name: build
         run: |
           ./alpine.sh cmake --build build_for_alpine

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3.6.0
       - name: Configure
-        run: emcmake cmake -B buildwasm -D ADA_TOOLS=OFF
+        run: emcmake cmake -B buildwasm -D ADA_TESTING=ON -D ADA_TOOLS=OFF
       - name: Build
         run: cmake --build buildwasm
       - name: Test

--- a/.github/workflows/macos_install.yml
+++ b/.github/workflows/macos_install.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Prepare
-        run: cmake -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
+        run: cmake -D ADA_TESTING=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
       - name: Build
         run: cmake --build build -j=3
       - name: Install

--- a/.github/workflows/ubuntu-s390x.yml
+++ b/.github/workflows/ubuntu-s390x.yml
@@ -36,7 +36,7 @@ jobs:
             apt-get update -q -y
             apt-get install -y cmake make g++ git ninja-build
           run: |
-            cmake -DCMAKE_BUILD_TYPE=Release -G Ninja -B build
+            cmake -D ADA_TESTING=ON -DCMAKE_BUILD_TYPE=Release -G Ninja -B build
             rm -r -f dependencies
             cmake --build build -j=4
             ctest --output-on-failure --test-dir build

--- a/.github/workflows/ubuntu-sanitized.yml
+++ b/.github/workflows/ubuntu-sanitized.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -DADA_SANITIZE=ON -DADA_DEVELOPMENT_CHECKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
+        run: cmake -D ADA_TESTING=ON -DADA_SANITIZE=ON -DADA_DEVELOPMENT_CHECKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
         env:
           CXX: g++-12
       - name: Build

--- a/.github/workflows/ubuntu-undef.yml
+++ b/.github/workflows/ubuntu-undef.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -D ADA_SANITIZE_UNDEFINED=ON -DADA_DEVELOPMENT_CHECKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
+        run: cmake -D ADA_TESTING=ON -D ADA_SANITIZE_UNDEFINED=ON -DADA_DEVELOPMENT_CHECKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
         env:
           CXX: g++-12
       - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -D ADA_BENCHMARKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
+        run: cmake -D ADA_TESTING=ON -D ADA_BENCHMARKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
         env:
           CXX: ${{matrix.cxx}}
       - name: Build

--- a/.github/workflows/ubuntu_install.yml
+++ b/.github/workflows/ubuntu_install.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -G Ninja -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
+        run: cmake -D ADA_TESTING=ON -G Ninja -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_INSTALL_PREFIX:PATH=destination -B build
       - name: Build
         run: cmake --build build -j=4
       - name: Install

--- a/.github/workflows/ubuntu_pedantic.yml
+++ b/.github/workflows/ubuntu_pedantic.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install ninja-build
       - name: Prepare
-        run: cmake -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
+        run: cmake -D ADA_TESTING=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -G Ninja -B build
         env:
           CXX: g++-12
           CXXFLAGS: -Werror

--- a/.github/workflows/visual_studio.yml
+++ b/.github/workflows/visual_studio.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure
       run: |
-        cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
+        cmake -D ADA_TESTING=ON -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
     - name: Build
       run: cmake --build build --config "${{matrix.config}}" --verbose
     - name: Run  tests

--- a/.github/workflows/visual_studio_clang.yml
+++ b/.github/workflows/visual_studio_clang.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure
       run: |
-        cmake -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -T ClangCL -B build
+        cmake -D ADA_TESTING=ON -DADA_DEVELOPMENT_CHECKS="${{matrix.devchecks}}" -G "${{matrix.gen}}" -A ${{matrix.arch}} -T ClangCL -B build
     - name: Build Debug
       run: cmake --build build --config Debug --verbose
     - name: Run Debug tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_subdirectory(src)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake)
 
 option(ADA_BENCHMARKS "Build benchmarks" OFF)
-option(ADA_TESTING "Build tests" ${BUILD_TESTING})
+option(ADA_TESTING "Build tests" OFF)
 
 # There are cases where when embedding ada as a dependency for other CMake
 # projects as submodules or subdirectories (via FetchContent) can lead to

--- a/cmake/ada-flags.cmake
+++ b/cmake/ada-flags.cmake
@@ -15,7 +15,7 @@ if(ADA_SANITIZE_UNDEFINED)
   message(STATUS "Undefined sanitizer enabled.")
 endif()
 option(ADA_COVERAGE "Compute coverage" OFF)
-option(ADA_TOOLS "Build cli tools (adaparse)" ON)
+option(ADA_TOOLS "Build cli tools (adaparse)" OFF)
 
 if (ADA_COVERAGE)
     message(STATUS "You want to compute coverage. We assume that you have installed gcovr.")


### PR DESCRIPTION
This makes sure that, by default, doing `cmake -B build` does not trigger any network access. So tests and tools must be enabled by a specific flag.

If we make this change **we should document it**.

Alternative to https://github.com/ada-url/ada/pull/772