### PR TITLE
update servo-url and fix detection

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -207,7 +207,7 @@ endif()
 # Boost
 if(ADA_BOOST_URL)
 find_package(
-    Boost 1.80
+    Boost 1.86
     COMPONENTS system
 )
 endif(ADA_BOOST_URL)
@@ -258,7 +258,7 @@ if(NOT WIN32)
 CPMAddPackage(
   NAME corrosion
   GITHUB_REPOSITORY corrosion-rs/corrosion
-  VERSION 0.4.4
+  VERSION 0.5.0
   DOWNLOAD_ONLY ON
   OPTIONS "Rust_FIND_QUIETLY OFF"
 )
@@ -272,22 +272,24 @@ if(RUST_FOUND)
   corrosion_import_crate(MANIFEST_PATH "competitors/servo-url/Cargo.toml" NO_LINKER_OVERRIDE PROFILE release)
 
   # Check if servo-url target was created successfully
-  if(TARGET servo-url)
-    message(STATUS "servo-url target was created. Linking benchmarks and servo-url.")
-    target_link_libraries(bench PRIVATE servo-url)
+  if(TARGET servo_url)
+    message(STATUS "servo_url target was created. Linking benchmarks and servo_url. ")
+    target_link_libraries(bench PRIVATE servo_url)
     target_compile_definitions(bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
 
-    target_link_libraries(benchdata PRIVATE servo-url)
+    target_link_libraries(benchdata PRIVATE servo_url)
     target_compile_definitions(benchdata PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
 
-    target_link_libraries(bbc_bench PRIVATE servo-url)
+    target_link_libraries(bbc_bench PRIVATE servo_url)
     target_compile_definitions(bbc_bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
 
-    target_link_libraries(percent_encode PRIVATE servo-url)
+    target_link_libraries(percent_encode PRIVATE servo_url)
     target_compile_definitions(percent_encode PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
 
-    target_link_libraries(wpt_bench PRIVATE servo-url)
+    target_link_libraries(wpt_bench PRIVATE servo_url)
     target_compile_definitions(wpt_bench PRIVATE ADA_RUST_VERSION="${Rust_VERSION}")
+  else()
+    message(SEND_ERROR "Rust servo-url target was not created successfully. Likely due to a bug.")
   endif()
 else()
   message(STATUS "Rust/Cargo is unavailable." )

--- a/benchmarks/competitors/servo-url/Cargo.lock
+++ b/benchmarks/competitors/servo-url/Cargo.lock
@@ -163,15 +163,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "percent-encoding"
@@ -181,9 +181,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -199,18 +199,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -239,9 +239,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -271,15 +271,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -312,9 +312,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -336,18 +336,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benchmarks/competitors/servo-url/Cargo.toml
+++ b/benchmarks/competitors/servo-url/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "servo-url"
 version = "0.1.0"
+edition = "2021"
 
 [lib]
 path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-url = "2.5.3"
+url = "2.5.4"
 libc = "0.2"
 
 [profile.release]

--- a/benchmarks/competitors/servo-url/lib.rs
+++ b/benchmarks/competitors/servo-url/lib.rs
@@ -5,9 +5,9 @@ use libc::{c_char, size_t};
 extern crate url;
 extern crate libc;
 
-#[no_mangle]
-pub unsafe extern "C" fn parse_url(raw_input: *const c_char, raw_input_length: size_t) -> *mut Url {
-  let input = std::str::from_utf8_unchecked(slice::from_raw_parts(raw_input as *const u8, raw_input_length));
+#[unsafe(no_mangle)]
+pub extern "C" fn parse_url(raw_input: *const c_char, raw_input_length: size_t) -> *mut Url {
+  let input = unsafe { std::str::from_utf8_unchecked(slice::from_raw_parts(raw_input as *const u8, raw_input_length)) };
   // This code would assume that the URL is parsed successfully:
   // let result = Url::parse(input).unwrap();
   // Box::into_raw(Box::new(result))
@@ -19,26 +19,26 @@ pub unsafe extern "C" fn parse_url(raw_input: *const c_char, raw_input_length: s
   }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn parse_url_to_href(raw_input: *const c_char, raw_input_length: size_t) -> *const c_char {
-  let input = std::str::from_utf8_unchecked(slice::from_raw_parts(raw_input as *const u8, raw_input_length));
+#[unsafe(no_mangle)]
+pub extern "C" fn parse_url_to_href(raw_input: *const c_char, raw_input_length: size_t) -> *const c_char {
+  let input = unsafe { std::str::from_utf8_unchecked(slice::from_raw_parts(raw_input as *const u8, raw_input_length)) };
   match Url::parse(input) {
     Ok(result) => std::ffi::CString::new(result.as_str()).unwrap().into_raw(),
     Err(_) => std::ptr::null_mut(),
   }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn free_url(raw: *mut Url) {
+#[unsafe(no_mangle)]
+pub extern "C" fn free_url(raw: *mut Url) {
   if raw.is_null() {
     return;
   }
 
-  drop(Box::from_raw(raw))
+  unsafe { drop(Box::from_raw(raw)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern fn free_string(ptr: *const c_char) {
     // Take the ownership back to rust and drop the owner
-    let _ = std::ffi::CString::from_raw(ptr as *mut _);
+    let _ = unsafe { std::ffi::CString::from_raw(ptr as *mut _) };
 }


### PR DESCRIPTION
We are still the fastest URL parser on both RFC-3986 and WHATWG.

```
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
BasicBench_AdaURL_href                  3411 ns         3404 ns       204433 speed=253.506M/s time/byte=3.94468ns time/url=378.251ns url/s=2.64375M/s
BasicBench_AdaURL_aggregator_href       2051 ns         2046 ns       338881 speed=421.819M/s time/byte=2.37068ns time/url=227.322ns url/s=4.39904M/s
BasicBench_AdaURL_CanParse              1431 ns         1425 ns       486000 speed=605.437M/s time/byte=1.6517ns time/url=158.38ns url/s=6.31394M/s
BasicBench_whatwg                       6840 ns         6789 ns       103240 speed=127.114M/s time/byte=7.86693ns time/url=754.351ns url/s=1.32564M/s
BasicBench_CURL                        17156 ns        17093 ns        41000 speed=50.4882M/s time/byte=19.8066ns time/url=1.89923us url/s=526.528k/s
BasicBench_uriparser_just_parse         4627 ns         4595 ns       151417 speed=187.82M/s time/byte=5.32424ns time/url=510.536ns url/s=1.95873M/s
BasicBench_http_parser_just_parse       4273 ns         4262 ns       164956 speed=202.481M/s time/byte=4.93873ns time/url=473.569ns url/s=2.11162M/s
BasicBench_ServoUrl                     9441 ns         9401 ns        75232 speed=91.7962M/s time/byte=10.8937ns time/url=1.04459us url/s=957.318k/s
```