### PR TITLE
minor fixes for add-url-pattern

### DIFF
--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -53,7 +53,7 @@ extern template url parse_url_impl<url>(std::string_view user_input,
                                         const url* base_url);
 
 tl::expected<URLPattern, url_pattern::errors> parse_url_pattern(
-    std::variant<std::string_view, typename URLPattern::Init> input,
+    std::variant<std::string_view, URLPattern::Init> input,
     const std::string_view* base_url = nullptr,
     const URLPattern::Options* options = nullptr);
 

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -9,6 +9,7 @@
 #include <variant>
 
 #include "ada/expected.h"
+#include "ada/url_pattern.h"
 
 /**
  * @private
@@ -16,11 +17,7 @@
 namespace ada {
 struct url_aggregator;
 struct url;
-class URLPattern {
- public:
-  struct Init;
-  struct Options;
-};
+
 namespace url_pattern {
 enum class errors : uint8_t;
 }
@@ -56,7 +53,7 @@ extern template url parse_url_impl<url>(std::string_view user_input,
                                         const url* base_url);
 
 tl::expected<URLPattern, url_pattern::errors> parse_url_pattern(
-    std::variant<std::string_view, URLPattern::Init> input,
+    std::variant<std::string_view, typename URLPattern::Init> input,
     const std::string_view* base_url = nullptr,
     const URLPattern::Options* options = nullptr);
 

--- a/include/ada/url_pattern-inl.h
+++ b/include/ada/url_pattern-inl.h
@@ -12,21 +12,6 @@
 
 namespace ada {
 
-// The default options is an options struct with delimiter code point set to
-// the empty string and prefix code point set to the empty string.
-const URLPattern::CompileComponentOptions
-    URLPattern::CompileComponentOptions::DEFAULT(std::nullopt, std::nullopt);
-
-// The hostname options is an options struct with delimiter code point set
-// "." and prefix code point set to the empty string.
-const URLPattern::CompileComponentOptions
-    URLPattern::CompileComponentOptions::HOSTNAME('.', std::nullopt);
-
-// The pathname options is an options struct with delimiter code point set
-// "/" and prefix code point set to "/".
-const URLPattern::CompileComponentOptions
-    URLPattern::CompileComponentOptions::PATHNAME('/', '/');
-
 inline std::string_view URLPattern::Component::get_pattern() const noexcept
     ada_lifetime_bound {
   return pattern;

--- a/include/ada/url_pattern.h
+++ b/include/ada/url_pattern.h
@@ -13,17 +13,19 @@
 #include <variant>
 #include <vector>
 
-namespace ada::parser {
-tl::expected<URLPattern, url_pattern::errors> parse_url_pattern(
-    std::variant<std::string_view, URLPattern::Init> input,
-    const std::string_view* base_url, const URLPattern::Options* options);
-}
-
 namespace ada {
 
 namespace url_pattern {
 enum class errors : uint8_t { type_error };
 }  // namespace url_pattern
+
+namespace parser {
+template <typename result_type, typename URLPattern_Init,
+          typename URLPattern_Options>
+tl::expected<result_type, url_pattern::errors> parse_url_pattern(
+    std::variant<std::string_view, URLPattern_Init> input,
+    const std::string_view* base_url, const URLPattern_Options* options);
+}
 
 // URLPattern is a Web Platform standard API for matching URLs against a
 // pattern syntax (think of it as a regular expression for URLs). It is
@@ -126,9 +128,9 @@ class URLPattern {
     // @see https://urlpattern.spec.whatwg.org/#options-ignore-case
     bool ignore_case = false;
 
-    static const CompileComponentOptions DEFAULT;
-    static const CompileComponentOptions HOSTNAME;
-    static const CompileComponentOptions PATHNAME;
+    static CompileComponentOptions DEFAULT;
+    static CompileComponentOptions HOSTNAME;
+    static CompileComponentOptions PATHNAME;
   };
 
   using EncodingCallback =
@@ -245,10 +247,12 @@ class URLPattern {
   Component hash{};
   bool ignore_case_ = false;
 
-  friend tl::expected<URLPattern, url_pattern::errors>
-  parser::parse_url_pattern(std::variant<std::string_view, Init> input,
-                            const std::string_view* base_url,
-                            const Options* options);
+  template <typename result_type, typename URLPattern_Init,
+            typename URLPattern_Options>
+  friend tl::expected<result_type, url_pattern::errors>
+  parser::parse_url_pattern(
+      std::variant<std::string_view, URLPattern_Init> input,
+      const std::string_view* base_url, const URLPattern_Options* options);
 };
 
 namespace url_pattern {
@@ -392,7 +396,8 @@ constexpr bool is_absolute_pathname(std::string_view input,
 
 // @see https://urlpattern.spec.whatwg.org/#parse-a-pattern-string
 std::vector<URLPattern::Part> parse_pattern_string(
-    std::string_view pattern, URLPattern::CompileComponentOptions& options,
+    std::string_view pattern,
+    const URLPattern::CompileComponentOptions& options,
     URLPattern::EncodingCallback encoding_callback);
 
 // @see https://urlpattern.spec.whatwg.org/#generate-a-pattern-string

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -21,12 +21,6 @@ ada_warn_unused tl::expected<result_type, ada::errors> parse(
   return u;
 }
 
-ada_warn_unused tl::expected<ada::URLPattern, ada::url_pattern::errors>
-parse_url_pattern(std::variant<std::string_view, URLPattern::Init> input,
-                  const std::string_view* base_url,
-                  const ada::URLPattern::Options* options) {
-  return ada::parser::parse_url_pattern(input, base_url, options);
-}
 template ada::result<url> parse<url>(std::string_view input,
                                      const url* base_url = nullptr);
 template ada::result<url_aggregator> parse<url_aggregator>(

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -904,9 +904,11 @@ result_type parse_url_impl(std::string_view user_input,
   return url;
 }
 
+template <>
 tl::expected<ada::URLPattern, ada::url_pattern::errors> parse_url_pattern(
     std::variant<std::string_view, URLPattern::Init> input,
     const std::string_view* base_url, const ada::URLPattern::Options* options) {
+  (void)options;
   // Let init be null.
   URLPattern::Init init;
 

--- a/src/url_pattern.cpp
+++ b/src/url_pattern.cpp
@@ -4,6 +4,20 @@
 #include <string>
 
 namespace ada {
+// The default options is an options struct with delimiter code point set to
+// the empty string and prefix code point set to the empty string.
+URLPattern::CompileComponentOptions
+    URLPattern::CompileComponentOptions::DEFAULT(std::nullopt, std::nullopt);
+
+// The hostname options is an options struct with delimiter code point set
+// "." and prefix code point set to the empty string.
+URLPattern::CompileComponentOptions
+    URLPattern::CompileComponentOptions::HOSTNAME('.', std::nullopt);
+
+// The pathname options is an options struct with delimiter code point set
+// "/" and prefix code point set to "/".
+URLPattern::CompileComponentOptions
+    URLPattern::CompileComponentOptions::PATHNAME('/', '/');
 
 tl::expected<URLPattern::Init, url_pattern::errors> URLPattern::Init::process(
     Init init, std::string type, std::optional<std::string_view> protocol,
@@ -583,6 +597,7 @@ tl::expected<std::string, errors> canonicalize_hash(std::string_view input) {
 }
 
 URLPattern::Init parse_constructor_string(std::string_view input) {
+  (void)input;
   // Let parser be a new constructor string parser whose input is input and
   // token list is the result of running tokenize given input and "lenient".
   // TODO: Implement this
@@ -673,6 +688,9 @@ constexpr bool is_absolute_pathname(std::string_view input,
 std::vector<URLPattern::Part> parse_pattern_string(
     std::string_view pattern, URLPattern::CompileComponentOptions& options,
     URLPattern::EncodingCallback encoding_callback) {
+  (void)pattern;
+  (void)options;
+  (void)encoding_callback;
   // TODO: Implement this
   return {};
 }
@@ -680,6 +698,8 @@ std::vector<URLPattern::Part> parse_pattern_string(
 std::string generate_pattern_string(
     std::vector<URLPattern::Part>& part_list,
     URLPattern::CompileComponentOptions& options) {
+  (void)part_list;
+  (void)options;
   // TODO: Implement this
   return {};
 }
@@ -725,16 +745,22 @@ URLPattern::Component URLPattern::Component::compile(
                    std::move(name_list), has_regexp_groups);
 }
 
+namespace url_pattern {
 std::tuple<std::string, std::vector<std::string>>
 generate_regular_expression_and_name_list(
     std::vector<URLPattern::Part>& part_list,
     URLPattern::CompileComponentOptions options) {
   // TODO: Implement this
+  (void)part_list;
+  (void)options;
   return {"", {}};
 }
+}  // namespace url_pattern
 
 std::optional<URLPattern::Result> URLPattern::exec(
     std::optional<Input> input, std::optional<std::string> base_url) {
+  (void)input;
+  (void)base_url;
   // TODO: Implement this
   return std::nullopt;
 }
@@ -742,6 +768,8 @@ std::optional<URLPattern::Result> URLPattern::exec(
 bool URLPattern::test(std::optional<Input> input,
                       std::optional<std::string_view> base_url) {
   // TODO: Implement this
+  (void)input;
+  (void)base_url;
   return false;
 }
 


### PR DESCRIPTION
This is a minor fix for @anonrig's add-url-pattern. Mostly, we use a friend template instead of a friend function and we avoid unnecessary forward references by switching the include order.