### PR TITLE
have better ubsan stack trace

### DIFF
--- a/include/ada/implementation-inl.h
+++ b/include/ada/implementation-inl.h
@@ -19,7 +19,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
     // Set init to the result of running parse a constructor string given input.
     auto parse_result = url_pattern_helpers::constructor_string_parser::parse(
         std::get<std::string_view>(input));
-    if (!parse_result) {
+    if (!parse_result.has_value()) {
       ada_log("constructor_string_parser::parse failed");
       return tl::unexpected(parse_result.error());
     }
@@ -53,7 +53,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
   auto processed_init = url_pattern_init::process(
       init, "pattern", std::nullopt, std::nullopt, std::nullopt, std::nullopt,
       std::nullopt, std::nullopt, std::nullopt, std::nullopt);
-  if (!processed_init) {
+  if (!processed_init.has_value()) {
     ada_log("url_pattern_init::process failed for init and 'pattern'");
     return tl::unexpected(processed_init.error());
   }
@@ -103,7 +103,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
       processed_init->protocol.value(),
       url_pattern_helpers::canonicalize_protocol,
       url_pattern_compile_component_options::DEFAULT);
-  if (!protocol_component) {
+  if (!protocol_component.has_value()) {
     ada_log("url_pattern_component::compile failed for protocol ",
             processed_init->protocol.value());
     return tl::unexpected(protocol_component.error());
@@ -117,7 +117,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
       processed_init->username.value(),
       url_pattern_helpers::canonicalize_username,
       url_pattern_compile_component_options::DEFAULT);
-  if (!username_component) {
+  if (!username_component.has_value()) {
     ada_log("url_pattern_component::compile failed for username ",
             processed_init->username.value());
     return tl::unexpected(username_component.error());
@@ -131,7 +131,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
       processed_init->password.value(),
       url_pattern_helpers::canonicalize_password,
       url_pattern_compile_component_options::DEFAULT);
-  if (!password_component) {
+  if (!password_component.has_value()) {
     ada_log("url_pattern_component::compile failed for password ",
             processed_init->password.value());
     return tl::unexpected(password_component.error());
@@ -153,7 +153,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
         processed_init->hostname.value(),
         url_pattern_helpers::canonicalize_ipv6_hostname,
         url_pattern_compile_component_options::DEFAULT);
-    if (!hostname_component) {
+    if (!hostname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for ipv6 hostname ",
               processed_init->hostname.value());
       return tl::unexpected(hostname_component.error());
@@ -167,7 +167,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
         processed_init->hostname.value(),
         url_pattern_helpers::canonicalize_hostname,
         url_pattern_compile_component_options::HOSTNAME);
-    if (!hostname_component) {
+    if (!hostname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for hostname ",
               processed_init->hostname.value());
       return tl::unexpected(hostname_component.error());
@@ -180,7 +180,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
   auto port_component = url_pattern_component::compile(
       processed_init->port.value(), url_pattern_helpers::canonicalize_port,
       url_pattern_compile_component_options::DEFAULT);
-  if (!port_component) {
+  if (!port_component.has_value()) {
     ada_log("url_pattern_component::compile failed for port ",
             processed_init->port.value());
     return tl::unexpected(port_component.error());
@@ -190,7 +190,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
   // Let compileOptions be a copy of the default options with the ignore case
   // property set to options["ignoreCase"].
   auto compile_options = url_pattern_compile_component_options::DEFAULT;
-  if (options) {
+  if (options != nullptr) {
     compile_options.ignore_case = options->ignore_case;
   }
 
@@ -212,7 +212,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
     auto pathname_component = url_pattern_component::compile(
         processed_init->pathname.value(),
         url_pattern_helpers::canonicalize_pathname, path_compile_options);
-    if (!pathname_component) {
+    if (!pathname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for pathname ",
               processed_init->pathname.value());
       return tl::unexpected(pathname_component.error());
@@ -225,7 +225,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
     auto pathname_component = url_pattern_component::compile(
         processed_init->pathname.value(),
         url_pattern_helpers::canonicalize_opaque_pathname, compile_options);
-    if (!pathname_component) {
+    if (!pathname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for opaque pathname ",
               processed_init->pathname.value());
       return tl::unexpected(pathname_component.error());
@@ -238,7 +238,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
   auto search_component = url_pattern_component::compile(
       processed_init->search.value(), url_pattern_helpers::canonicalize_search,
       compile_options);
-  if (!search_component) {
+  if (!search_component.has_value()) {
     ada_log("url_pattern_component::compile failed for search ",
             processed_init->search.value());
     return tl::unexpected(search_component.error());
@@ -250,7 +250,7 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init> input,
   auto hash_component = url_pattern_component::compile(
       processed_init->hash.value(), url_pattern_helpers::canonicalize_hash,
       compile_options);
-  if (!hash_component) {
+  if (!hash_component.has_value()) {
     ada_log("url_pattern_component::compile failed for hash ",
             processed_init->hash.value());
     return tl::unexpected(hash_component.error());

--- a/include/ada/url_pattern.h
+++ b/include/ada/url_pattern.h
@@ -128,12 +128,12 @@ enum class url_pattern_part_modifier : uint8_t {
 class url_pattern_part {
  public:
   url_pattern_part(url_pattern_part_type _type, std::string&& _value,
-                   url_pattern_part_modifier _modifier)
+                   url_pattern_part_modifier _modifier) noexcept
       : type(_type), value(_value), modifier(_modifier) {}
 
   url_pattern_part(url_pattern_part_type _type, std::string&& _value,
                    url_pattern_part_modifier _modifier, std::string&& _name,
-                   std::string&& _prefix, std::string&& _suffix)
+                   std::string&& _prefix, std::string&& _suffix) noexcept
       : type(_type),
         value(_value),
         modifier(_modifier),
@@ -159,10 +159,10 @@ class url_pattern_part {
 
 // @see https://urlpattern.spec.whatwg.org/#options-header
 struct url_pattern_compile_component_options {
-  url_pattern_compile_component_options() = default;
+  url_pattern_compile_component_options() noexcept = default;
   explicit url_pattern_compile_component_options(
       std::optional<char> new_delimiter = std::nullopt,
-      std::optional<char> new_prefix = std::nullopt)
+      std::optional<char> new_prefix = std::nullopt) noexcept
       : delimiter(new_delimiter), prefix(new_prefix) {}
 
   std::string_view get_delimiter() const ada_warn_unused;
@@ -188,25 +188,25 @@ struct url_pattern_compile_component_options {
 // URLPatternComponentResult API is defined as part of the URLPattern
 // specification.
 struct url_pattern_component_result {
-  std::string input;
-  std::unordered_map<std::string, std::string> groups;
+  std::string input{};
+  std::unordered_map<std::string, std::string> groups{};
 };
 
 class url_pattern_component {
  public:
-  url_pattern_component() = default;
+  url_pattern_component() noexcept = default;
 
   // This function explicitly takes a std::string because it is moved.
   // To avoid unnecessary copy, move each value while calling the constructor.
-  url_pattern_component(std::string_view new_pattern, std::regex&& new_regexp,
+  url_pattern_component(std::string&& new_pattern, std::regex&& new_regexp,
                         std::regex_constants::syntax_option_type new_flags,
                         std::vector<std::string>&& new_group_name_list,
-                        bool new_has_regexp_groups)
-      : regexp(new_regexp),
+                        bool new_has_regexp_groups) noexcept
+      : has_regexp_groups(new_has_regexp_groups),
+        regexp(new_regexp),
+        group_name_list(std::move(new_group_name_list)),
         pattern(std::move(new_pattern)),
-        flags(new_flags),
-        group_name_list(new_group_name_list),
-        has_regexp_groups(new_has_regexp_groups) {}
+        flags(new_flags) {}
 
   // @see https://urlpattern.spec.whatwg.org/#compile-a-component
   template <url_pattern_encoding_callback F>
@@ -220,11 +220,11 @@ class url_pattern_component {
 
   std::string to_string() const;
 
+  bool has_regexp_groups{false};
   std::regex regexp{};
-  std::string pattern{};
-  std::regex_constants::syntax_option_type flags = std::regex::ECMAScript;
   std::vector<std::string> group_name_list{};
-  bool has_regexp_groups = false;
+  std::string pattern{};
+  std::regex_constants::syntax_option_type flags{std::regex::ECMAScript};
 };
 
 using url_pattern_input = std::variant<url_aggregator, url_pattern_init>;

--- a/include/ada/url_pattern_helpers.h
+++ b/include/ada/url_pattern_helpers.h
@@ -83,9 +83,9 @@ class url_pattern_parser {
   // @see https://urlpattern.spec.whatwg.org/#is-a-duplicate-name
   bool is_duplicate_name(std::string_view name);
 
-  std::vector<Token> tokens{};
   F encoding_callback;
   std::string segment_wildcard_regexp;
+  std::vector<Token> tokens{};
   std::vector<url_pattern_part> parts{};
   std::string pending_fixed_value{};
   size_t index = 0;
@@ -136,7 +136,8 @@ class Tokenizer {
 };
 
 // @see https://urlpattern.spec.whatwg.org/#constructor-string-parser
-struct constructor_string_parser {
+class constructor_string_parser {
+ public:
   explicit constructor_string_parser(std::string_view new_input,
                                      std::vector<Token>&& new_token_list)
       : input(new_input), token_list(std::move(new_token_list)) {}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -911,7 +911,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
     // Set init to the result of running parse a constructor string given input.
     auto parse_result = url_pattern_helpers::constructor_string_parser::parse(
         std::get<std::string_view>(input));
-    if (!parse_result) {
+    if (!parse_result.has_value()) {
       ada_log("constructor_string_parser::parse failed");
       return tl::unexpected(parse_result.error());
     }
@@ -945,7 +945,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
   auto processed_init = url_pattern_init::process(
       init, "pattern", std::nullopt, std::nullopt, std::nullopt, std::nullopt,
       std::nullopt, std::nullopt, std::nullopt, std::nullopt);
-  if (!processed_init) {
+  if (!processed_init.has_value()) {
     ada_log("url_pattern_init::process failed for init and 'pattern'");
     return tl::unexpected(processed_init.error());
   }
@@ -995,7 +995,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
       processed_init->protocol.value(),
       url_pattern_helpers::canonicalize_protocol,
       url_pattern_compile_component_options::DEFAULT);
-  if (!protocol_component) {
+  if (!protocol_component.has_value()) {
     ada_log("url_pattern_component::compile failed for protocol ",
             processed_init->protocol.value());
     return tl::unexpected(protocol_component.error());
@@ -1009,7 +1009,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
       processed_init->username.value(),
       url_pattern_helpers::canonicalize_username,
       url_pattern_compile_component_options::DEFAULT);
-  if (!username_component) {
+  if (!username_component.has_value()) {
     ada_log("url_pattern_component::compile failed for username ",
             processed_init->username.value());
     return tl::unexpected(username_component.error());
@@ -1023,7 +1023,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
       processed_init->password.value(),
       url_pattern_helpers::canonicalize_password,
       url_pattern_compile_component_options::DEFAULT);
-  if (!password_component) {
+  if (!password_component.has_value()) {
     ada_log("url_pattern_component::compile failed for password ",
             processed_init->password.value());
     return tl::unexpected(password_component.error());
@@ -1045,7 +1045,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
         processed_init->hostname.value(),
         url_pattern_helpers::canonicalize_ipv6_hostname,
         url_pattern_compile_component_options::DEFAULT);
-    if (!hostname_component) {
+    if (!hostname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for ipv6 hostname ",
               processed_init->hostname.value());
       return tl::unexpected(hostname_component.error());
@@ -1059,7 +1059,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
         processed_init->hostname.value(),
         url_pattern_helpers::canonicalize_hostname,
         url_pattern_compile_component_options::HOSTNAME);
-    if (!hostname_component) {
+    if (!hostname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for hostname ",
               processed_init->hostname.value());
       return tl::unexpected(hostname_component.error());
@@ -1072,7 +1072,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
   auto port_component = url_pattern_component::compile(
       processed_init->port.value(), url_pattern_helpers::canonicalize_port,
       url_pattern_compile_component_options::DEFAULT);
-  if (!port_component) {
+  if (!port_component.has_value()) {
     ada_log("url_pattern_component::compile failed for port ",
             processed_init->port.value());
     return tl::unexpected(port_component.error());
@@ -1104,7 +1104,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
     auto pathname_component = url_pattern_component::compile(
         processed_init->pathname.value(),
         url_pattern_helpers::canonicalize_pathname, path_compile_options);
-    if (!pathname_component) {
+    if (!pathname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for pathname ",
               processed_init->pathname.value());
       return tl::unexpected(pathname_component.error());
@@ -1117,7 +1117,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
     auto pathname_component = url_pattern_component::compile(
         processed_init->pathname.value(),
         url_pattern_helpers::canonicalize_opaque_pathname, compile_options);
-    if (!pathname_component) {
+    if (!pathname_component.has_value()) {
       ada_log("url_pattern_component::compile failed for opaque pathname ",
               processed_init->pathname.value());
       return tl::unexpected(pathname_component.error());
@@ -1130,7 +1130,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
   auto search_component = url_pattern_component::compile(
       processed_init->search.value(), url_pattern_helpers::canonicalize_search,
       compile_options);
-  if (!search_component) {
+  if (!search_component.has_value()) {
     ada_log("url_pattern_component::compile failed for search ",
             processed_init->search.value());
     return tl::unexpected(search_component.error());
@@ -1142,7 +1142,7 @@ tl::expected<url_pattern, url_pattern_errors> parse_url_pattern_impl(
   auto hash_component = url_pattern_component::compile(
       processed_init->hash.value(), url_pattern_helpers::canonicalize_hash,
       compile_options);
-  if (!hash_component) {
+  if (!hash_component.has_value()) {
     ada_log("url_pattern_component::compile failed for hash ",
             processed_init->hash.value());
     return tl::unexpected(hash_component.error());

--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -20,7 +20,7 @@ constructor_string_parser::compute_protocol_matches_special_scheme_flag() {
   auto protocol_component = url_pattern_component::compile(
       protocol_string, canonicalize_protocol,
       url_pattern_compile_component_options::DEFAULT);
-  if (!protocol_component) {
+  if (!protocol_component.has_value()) {
     ada_log("url_pattern_component::compile failed for protocol_string ",
             protocol_string);
     return protocol_component.error();
@@ -273,7 +273,7 @@ constructor_string_parser::parse(std::string_view input) {
   // Let parser be a new constructor string parser whose input is input and
   // token list is the result of running tokenize given input and "lenient".
   auto token_list = tokenize(input, token_policy::LENIENT);
-  if (!token_list) {
+  if (!token_list.has_value()) {
     return tl::unexpected(token_list.error());
   }
   auto parser = constructor_string_parser(input, std::move(*token_list));
@@ -927,7 +927,7 @@ parse_pattern_string(std::string_view input,
   // Set parser’s token list to the result of running tokenize given input and
   // "strict".
   auto tokenize_result = tokenize(input, token_policy::STRICT);
-  if (!tokenize_result) {
+  if (!tokenize_result.has_value()) {
     ada_log("parse_pattern_string tokenize failed");
     return tl::unexpected(tokenize_result.error());
   }

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -18,7 +18,7 @@ TEST(wpt_urlpattern_tests, basic_tests) {
   auto init = ada::url_pattern_init{};
   init.pathname = "/books";
   auto url = ada::parse_url_pattern(init);
-  ASSERT_TRUE(url);
+  ASSERT_TRUE(url.has_value());
   ASSERT_EQ(url->get_protocol(), "*");
   ASSERT_EQ(url->get_hostname(), "*");
   ASSERT_EQ(url->get_username(), "*");


### PR DESCRIPTION
> Not intended to be merged.

It seems `.has_value()` checks are needed for undefined sanitizer to pass. Recommend enabling `ADA_SANITIZE_UNDEFINED=ON` to have a better stack trace. (PS: disable `ADA_SANITIZE`)

## Stack trace after these changes

```
Load of value 6, which is not a valid value for type 'bool'
  at 0x5555555ffd3f tl::expected<ada::url_pattern_component, ada::url_pattern_errors>::has_value() const
  at 0x55555560552c ada::parse_url_pattern(std::variant<std::basic_string_view<char, std::char_traits<char> >, ada::url_pattern_init>, std::basic_string_view<char, std::char_traits<char> > const*, ada::url_pattern_options const*)
  at 0x5555555ce8b6 wpt_urlpattern_tests_basic_tests_Test::TestBody() (wpt_urlpattern_tests.cpp:20)
  at 0x5555557be942 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2638)
  at 0x5555557b620c void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2674)
  at 0x55555578eab1 testing::Test::Run() (gtest.cc:2713)
  at 0x55555578f56f testing::TestInfo::Run() (gtest.cc:2859)
  at 0x55555578ff37 testing::TestSuite::Run() (gtest.cc:3037)
  at 0x55555579ff5d testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5967)
  at 0x5555557bfe9f bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2638)
  at 0x5555557b75a4 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2674)
  at 0x55555579e449 testing::UnitTest::Run() (gtest.cc:5546)
  at 0x55555577a3fd RUN_ALL_TESTS() (gtest.h:2334)
  at 0x55555577a3e5 main (gtest_main.cc:64)
  at 0x7ffff702a1c9 __libc_start_call_main (libc_start_call_main.h:58)
  at 0x7ffff702a28a __libc_start_main_impl (libc-start.c:360)
  at 0x5555555cde24 _start
```

## Before 

```
Load of value 96, which is not a valid value for type 'bool'
  at 0x55555562d9ac ada::url_pattern_component::url_pattern_component(ada::url_pattern_component&&)
  at 0x555555706c03 tl::detail::expected_storage_base<ada::url_pattern_component, ada::url_pattern_errors, false, true>::expected_storage_base<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:616)
  at 0x5555556fecce tl::detail::expected_operations_base<ada::url_pattern_component, ada::url_pattern_errors>::expected_storage_base<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:727)
  at 0x5555556fecf8 tl::detail::expected_copy_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:987)
  at 0x5555556fed22 tl::detail::expected_move_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:1023)
  at 0x5555556fed4c tl::detail::expected_copy_assign_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:1058)
  at 0x5555556fed76 tl::detail::expected_move_assign_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:1098)
  at 0x5555556feda9 tl::expected<ada::url_pattern_component, ada::url_pattern_errors>::expected<ada::url_pattern_component, (void*)0>(tl::in_place_t, ada::url_pattern_component&&) (expected.h:1608)
  at 0x5555556f3f1b tl::expected<ada::url_pattern_component, ada::url_pattern_errors>::expected<ada::url_pattern_component, (void*)0, (void*)0>(ada::url_pattern_component&&) (expected.h:1738)
  at 0x5555556c2a1c tl::expected<ada::url_pattern_component, ada::url_pattern_errors> ada::url_pattern_component::compile<tl::expected<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ada::url_pattern_errors> (*)(std::basic_string_view<char, std::char_traits<char> >)>(std::basic_string_view<char, std::char_traits<char> >, tl::expected<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ada::url_pattern_errors> (*)(std::basic_string_view<char, std::char_traits<char> >), ada::url_pattern_compile_component_options&) (url_pattern.cpp:540)
  at 0x55555560363d ada::parse_url_pattern(std::variant<std::basic_string_view<char, std::char_traits<char> >, ada::url_pattern_init>, std::basic_string_view<char, std::char_traits<char> > const*, ada::url_pattern_options const*)
  at 0x5555555ce8b6 wpt_urlpattern_tests_basic_tests_Test::TestBody() (wpt_urlpattern_tests.cpp:20)
  at 0x5555557be8ac void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2638)
  at 0x5555557b6176 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2674)
  at 0x55555578ea1b testing::Test::Run() (gtest.cc:2713)
  at 0x55555578f4d9 testing::TestInfo::Run() (gtest.cc:2859)
  at 0x55555578fea1 testing::TestSuite::Run() (gtest.cc:3037)
  at 0x55555579fec7 testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5967)
  at 0x5555557bfe09 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2638)
  at 0x5555557b750e bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2674)
  at 0x55555579e3b3 testing::UnitTest::Run() (gtest.cc:5546)
  at 0x55555577a367 RUN_ALL_TESTS() (gtest.h:2334)
  at 0x55555577a34f main (gtest_main.cc:64)
  at 0x7ffff702a1c9 __libc_start_call_main (libc_start_call_main.h:58)
  at 0x7ffff702a28a __libc_start_main_impl (libc-start.c:360)
  at 0x5555555cde24 _start

```


------

Note: If you enable `ADA_SANITIZE_WITHOUT_LEAKS` you get an a lot different stack trace.

```
Stack-buffer-overflow on address 0x7fffffffbac0 at pc 0x7ffff78fb303 bp 0x7fffffffa690 sp 0x7fffffff9e38
WRITE of size 2 at 0x7fffffffbac0 thread T0
  at 0x7ffff78fb302 memcpy (sanitizer_common_interceptors_memintrinsics.inc:115)
  at 0x55555559f858 std::char_traits<char>::copy(char*, char const*, unsigned long)
  at 0x5555555bfe63 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&) (basic_string.h:683)
  at 0x5555556675b7 ada::url_pattern_component::url_pattern_component(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool) (url_pattern.h:208)
  at 0x555555732840 tl::detail::expected_storage_base<ada::url_pattern_component, ada::url_pattern_errors, false, true>::expected_storage_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:616)
  at 0x55555571711c tl::detail::expected_operations_base<ada::url_pattern_component, ada::url_pattern_errors>::expected_storage_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:727)
  at 0x555555717264 tl::detail::expected_copy_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:987)
  at 0x5555557173ac tl::detail::expected_move_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:1023)
  at 0x5555557174f4 tl::detail::expected_copy_assign_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:1058)
  at 0x55555571763c tl::detail::expected_move_assign_base<ada::url_pattern_component, ada::url_pattern_errors, false>::expected_storage_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:1098)
  at 0x555555717723 tl::expected<ada::url_pattern_component, ada::url_pattern_errors>::expected<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, bool const&, (void*)0>(tl::in_place_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char> >&&, std::regex_constants::syntax_option_type&, std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, bool const&) (expected.h:1608)
  at 0x5555556c7900 tl::expected<ada::url_pattern_component, ada::url_pattern_errors> ada::url_pattern_component::compile<tl::expected<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ada::url_pattern_errors> (*)(std::basic_string_view<char, std::char_traits<char> >)>(std::basic_string_view<char, std::char_traits<char> >, tl::expected<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ada::url_pattern_errors> (*)(std::basic_string_view<char, std::char_traits<char> >), ada::url_pattern_compile_component_options&) (url_pattern.cpp:542)
  at 0x5555555b9dcb ada::parse_url_pattern(std::variant<std::basic_string_view<char, std::char_traits<char> >, ada::url_pattern_init>, std::basic_string_view<char, std::char_traits<char> > const*, ada::url_pattern_options const*)
  at 0x5555555876a9 wpt_urlpattern_tests_basic_tests_Test::TestBody() (wpt_urlpattern_tests.cpp:20)
  at 0x5555558604de void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2638)
  at 0x555555857da8 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2674)
  at 0x55555583064d testing::Test::Run() (gtest.cc:2713)
  at 0x55555583110b testing::TestInfo::Run() (gtest.cc:2859)
  at 0x555555831ad3 testing::TestSuite::Run() (gtest.cc:3037)
  at 0x555555841af9 testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5967)
  at 0x555555861a3b bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2638)
  at 0x555555859140 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2674)
  at 0x55555583ffe5 testing::UnitTest::Run() (gtest.cc:5546)
  at 0x55555581bf99 RUN_ALL_TESTS() (gtest.h:2334)
  at 0x55555581bf81 main (gtest_main.cc:64)
  at 0x7ffff702a1c9 __libc_start_call_main (libc_start_call_main.h:58)
  at 0x7ffff702a28a __libc_start_main_impl (libc-start.c:360)
  at 0x555555586144 _start
Address 0x7fffffffbac0 is located in stack of thread T0 at offset 2400 in frame
  at 0x5555555b7905 ada::parse_url_pattern(std::variant<std::basic_string_view<char, std::char_traits<char> >, ada::url_pattern_init>, std::basic_string_view<char, std::char_traits<char> > const*, ada::url_pattern_options const*)
```