### PR TITLE
make regex result accept optional string

### DIFF
--- a/include/ada/url_pattern-inl.h
+++ b/include/ada/url_pattern-inl.h
@@ -39,7 +39,8 @@ std::string url_pattern_component<regex_provider>::to_string() const {
 template <url_pattern_regex::regex_concept regex_provider>
 url_pattern_component_result
 url_pattern_component<regex_provider>::create_component_match_result(
-    std::string_view input, std::vector<std::string>&& exec_result) {
+    std::string_view input,
+    std::vector<std::optional<std::string>>&& exec_result) {
   // Let result be a new URLPatternComponentResult.
   // Set result["input"] to input.
   // Let groups be a record<USVString, (USVString or undefined)>.
@@ -47,7 +48,7 @@ url_pattern_component<regex_provider>::create_component_match_result(
       url_pattern_component_result{.input = std::string(input), .groups = {}};
 
   // If input is empty, then groups will always be empty.
-  if (input.empty() || exec_result.empty()) {
+  if (input.empty()) {
     return result;
   }
 

--- a/include/ada/url_pattern-inl.h
+++ b/include/ada/url_pattern-inl.h
@@ -53,7 +53,7 @@ url_pattern_component<regex_provider>::create_component_match_result(
   }
 
   // Optimization: Let's reserve the size.
-  result.groups.reserve(exec_result.size() - 1);
+  result.groups.reserve(exec_result.size());
 
   // We explicitly start iterating from 0 even though the spec
   // says we should start from 1. This case is handled by the

--- a/include/ada/url_pattern.h
+++ b/include/ada/url_pattern.h
@@ -133,7 +133,7 @@ inline url_pattern_compile_component_options
 // specification.
 struct url_pattern_component_result {
   std::string input;
-  std::unordered_map<std::string, std::string> groups;
+  std::unordered_map<std::string, std::optional<std::string>> groups;
 
   bool operator==(const url_pattern_component_result&) const;
 
@@ -142,7 +142,8 @@ struct url_pattern_component_result {
                       std::ostream* os) {
     *os << "input: '" << result.input << "', group: ";
     for (const auto& group : result.groups) {
-      *os << "(" << group.first << ", " << group.second << ") ";
+      *os << "(" << group.first << ", " << group.second.value_or("undefined")
+          << ") ";
     }
   }
 #endif  // ADA_TESTING
@@ -172,7 +173,8 @@ class url_pattern_component {
 
   // @see https://urlpattern.spec.whatwg.org/#create-a-component-match-result
   url_pattern_component_result create_component_match_result(
-      std::string_view input, std::vector<std::string>&& exec_result);
+      std::string_view input,
+      std::vector<std::optional<std::string>>&& exec_result);
 
   std::string to_string() const;
 

--- a/include/ada/url_pattern_regex.h
+++ b/include/ada/url_pattern_regex.h
@@ -24,7 +24,7 @@ concept regex_concept = requires(T t, std::string_view pattern,
   // Function to perform regex search
   {
     T::regex_search(input, std::declval<typename T::regex_type&>())
-  } -> std::same_as<std::optional<std::vector<std::string>>>;
+  } -> std::same_as<std::optional<std::vector<std::optional<std::string>>>>;
 
   // Function to match regex pattern
   {
@@ -44,7 +44,7 @@ class std_regex_provider {
   using regex_type = std::regex;
   static std::optional<regex_type> create_instance(std::string_view pattern,
                                                    bool ignore_case);
-  static std::optional<std::vector<std::string>> regex_search(
+  static std::optional<std::vector<std::optional<std::string>>> regex_search(
       std::string_view input, const regex_type& pattern);
   static bool regex_match(std::string_view input, const regex_type& pattern);
 };

--- a/src/url_pattern_regex.cpp
+++ b/src/url_pattern_regex.cpp
@@ -19,8 +19,9 @@ std::optional<std::regex> std_regex_provider::create_instance(
   }
 }
 
-std::optional<std::vector<std::string>> std_regex_provider::regex_search(
-    std::string_view input, const std::regex& pattern) {
+std::optional<std::vector<std::optional<std::string>>>
+std_regex_provider::regex_search(std::string_view input,
+                                 const std::regex& pattern) {
   std::string input_str(
       input.begin(),
       input.end());  // Convert string_view to string for regex_search
@@ -29,7 +30,7 @@ std::optional<std::vector<std::string>> std_regex_provider::regex_search(
                          std::regex_constants::match_any)) {
     return std::nullopt;
   }
-  std::vector<std::string> matches;
+  std::vector<std::optional<std::string>> matches;
   if (match_result.empty()) {
     return matches;
   }


### PR DESCRIPTION
Realized that we didn't follow the spec on this one. There is a test case that checks if a group value is `undefined`. I'll follow up on the other PR once this lands.