### PR TITLE
add more macos versions to test

### DIFF
--- a/.github/workflows/macos_install.yml
+++ b/.github/workflows/macos_install.yml
@@ -1,4 +1,4 @@
-name: macos (Installation)
+name: macOS (Installation)
 
 on:
   pull_request:
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   macos-build:
-    runs-on: macos-15
     strategy:
       matrix:
-        include:
-          - shared: OFF
+        shared: [OFF]
+        runs-on: [macos-13, macos-14, macos-15]
+    runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Prepare

--- a/include/ada/url_pattern.h
+++ b/include/ada/url_pattern.h
@@ -289,15 +289,59 @@ class url_pattern {
       std::variant<std::string_view, url_pattern_init> input,
       const std::string_view* base_url, const url_pattern_options* options);
 
- private:
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> protocol_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> username_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> password_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> hostname_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> port_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> pathname_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> search_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   url_pattern_component<regex_provider> hash_component{};
+  /**
+   * @private
+   * We can not make this private due to a LLVM bug.
+   * Ref: https://github.com/ada-url/ada/pull/859
+   */
   bool ignore_case_ = false;
 };
 


### PR DESCRIPTION
let's test more macOS

the following error message only exist on macOS 13 and 14, but not on macOS 15 builds

```
/Users/runner/work/ada/ada/include/ada/parser-inl.h:117:16: error: 'protocol_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
  url_pattern_.protocol_component = std::move(*protocol_component);
               ^
/Users/runner/work/ada/ada/include/ada/implementation-inl.h:21:18: note: in instantiation of function template specialization 'ada::parser::parse_url_pattern_impl<ada::url_pattern_regex::std_regex_provider>' requested here
  return parser::parse_url_pattern_impl<regex_provider>(std::move(input),
                 ^
/Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:29:12: note: in instantiation of function template specialization 'ada::parse_url_pattern<ada::url_pattern_regex::std_regex_provider>' requested here
      ada::parse_url_pattern<ada::url_pattern_regex::std_regex_provider>(init);
           ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:293:41: note: declared private here
  url_pattern_component<regex_provider> protocol_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:131:16: error: 'username_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
  url_pattern_.username_component = std::move(*username_component);
               ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:294:41: note: declared private here
  url_pattern_component<regex_provider> username_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:145:16: error: 'password_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
  url_pattern_.password_component = std::move(*password_component);
               ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:295:41: note: declared private here
  url_pattern_component<regex_provider> password_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:167:18: error: 'hostname_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
    url_pattern_.hostname_component = std::move(*hostname_component);
                 ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:296:41: note: declared private here
  url_pattern_component<regex_provider> hostname_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:181:18: error: 'hostname_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
    url_pattern_.hostname_component = std::move(*hostname_component);
                 ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:296:41: note: declared private here
  url_pattern_component<regex_provider> hostname_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:194:16: error: 'port_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
  url_pattern_.port_component = std::move(*port_component);
               ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:297:41: note: declared private here
  url_pattern_component<regex_provider> port_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:207:40: error: 'protocol_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
          regex_provider>(url_pattern_.protocol_component)) {
                                       ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:293:41: note: declared private here
  url_pattern_component<regex_provider> protocol_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:226:18: error: 'pathname_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
    url_pattern_.pathname_component = std::move(*pathname_component);
                 ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:298:41: note: declared private here
  url_pattern_component<regex_provider> pathname_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:239:18: error: 'pathname_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
    url_pattern_.pathname_component = std::move(*pathname_component);
                 ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:298:41: note: declared private here
  url_pattern_component<regex_provider> pathname_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:252:16: error: 'search_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
  url_pattern_.search_component = std::move(*search_component);
               ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:299:41: note: declared private here
  url_pattern_component<regex_provider> search_component{};
                                        ^
In file included from /Users/runner/work/ada/ada/tests/wpt_urlpattern_tests.cpp:8:
In file included from /Users/runner/work/ada/ada/include/ada.h:17:
/Users/runner/work/ada/ada/include/ada/parser-inl.h:264:16: error: 'hash_component' is a private member of 'ada::url_pattern<ada::url_pattern_regex::std_regex_provider>'
  url_pattern_.hash_component = std::move(*hash_component);
               ^
/Users/runner/work/ada/ada/include/ada/url_pattern.h:300:41: note: declared private here
  url_pattern_component<regex_provider> hash_component{};
                                        ^
11 errors generated.
```