### PR TITLE
Add a regression test for url_search_params::sort taken from WPT

### DIFF
--- a/tests/url_search_params.cpp
+++ b/tests/url_search_params.cpp
@@ -123,6 +123,19 @@ TEST(url_search_params, sort) {
   SUCCEED();
 }
 
+// Taken from
+// https://github.com/web-platform-tests/wpt/blob/d5085f61e2d949bc9fb24b04f4c6a47bdf6d3be9/url/urlsearchparams-sort.any.js#L11
+TEST(url_search_params, sort_unicode_code_units) {
+  ada::url_search_params search_params(
+      "ﬃ&🌈");  // 🌈 > code point, but < code unit because two code units
+  search_params.sort();
+  ASSERT_EQ(search_params.size(), 2);
+  auto keys = search_params.get_keys();
+  ASSERT_EQ(keys.next(), "🌈");
+  ASSERT_EQ(keys.next(), "ﬃ");
+  SUCCEED();
+}
+
 TEST(url_search_params, string_constructor) {
   auto p = ada::url_search_params("?a=b");
   ASSERT_EQ(p.to_string(), "a=b");


### PR DESCRIPTION
While working on integrating Web Platform Tests as a test suite for Cloudflare's worked, I discovered a situation where ada-url's implementation of url_search_params::sort appears not to be following the URL spec.

The URL spec provides the following requirements for URLSearchParams.sort:

> The sort() method steps are:
> 1. Sort all [tuples](https://infra.spec.whatwg.org/#tuple) in [this](https://webidl.spec.whatwg.org/#this)’s [list](https://url.spec.whatwg.org/#concept-urlsearchparams-list), if any, by their names. Sorting must be done by comparison of code units. The relative order between [tuples](https://infra.spec.whatwg.org/#tuple) with equal names must be preserved. 

&mdash; https://url.spec.whatwg.org/#example-searchparams-sort

WPT's urlsearchparams-sort.any.js test uses the following example to demonstrate this:

> {
>  "input": "ﬃ&🌈", // 🌈 > code point, but < code unit because two code units
>    "output": [["🌈", ""], ["ﬃ", ""]]
> },
&mdash; https://github.com/web-platform-tests/wpt/blob/master/url/urlsearchparams-sort.any.js#L11

So the spec requires _"comparsion of code units"_ but as far as I can tell, it isn't very clear about what encoding should be used to perform the comparsion. Based on the WPT test, and checking other implementations like Node and Chromium, the encoding used is UTF-16. This makes sense, as this matches the behaviour of Javascript's String type.

I can fix this by implementing something like [`ada::idna::utf8_to_utf32`](https://github.com/ada-url/ada/blob/main/src/ada_idna.cpp#L11) to do a conversion from utf8 to utf16 before sorting the keys, but please let me know if you have an alternative approach in mind - I'd be happy to implement it that way instead.