### PR TITLE
fixing issue 861

### DIFF
--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -166,7 +166,8 @@ inline void url_search_params::sort() {
                                       const key_value_pair &rhs) {
     size_t i = 0, j = 0;
     uint32_t low_surrogate1 = 0, low_surrogate2 = 0;
-    while (i < lhs.first.size() && j < rhs.first.size()) {
+    while ((i < lhs.first.size() || low_surrogate1 != 0) &&
+           (j < rhs.first.size() || low_surrogate2 != 0)) {
       uint32_t codePoint1 = 0, codePoint2 = 0;
 
       if (low_surrogate1 != 0) {
@@ -232,7 +233,6 @@ inline void url_search_params::sort() {
         return (codePoint1 < codePoint2);
       }
     }
-
     return (i < lhs.first.size());
   });
 }

--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -233,7 +233,7 @@ inline void url_search_params::sort() {
         return (codePoint1 < codePoint2);
       }
     }
-    return (i < lhs.first.size());
+    return (j < rhs.first.size() || low_surrogate2 != 0);
   });
 }
 

--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -161,10 +161,95 @@ inline void url_search_params::remove(const std::string_view key,
   });
 }
 
+// returns -1 if str1 < str2, 0 if str1 == str2, 1 if str1 > str2
+// the comparison is done using the UTF-16 code units of the UTF-8 code points
+inline int compare_utf8_as_utf16(std::string_view str1, std::string_view str2) {
+  size_t i = 0;
+  size_t j = 0;
+  uint32_t low_surrogate1 = 0;
+  uint32_t low_surrogate2 = 0;
+  while (i < str1.size() && j < str2.size()) {
+    uint32_t codePoint1 = 0;
+    uint32_t codePoint2 = 0;
+
+    if (low_surrogate1 != 0) {
+      codePoint1 = low_surrogate1;
+      low_surrogate1 = 0;
+    } else {
+      uint8_t c1 = uint8_t(str1[i]);
+      if (c1 <= 0x7F) {
+        codePoint1 = c1;
+        i++;
+      } else if (c1 <= 0xDF) {
+        codePoint1 = ((c1 & 0x1F) << 6) | (uint8_t(str1[i + 1]) & 0x3F);
+        i += 2;
+      } else if (c1 <= 0xEF) {
+        codePoint1 = ((c1 & 0x0F) << 12) |
+                     ((uint8_t(str1[i + 1]) & 0x3F) << 6) |
+                     (uint8_t(str1[i + 2]) & 0x3F);
+        i += 3;
+      } else {
+        codePoint1 = ((c1 & 0x07) << 18) |
+                     ((uint8_t(str1[i + 1]) & 0x3F) << 12) |
+                     ((uint8_t(str1[i + 2]) & 0x3F) << 6) |
+                     (uint8_t(str1[i + 3]) & 0x3F);
+        i += 4;
+
+        codePoint1 -= 0x10000;
+        uint16_t high_surrogate = uint16_t(0xD800 + (codePoint1 >> 10));
+        low_surrogate1 = uint16_t(0xDC00 + (codePoint1 & 0x3FF));
+        codePoint1 = high_surrogate;
+      }
+    }
+
+    if (low_surrogate2 != 0) {
+      codePoint2 = low_surrogate2;
+      low_surrogate2 = 0;
+    } else {
+      uint8_t c2 = uint8_t(str2[j]);
+      if (c2 <= 0x7F) {
+        codePoint2 = c2;
+        j++;
+      } else if (c2 <= 0xDF) {
+        codePoint2 = ((c2 & 0x1F) << 6) | (uint8_t(str2[j + 1]) & 0x3F);
+        j += 2;
+      } else if (c2 <= 0xEF) {
+        codePoint2 = ((c2 & 0x0F) << 12) |
+                     ((uint8_t(str2[j + 1]) & 0x3F) << 6) |
+                     (uint8_t(str2[j + 2]) & 0x3F);
+        j += 3;
+      } else {
+        codePoint2 = ((c2 & 0x07) << 18) |
+                     ((uint8_t(str2[j + 1]) & 0x3F) << 12) |
+                     ((uint8_t(str2[j + 2]) & 0x3F) << 6) |
+                     (uint8_t(str2[j + 3]) & 0x3F);
+        j += 4;
+        codePoint2 -= 0x10000;
+        uint16_t high_surrogate = uint16_t(0xD800 + (codePoint2 >> 10));
+        low_surrogate2 = uint16_t(0xDC00 + (codePoint2 & 0x3FF));
+        codePoint2 = high_surrogate;
+      }
+    }
+
+    if (codePoint1 != codePoint2) {
+      return (codePoint1 < codePoint2) ? -1 : 1;
+    }
+  }
+
+  if (i < str1.size()) {
+    return 1;
+  }
+  if (j < str2.size()) {
+    return -1;
+  }
+
+  return 0;
+}
+
 inline void url_search_params::sort() {
   std::ranges::stable_sort(
       params, [](const key_value_pair &lhs, const key_value_pair &rhs) {
-        return lhs.first < rhs.first;
+        return compare_utf8_as_utf16(lhs.first, rhs.first) == -1;
       });
 }
 

--- a/tests/url_search_params.cpp
+++ b/tests/url_search_params.cpp
@@ -257,3 +257,15 @@ TEST(url_search_params, test_character_set) {
   }
   SUCCEED();
 }
+
+// Taken from
+// https://github.com/web-platform-tests/wpt/blob/d5085f61e2d949bc9fb24b04f4c6a47bdf6d3be9/url/urlsearchparams-sort.any.js#L11
+TEST(url_search_params, sort_unicode_code_units) {
+  ada::url_search_params search_params("\xef\xac\x83&\xf0\x9f\x8c\x88");
+  search_params.sort();
+  ASSERT_EQ(search_params.size(), 2);
+  auto keys = search_params.get_keys();
+  ASSERT_EQ(keys.next(), "\xf0\x9f\x8c\x88");
+  ASSERT_EQ(keys.next(), "\xef\xac\x83");
+  SUCCEED();
+}

--- a/tests/url_search_params.cpp
+++ b/tests/url_search_params.cpp
@@ -269,3 +269,13 @@ TEST(url_search_params, sort_unicode_code_units) {
   ASSERT_EQ(keys.next(), "\xef\xac\x83");
   SUCCEED();
 }
+
+TEST(url_search_params, sort_unicode_code_units_edge_case) {
+  ada::url_search_params search_params("\xf0\x9f\x8c\x88\xef\xac\x83&\xf0\x9f\x8c\x88");
+  search_params.sort();
+  ASSERT_EQ(search_params.size(), 2);
+  auto keys = search_params.get_keys();
+  ASSERT_EQ(keys.next(), "\xf0\x9f\x8c\x88");
+  ASSERT_EQ(keys.next(), "\xf0\x9f\x8c\x88\xef\xac\x83");
+  SUCCEED();
+}

--- a/tests/url_search_params.cpp
+++ b/tests/url_search_params.cpp
@@ -271,7 +271,8 @@ TEST(url_search_params, sort_unicode_code_units) {
 }
 
 TEST(url_search_params, sort_unicode_code_units_edge_case) {
-  ada::url_search_params search_params("\xf0\x9f\x8c\x88\xef\xac\x83&\xf0\x9f\x8c\x88");
+  ada::url_search_params search_params(
+      "\xf0\x9f\x8c\x88\xef\xac\x83&\xf0\x9f\x8c\x88");
   search_params.sort();
   ASSERT_EQ(search_params.size(), 2);
   auto keys = search_params.get_keys();


### PR DESCRIPTION
In https://github.com/ada-url/ada/pull/861, @npaun reported an issue with how we sort in URLSearchParams.sort. A reasonable interpretation is that we should sort in UTF-16 code units. That is what this PR does. I am including @npaun's test case (although, using only ASCII characters to avoid issues).