### PR TITLE
improve urlpattern::match() performance

### DIFF
--- a/include/ada/url_pattern.h
+++ b/include/ada/url_pattern.h
@@ -170,7 +170,7 @@ class url_pattern_component {
 
   // @see https://urlpattern.spec.whatwg.org/#create-a-component-match-result
   url_pattern_component_result create_component_match_result(
-      std::string_view input,
+      std::string&& input,
       std::vector<std::optional<std::string>>&& exec_result);
 
 #if ADA_TESTING

--- a/include/ada/url_pattern_regex.h
+++ b/include/ada/url_pattern_regex.h
@@ -43,7 +43,7 @@ concept regex_concept = requires(T t, std::string_view pattern,
 };
 
 #ifdef ADA_USE_UNSAFE_STD_REGEX_PROVIDER
-class std_regex_provider {
+class std_regex_provider final {
  public:
   std_regex_provider() = default;
   using regex_type = std::regex;


### PR DESCRIPTION
Improves the performance of both happy path and bad path, and reduces unnecessary string copies.

PS: We need benchmarks for URLPattern, but the change is not controversial.