### PR TITLE
add fail-fast: false to macos install

### DIFF
--- a/.github/workflows/macos_install.yml
+++ b/.github/workflows/macos_install.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   macos-build:
     strategy:
+      fail-fast: false
       matrix:
         shared: [OFF]
         runs-on: [macos-13, macos-14, macos-15]


### PR DESCRIPTION
It seems the macOS-build workflow fails at the moment on main.