### PR TITLE
reduce string allocations in url_pattern_init::process

### DIFF
--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -55,14 +55,14 @@ template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_hash_prefix() {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index and "#".
-  return is_non_special_pattern_char(token_index, "#");
+  return is_non_special_pattern_char(token_index, '#');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_search_prefix() {
   // If result of running is a non-special pattern char given parser, parser’s
   // token index and "?" is true, then return true.
-  if (is_non_special_pattern_char(token_index, "?")) {
+  if (is_non_special_pattern_char(token_index, '?')) {
     return true;
   }
 
@@ -93,13 +93,15 @@ bool constructor_string_parser<regex_provider>::is_search_prefix() {
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_non_special_pattern_char(
-    size_t index, std::string_view value) const {
+    size_t index, uint32_t value) const {
   // Let token be the result of running get a safe token given parser and index.
   auto token = get_safe_token(index);
   ADA_ASSERT_TRUE(token);
 
   // If token’s value is not value, then return false.
-  if (token->value != value) {
+  // TODO: Remove this once we make sure get_safe_token returns a non-empty
+  // string.
+  if (!token->value.empty() && token->value[0] != value) {
     return false;
   }
 
@@ -152,12 +154,12 @@ bool constructor_string_parser<regex_provider>::next_is_authority_slashes()
     const {
   // If the result of running is a non-special pattern char given parser,
   // parser’s token index + 1, and "/" is false, then return false.
-  if (!is_non_special_pattern_char(token_index + 1, "/")) {
+  if (!is_non_special_pattern_char(token_index + 1, '/')) {
     return false;
   }
   // If the result of running is a non-special pattern char given parser,
   // parser’s token index + 2, and "/" is false, then return false.
-  if (!is_non_special_pattern_char(token_index + 2, "/")) {
+  if (!is_non_special_pattern_char(token_index + 2, '/')) {
     return false;
   }
   return true;
@@ -167,7 +169,7 @@ template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_protocol_suffix() const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and ":".
-  return is_non_special_pattern_char(token_index, ":");
+  return is_non_special_pattern_char(token_index, ':');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
@@ -295,42 +297,42 @@ bool constructor_string_parser<regex_provider>::is_an_identity_terminator()
     const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and "@".
-  return is_non_special_pattern_char(token_index, "@");
+  return is_non_special_pattern_char(token_index, '@');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_pathname_start() const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and "/".
-  return is_non_special_pattern_char(token_index, "/");
+  return is_non_special_pattern_char(token_index, '/');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_password_prefix() const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and ":".
-  return is_non_special_pattern_char(token_index, ":");
+  return is_non_special_pattern_char(token_index, ':');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_an_ipv6_open() const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and "[".
-  return is_non_special_pattern_char(token_index, "[");
+  return is_non_special_pattern_char(token_index, '[');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_an_ipv6_close() const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and "]".
-  return is_non_special_pattern_char(token_index, "]");
+  return is_non_special_pattern_char(token_index, ']');
 }
 
 template <url_pattern_regex::regex_concept regex_provider>
 bool constructor_string_parser<regex_provider>::is_port_prefix() const {
   // Return the result of running is a non-special pattern char given parser,
   // parser’s token index, and ":".
-  return is_non_special_pattern_char(token_index, ":");
+  return is_non_special_pattern_char(token_index, ':');
 }
 
 inline void Tokenizer::get_next_code_point() {

--- a/include/ada/url_pattern_helpers.h
+++ b/include/ada/url_pattern_helpers.h
@@ -222,7 +222,7 @@ struct constructor_string_parser {
 
  private:
   // @see https://urlpattern.spec.whatwg.org/#is-a-non-special-pattern-char
-  bool is_non_special_pattern_char(size_t index, std::string_view value) const;
+  bool is_non_special_pattern_char(size_t index, uint32_t value) const;
 
   // @see https://urlpattern.spec.whatwg.org/#get-a-safe-token
   const token* get_safe_token(size_t index) const;

--- a/src/url_pattern.cpp
+++ b/src/url_pattern.cpp
@@ -200,6 +200,7 @@ tl::expected<url_pattern_init, errors> url_pattern_init::process(
         !url_pattern_helpers::is_absolute_pathname(*result.pathname, type)) {
       // Let baseURLPath be the result of running process a base URL string
       // given the result of URL path serializing baseURL and type.
+      // TODO: Optimization opportunity: Avoid returning a string if no slash exist.
       std::string base_url_path = url_pattern_helpers::process_base_url_string(
           base_url->get_pathname(), type);
 

--- a/src/url_pattern.cpp
+++ b/src/url_pattern.cpp
@@ -200,7 +200,8 @@ tl::expected<url_pattern_init, errors> url_pattern_init::process(
         !url_pattern_helpers::is_absolute_pathname(*result.pathname, type)) {
       // Let baseURLPath be the result of running process a base URL string
       // given the result of URL path serializing baseURL and type.
-      // TODO: Optimization opportunity: Avoid returning a string if no slash exist.
+      // TODO: Optimization opportunity: Avoid returning a string if no slash
+      // exist.
       std::string base_url_path = url_pattern_helpers::process_base_url_string(
           base_url->get_pathname(), type);
 

--- a/src/url_pattern.cpp
+++ b/src/url_pattern.cpp
@@ -212,12 +212,12 @@ tl::expected<url_pattern_init, errors> url_pattern_init::process(
       if (slash_index != std::string::npos) {
         // Let new pathname be the code point substring from 0 to slash index +
         // 1 within baseURLPath.
-        std::string new_pathname = base_url_path.substr(0, slash_index + 1);
+        base_url_path.resize(slash_index + 1);
         // Append result["pathname"] to the end of new pathname.
         ADA_ASSERT_TRUE(result.pathname.has_value());
-        new_pathname.append(result.pathname.value());
+        base_url_path.append(std::move(*result.pathname));
         // Set result["pathname"] to new pathname.
-        result.pathname = std::move(new_pathname);
+        result.pathname = std::move(base_url_path);
       }
     }
 

--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -825,11 +825,9 @@ constexpr bool is_absolute_pathname(
   // If input’s code point length is less than 2, then return false.
   if (input.size() < 2) return false;
   // If input[0] is U+005C (\) and input[1] is U+002F (/), then return true.
-  if (input.starts_with("\\/")) return true;
   // If input[0] is U+007B ({) and input[1] is U+002F (/), then return true.
-  if (input.starts_with("{/")) return true;
   // Return false.
-  return false;
+  return input[1] == '/' && (input[0] == '\\' || input[0] == '{');
 }
 
 std::string generate_pattern_string(


### PR DESCRIPTION
Removes multiple string allocations and copies in url_pattern_init::process()