### PR TITLE
fix(url): handle tab/newline-only inputs in set_port

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -794,11 +794,12 @@ bool url::set_port(const std::string_view input) {
     return false;
   }
 
-  size_t len = 0;
-  while (len < trimmed.length() && ada::unicode::is_ascii_digit(trimmed[len])) {
-    len++;
-  }
-  std::string_view digits_to_parse = std::string_view(trimmed.data(), len);
+  // Find the first non-digit character to determine the length of digits
+  auto first_non_digit =
+      std::ranges::find_if_not(trimmed, ada::unicode::is_ascii_digit);
+  std::string_view digits_to_parse =
+      std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
+
   // Revert changes if parse_port fails.
   std::optional<uint16_t> previous_port = port;
   parse_port(digits_to_parse);

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -776,10 +776,16 @@ bool url::set_port(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
+
+  if (input.empty()) {
+    port = std::nullopt;
+    return true;
+  }
+
   std::string trimmed(input);
   helpers::remove_ascii_tab_or_newline(trimmed);
+
   if (trimmed.empty()) {
-    port = std::nullopt;
     return true;
   }
 
@@ -788,9 +794,14 @@ bool url::set_port(const std::string_view input) {
     return false;
   }
 
+  size_t len = 0;
+  while (len < trimmed.length() && ada::unicode::is_ascii_digit(trimmed[len])) {
+    len++;
+  }
+  std::string_view digits_to_parse = std::string_view(trimmed.data(), len);
   // Revert changes if parse_port fails.
   std::optional<uint16_t> previous_port = port;
-  parse_port(trimmed);
+  parse_port(digits_to_parse);
   if (is_valid) {
     return true;
   }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -280,10 +280,16 @@ bool url_aggregator::set_port(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
+
+  if (input.empty()) {
+    clear_port();
+    return true;
+  }
+
   std::string trimmed(input);
   helpers::remove_ascii_tab_or_newline(trimmed);
+
   if (trimmed.empty()) {
-    clear_port();
     return true;
   }
 
@@ -292,9 +298,15 @@ bool url_aggregator::set_port(const std::string_view input) {
     return false;
   }
 
+  size_t len = 0;
+  while (len < trimmed.length() && ada::unicode::is_ascii_digit(trimmed[len])) {
+    len++;
+  }
+  std::string_view digits_to_parse = std::string_view(trimmed.data(), len);
+
   // Revert changes if parse_port fails.
   uint32_t previous_port = components.port;
-  parse_port(trimmed);
+  parse_port(digits_to_parse);
   if (is_valid) {
     return true;
   }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -298,11 +298,11 @@ bool url_aggregator::set_port(const std::string_view input) {
     return false;
   }
 
-  size_t len = 0;
-  while (len < trimmed.length() && ada::unicode::is_ascii_digit(trimmed[len])) {
-    len++;
-  }
-  std::string_view digits_to_parse = std::string_view(trimmed.data(), len);
+  // Find the first non-digit character to determine the length of digits
+  auto first_non_digit =
+      std::ranges::find_if_not(trimmed, ada::unicode::is_ascii_digit);
+  std::string_view digits_to_parse =
+      std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
 
   // Revert changes if parse_port fails.
   uint32_t previous_port = components.port;

--- a/tests/wpt/ada_extra_setters_tests.json
+++ b/tests/wpt/ada_extra_setters_tests.json
@@ -98,6 +98,20 @@
       "expected": {
         "port": "4"
       }
+    },
+    {
+      "href": "https://domain.com:3000",
+      "new_value": "\n\t80\n\t80\n\t",
+      "expected": {
+          "port": "8080"
+      }
+    },
+    {
+        "href": "https://domain.com:3000",
+        "new_value": "\n\n\t\t",
+        "expected": {
+            "port": "3000"
+        }
     }
   ],
   "hash": [


### PR DESCRIPTION
This change updates set_port so that when the input consists only of tab (\t), newline (\n), or carriage return characters, the port is left unchanged. Also adds these cases to ada_extra_setters_tests.json while waiting for their inclusion in WPT.

Refs: https://github.com/web-platform-tests/wpt/pull/53420