### PR TITLE
fix(url): handle :port values in host setter

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -691,35 +691,67 @@ bool url::set_host_or_hostname(const std::string_view input) {
     // Note: the 'found_colon' value is true if and only if a colon was
     // encountered while not inside brackets.
     if (found_colon) {
+      // If buffer is the empty string, host-missing validation error, return
+      // failure.
+      std::string_view buffer = host_view.substr(0, location);
+      if (buffer.empty()) {
+        return false;
+      }
+
+      // If state override is given and state override is hostname state, then
+      // return failure.
       if constexpr (override_hostname) {
         return false;
       }
-      std::string_view buffer = new_host.substr(location + 1);
-      if (!buffer.empty()) {
-        set_port(buffer);
-      }
-    }
-    // If url is special and host_view is the empty string, validation error,
-    // return failure. Otherwise, if state override is given, host_view is the
-    // empty string, and either url includes credentials or url's port is
-    // non-null, return.
-    else if (host_view.empty() &&
-             (is_special() || has_credentials() || port.has_value())) {
-      return false;
-    }
 
-    // Let host be the result of host parsing host_view with url is not special.
-    if (host_view.empty() && !is_special()) {
-      host = "";
+      // Let host be the result of host parsing buffer with url is not special.
+      bool succeeded = parse_host(buffer);
+      if (!succeeded) {
+        host = std::move(previous_host);
+        update_base_port(previous_port);
+        return false;
+      }
+
+      // Set url's host to host, buffer to the empty string, and state to port
+      // state.
+      std::string_view port_buffer = new_host.substr(location + 1);
+      if (!port_buffer.empty()) {
+        set_port(port_buffer);
+      }
       return true;
     }
+    // Otherwise, if one of the following is true:
+    // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
+    // - url is special and c is U+005C (\)
+    else {
+      // If url is special and host_view is the empty string, host-missing
+      // validation error, return failure.
+      if (host_view.empty() && is_special()) {
+        return false;
+      }
 
-    bool succeeded = parse_host(host_view);
-    if (!succeeded) {
-      host = std::move(previous_host);
-      update_base_port(previous_port);
+      // Otherwise, if state override is given, host_view is the empty string,
+      // and either url includes credentials or url's port is non-null, then
+      // return failure.
+      if (host_view.empty() && (has_credentials() || port.has_value())) {
+        return false;
+      }
+
+      // Let host be the result of host parsing host_view with url is not
+      // special.
+      if (host_view.empty() && !is_special()) {
+        host = "";
+        return true;
+      }
+
+      bool succeeded = parse_host(host_view);
+      if (!succeeded) {
+        host = std::move(previous_host);
+        update_base_port(previous_port);
+        return false;
+      }
+      return true;
     }
-    return succeeded;
   }
 
   size_t location = new_host.find_first_of("/\\?");

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -549,43 +549,75 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     // Note: the 'found_colon' value is true if and only if a colon was
     // encountered while not inside brackets.
     if (found_colon) {
+      // If buffer is the empty string, host-missing validation error, return
+      // failure.
+      std::string_view host_buffer = host_view.substr(0, location);
+      if (host_buffer.empty()) {
+        return false;
+      }
+
+      // If state override is given and state override is hostname state, then
+      // return failure.
       if constexpr (override_hostname) {
         return false;
       }
-      std::string_view sub_buffer = new_host.substr(location + 1);
-      if (!sub_buffer.empty()) {
-        set_port(sub_buffer);
-      }
-    }
-    // If url is special and host_view is the empty string, validation error,
-    // return failure. Otherwise, if state override is given, host_view is the
-    // empty string, and either url includes credentials or url's port is
-    // non-null, return.
-    else if (host_view.empty() &&
-             (is_special() || has_credentials() || has_port())) {
-      return false;
-    }
 
-    // Let host be the result of host parsing host_view with url is not special.
-    if (host_view.empty() && !is_special()) {
-      if (has_hostname()) {
-        clear_hostname();  // easy!
+      // Let host be the result of host parsing buffer with url is not special.
+      bool succeeded = parse_host(host_buffer);
+      if (!succeeded) {
+        update_base_hostname(previous_host);
+        update_base_port(previous_port);
+        return false;
+      }
+
+      // Set url's host to host, buffer to the empty string, and state to port
+      // state.
+      std::string_view port_buffer = new_host.substr(location + 1);
+      if (!port_buffer.empty()) {
+        set_port(port_buffer);
+      }
+      return true;
+    }
+    // Otherwise, if one of the following is true:
+    // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
+    // - url is special and c is U+005C (\)
+    else {
+      // If url is special and host_view is the empty string, host-missing
+      // validation error, return failure.
+      if (host_view.empty() && is_special()) {
+        return false;
+      }
+
+      // Otherwise, if state override is given, host_view is the empty string,
+      // and either url includes credentials or url's port is non-null, then
+      // return failure.
+      if (host_view.empty() && (has_credentials() || has_port())) {
+        return false;
+      }
+
+      // Let host be the result of host parsing host_view with url is not
+      // special.
+      if (host_view.empty() && !is_special()) {
+        if (has_hostname()) {
+          clear_hostname();  // easy!
+        } else if (has_dash_dot()) {
+          add_authority_slashes_if_needed();
+          delete_dash_dot();
+        }
+        return true;
+      }
+
+      bool succeeded = parse_host(host_view);
+      if (!succeeded) {
+        update_base_hostname(previous_host);
+        update_base_port(previous_port);
+        return false;
       } else if (has_dash_dot()) {
-        add_authority_slashes_if_needed();
+        // Should remove dash_dot from pathname
         delete_dash_dot();
       }
       return true;
     }
-
-    bool succeeded = parse_host(host_view);
-    if (!succeeded) {
-      update_base_hostname(previous_host);
-      update_base_port(previous_port);
-    } else if (has_dash_dot()) {
-      // Should remove dash_dot from pathname
-      delete_dash_dot();
-    }
-    return succeeded;
   }
 
   size_t location = new_host.find_first_of("/\\?");

--- a/tests/wpt/ada_extra_setters_tests.json
+++ b/tests/wpt/ada_extra_setters_tests.json
@@ -144,5 +144,16 @@
         "pathname": "space   %20"
       }
     }
+  ],
+  "host": [
+    {
+      "href": "foo://path/to",
+      "new_value": ":80",
+      "expected": {
+        "href": "foo://path/to",
+        "host": "path",
+        "port": ""
+      }
+    }
   ]
 }


### PR DESCRIPTION
The current implementation incorrectly allows values like ":80" (empty host with port), resulting in `foo://:80/to`, while the spec requires failure if the host is missing. This update aligns behavior with the spec.

```js
const NodeURL = require("url").URL;
const WhatwgURL = require("whatwg-url").URL;
const newHost = ':80';

const url = new NodeURL("foo://path/to");  
url.host = newHost;
console.log(url.href); // Wrong: foo://:80/to

const url2 = new WhatwgURL("foo://path/to");
url2.host = newHost;
console.log(url2.href); // Correct: foo://path/to
```

Refs: https://url.spec.whatwg.org/#host-state
> If buffer is the empty string, host-missing validation error, return failure.

WPT tests for this case will be added in a follow-up PR.