### PR TITLE
Add the Nim wrapper to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The following libraries are maintained by the Ada team and available under [Ada 
 - [Python](https://github.com/TkTech/can_ada): Python bindings for Ada
 - [React Native](https://github.com/KusStar/react-native-fast-url): A Fast URL and URLSearchParams polyfill for React Native.
 - [D](https://github.com/kassane/ada-d): D bindings for Ada, `@nogc`, `nothrow` and `@safe` compat.
+- [Nim](https://github.com/ferus-web/nim-ada): High-level Nim abstraction over Ada, uses ORC move semantics to safely and efficiently handle memory.
 
 ## Usage
 


### PR DESCRIPTION
The title says it all. This MR adds the [Nim wrapper](https://github.com/ferus-web/nim-ada) to the README.
