### PR TITLE
fix(test): remove nonexistent url_pattern::to_string() call

### DIFF
--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -462,7 +462,15 @@ TEST(wpt_urlpattern_tests, urlpattern_test_data) {
         FAIL() << "Test should have succeeded but failed" << std::endl
                << main_object.raw_json().value() << std::endl;
       }
-      ada_log("parse_result: ", parse_result->to_string());
+      ada_log("parse_result:");
+      ada_log("  protocol: '", parse_result->get_protocol(), "'");
+      ada_log("  username: '", parse_result->get_username(), "'");
+      ada_log("  password: '", parse_result->get_password(), "'");
+      ada_log("  hostname: '", parse_result->get_hostname(), "'");
+      ada_log("  port: '", parse_result->get_port(), "'");
+      ada_log("  pathname: '", parse_result->get_pathname(), "'");
+      ada_log("  search: '", parse_result->get_search(), "'");
+      ada_log("  hash: '", parse_result->get_hash(), "'");
       ondemand::array exactly_empty_components;
       if (!main_object["exactly_empty_components"].get_array().get(
               exactly_empty_components)) {


### PR DESCRIPTION
This PR fixes a test error with `ada_log` caused by calling a nonexistent `to_string` method on url_pattern. According to the WHATWG specification, `url_pattern` does not provide a `to_string` method. Instead of implementing a `to_string` method, I changed the logging output.

Steps to reproduce:
```sh
cmake -B build -DADA_TESTING=ON
cmake --build build 
ADA_LOGGING=1 ctest --output-on-failure --test-dir build
```

Outputs:
```sh
parse_result:
  protocol: 'https'
  username: 'user'
  password: 'pass'
  hostname: 'example.com'
  port: '8080'
  pathname: '/path'
  search: '?query'
  hash: '#fragment'
```

Refs:
+ https://github.com/ada-url/ada/blob/main/include/ada/url_pattern_init.h