### PR TITLE
fix(logging): add missing process_type ostream operator<<

### DIFF
--- a/include/ada/url_pattern_init.h
+++ b/include/ada/url_pattern_init.h
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <string>
 #include <optional>
+#include <iostream>
 
 #if ADA_TESTING
 #include <iostream>
@@ -39,6 +40,17 @@ struct url_pattern_init {
     url,
     pattern,
   };
+
+  friend std::ostream& operator<<(std::ostream& os, process_type type) {
+    switch (type) {
+      case process_type::url:
+        return os << "url";
+      case process_type::pattern:
+        return os << "pattern";
+      default:
+        return os << "unknown";
+    }
+  }
 
   // All strings must be valid UTF-8.
   // @see https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit


### PR DESCRIPTION
This PR adds a required operator`<<` overload for the `process_type` enum, which is necessary for logging with ada_log. If there is a more appropriate or recommended way to handle this, please let me know!

Steps to reproduce:
```sh
cmake -B build -DADA_TESTING=ON
cmake --build build 
ADA_LOGGING=1 ctest --output-on-failure --test-dir build
```