### PR TITLE
Add missing includes of <iterator> header

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -4,6 +4,7 @@
 
 #include <numeric>
 #include <algorithm>
+#include <iterator>
 #include <ranges>
 #include <string>
 #include <string_view>

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -8,6 +8,7 @@
 #include "ada/url_aggregator.h"
 #include "ada/url_aggregator-inl.h"
 
+#include <iterator>
 #include <ranges>
 #include <string>
 #include <string_view>

--- a/src/url_components.cpp
+++ b/src/url_components.cpp
@@ -1,6 +1,7 @@
 #include "ada/helpers.h"
 #include "ada/url_components-inl.h"
 
+#include <iterator>
 #include <string>
 
 namespace ada {


### PR DESCRIPTION
The `std::back_insert_iterator` function is defined in the `<iterator>` header, so it should be included in files which use that function.