### PR TITLE
suppress `clang-tidy` warnings re: Annex K functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
   -bugprone-suspicious-include,
   -bugprone-unhandled-exception-at-new,
   clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: '*'


### PR DESCRIPTION
Quick follow-up to https://github.com/ada-url/ada/pull/981

Suppress clang-tidy's `clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling` check, which produces false positives for functions like `fprintf()`. Further, this check recommends adoption of C11 Annex K functions that are unavailable under many libc's (including glibc) and controversial amongst experts.

Apologies for not including this as part of https://github.com/ada-url/ada/pull/981. I only realized after merging that although this check does not currently generate false positives on the ada codebase, it would be confusing for contributors to have future PRs blocked because of innocent/innocuous use of functions like `fprintf()` and `memset()`.

For additional background:

- https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1969.htm
- https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2336.pdf
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88700
- https://gcc.gnu.org/pipermail/gcc/2019-December/231070.html
- https://github.com/llvm/llvm-project/issues/64027