### PR TITLE
add RVV support

### DIFF
--- a/.github/workflows/ubuntu-riscv64-rvv.yml
+++ b/.github/workflows/ubuntu-riscv64-rvv.yml
@@ -1,0 +1,50 @@
+name: Ubuntu RISC-V Vector Extension
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ubuntu-build:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup ENV
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y cmake curl ninja-build \
+                                  g++-riscv64-linux-gnu \
+                                  gcc-riscv64-linux-gnu \
+                                  qemu-user-static  qemu-user
+      - name: Build
+        run: |
+          export QEMU_LD_PREFIX="/usr/riscv64-linux-gnu"
+          export QEMU_CPU="rv64,vlen=128"
+          cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains-dev/riscv64-rvv.cmake \
+                -DADA_TESTING=ON \
+                -DADA_USE_SIMDUTF=ON \
+                -DCMAKE_BUILD_TYPE=Release \
+                -G Ninja -B build
+          cmake --build build -j=4
+      - name: Test
+        run: |
+          export QEMU_LD_PREFIX="/usr/riscv64-linux-gnu"
+          export QEMU_CPU="rv64,v=on,vlen=128"
+          ctest --output-on-failure --test-dir build

--- a/cmake/toolchains-dev/README.md
+++ b/cmake/toolchains-dev/README.md
@@ -27,3 +27,22 @@ $ ctest --output-on-failure --test-dir build
 or
 $ qemu-loongarch64 build/singleheader/cdemo
 ```
+
+# RISC-V Vector Extension
+
+The RISC-V Vector optimizations are supported by GCC-13, CLANG-16 and above.
+
+Native builds will use the RVV code, if the specified `-march` ISA string or default target ISA supports the V extension.
+
+For cross compilation, you may need to adjust the cross compiler target prefix in the toolchain file from `riscv64-linux-gnu` to e.g. `riscv64-unknown-linux-gnu` when using https://github.com/riscv-collab/riscv-gnu-toolchain.
+
+```
+# For Debian/Ubuntu
+$ sudo apt install g++-riscv64-linux-gnu qemu-system-riscv qemu-user
+$ mkdir build; cd build
+$ export QEMU_LD_PREFIX="/usr/riscv64-linux-gnu"
+$ export QEMU_CPU="rv64,v=on"
+$ mkdir build && cd build
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains-dev/riscv64-rvv.cmake -DADA_TESTING=ON ..
+$ cmake --build -j $(nproc)
+```

--- a/cmake/toolchains-dev/riscv64-rvv.cmake
+++ b/cmake/toolchains-dev/riscv64-rvv.cmake
@@ -1,0 +1,19 @@
+# Usage:
+# $ cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains-dev/riscv64-rvv.cmake
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(target       riscv64-linux-gnu)
+set(c_compiler   gcc)
+set(cxx_compiler g++)
+
+set(CMAKE_C_COMPILER   "${target}-${c_compiler}")
+set(CMAKE_CXX_COMPILER "${target}-${cxx_compiler}")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_CROSSCOMPILING_EMULATOR "qemu-riscv64")
+
+set(CMAKE_CXX_FLAGS "-march=rv64gcv")

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -247,6 +247,10 @@ namespace ada {
 #define ADA_LSX 1
 #endif
 
+#if defined(__riscv_v) && __riscv_v_intrinsic >= 11000
+#define ADA_RVV 1
+#endif
+
 #ifndef __has_cpp_attribute
 #define ada_lifetime_bound
 #elif __has_cpp_attribute(msvc::lifetimebound)

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -248,6 +248,7 @@ namespace ada {
 #endif
 
 #if defined(__riscv_v) && __riscv_v_intrinsic >= 11000
+// Support RVV intrinsics v0.11 and above
 #define ADA_RVV 1
 #endif
 


### PR DESCRIPTION
This adds support for the RISC-V vector extension.

One the SpacemiT X60, I get speedups of 1.12x, 1.15x and 1.24x, for AdaURL_href, AdaURL_aggregator_href and AdaURL_CanParse respectively. This is in-line with, even above, the relative speedup from the SSE code paths when toggled on Zen1 (1.04x, 1.01x and 1.11x).

I decided to use LMUL=1 because URLs usually are on the smaller side.
There is a `#if`ed out codepath that implements `find_next_host_delimiter_special()` with a LUT, which was slower than the regular implementation on the X60, but I could see if being faster on future OoO hardware.

I didn't add runtime ISA detection yet, because I expect toolchains to move the default to RVA23 in the future. That would probably be better in a seperate PR anyways, as ada currently doesn't have the infrastructure for runtime dispatch.