### PR TITLE
add avx512 SIMD support for newer cpus

### DIFF
--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -233,6 +233,10 @@ namespace ada {
   } while (0)
 #endif
 
+#if defined(__AVX512BW__)
+#define ADA_AVX512 1
+#endif
+
 #if defined(__SSE2__) || defined(__x86_64__) || defined(__x86_64) || \
     (defined(_M_AMD64) || defined(_M_X64) ||                         \
      (defined(_M_IX86_FP) && _M_IX86_FP == 2))


### PR DESCRIPTION
I've always wanted to learn AVX512, so what better time to do it then now... I've just learned that my CPU supports it.

@lemire appreciate if you have a supported machine, can you could run the benchmarks with and without these? just to make sure we don't regress. prior to this change we were using SSE2 for those machines. I assume we'll get a nice speed bump, but you never know...

I'll open another PR for SSE4 support.


---

My results show that AVX512 is slower than SSE2, probably due to the size of the URLs..

```
  Detailed Results

  | Benchmark                         | SSE2 (ns) | AVX512 (ns) | Difference    |
  |-----------------------------------|-----------|-------------|---------------|
  | BasicBench_AdaURL_href            | 2,607     | 2,994       | +14.8% slower |
  | BasicBench_AdaURL_aggregator_href | 1,735     | 1,907       | +9.9% slower  |
  | BasicBench_AdaURL_CanParse        | 1,307     | 1,396       | +6.8% slower  |
```