### PR TITLE
add SSSE3 SIMD instructions

### DIFF
--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -233,6 +233,10 @@ namespace ada {
   } while (0)
 #endif
 
+#if defined(__SSSE3__)
+#define ADA_SSSE3 1
+#endif
+
 #if defined(__SSE2__) || defined(__x86_64__) || defined(__x86_64) || \
     (defined(_M_AMD64) || defined(_M_X64) ||                         \
      (defined(_M_IX86_FP) && _M_IX86_FP == 2))


### PR DESCRIPTION
It seems SSSE3 gives us a 5% performance boost.


  1. BasicBench_AdaURL_href (Full URL parsing with href getter)

  | Metric               | SSE2 Baseline (median) | SSSE3 Optimized (median) | Improvement |
  |----------------------|------------------------|--------------------------|-------------|
  | Time per URL         | 249.276 ns             | 237.648 ns               | 4.7% faster |
  | Throughput           | 327.212 M/s            | 354.032 M/s              | 8.2% higher |
  | URLs per second      | 3.767M                 | 4.076M                   | 8.2% more   |
  | Time per byte        | 3.056 ns               | 2.825 ns                 | 7.6% faster |
  | Cycles per URL       | 974.434                | 964.386                  | 1.0% fewer  |
  | Instructions per URL | 3.218k                 | 3.190k                   | 0.9% fewer  |

  2. BasicBench_AdaURL_aggregator_href (Aggregator parsing)

  | Metric               | SSE2 Baseline (median) | SSSE3 Optimized (median) | Improvement |
  |----------------------|------------------------|--------------------------|-------------|
  | Time per URL         | 155.386 ns             | 150.837 ns               | 2.9% faster |
  | Throughput           | 517.071 M/s            | 526.278 M/s              | 1.8% higher |
  | URLs per second      | 5.953M                 | 6.059M                   | 1.8% more   |
  | Time per byte        | 1.934 ns               | 1.900 ns                 | 1.8% faster |
  | Cycles per URL       | 619.107                | 603.857                  | 2.5% fewer  |
  | Instructions per URL | 2.209k                 | 2.178k                   | 1.4% fewer  |
