### PR TITLE
[url_patter] Avoid parsing the port

### DIFF
--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -341,7 +341,7 @@ tl::expected<std::string, errors> canonicalize_port(
   } else if (digits_to_parse.size() > 5) {
     return tl::unexpected(errors::type_error);
   }
-  if(digits_to_parse[0] == '0' && digits_to_parse.size() > 1) {
+  if (digits_to_parse[0] == '0' && digits_to_parse.size() > 1) {
     // Leading zeros are not allowed for multi-digit ports
     return tl::unexpected(errors::type_error);
   }


### PR DESCRIPTION
In this function, we parse the 16-bit port, only to convert it back to a string. That looks inefficient.

If we don't need the port number, we can be faster.

I asked grok to verify my code, here was the answer:

https://x.com/lemire/status/1999223408605774179?s=20