### PR TITLE
oss-fuzz: Add unit test build to oss-fuzz build script

### DIFF
--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -69,3 +69,9 @@ $CXX $CFLAGS $CXXFLAGS $LIB_FUZZING_ENGINE ./ada.o ada_c.o \
      -o $OUT/ada_c
 
 cp $SRC/ada-url/fuzz/*.dict $SRC/ada-url/fuzz/*.options $OUT/
+
+# Build unit test
+mkdir build-tests
+cd build-tests
+cmake -DADA_TESTING=True ..
+make


### PR DESCRIPTION
OSS-Fuzz has a new Chronos feature that allows fast rebuilding of OSS-Fuzz-integrated projects and checks whether the project code or fuzzers still pass their unit tests after patching. To enable this feature, the unit tests of integrated projects need to be built. Therefore, this PR modifies the build script used by OSS-Fuzz to also build the unit tests for this project. The OSS-Fuzz-side changes for this project's integration can be found here: https://github.com/google/oss-fuzz/pull/14563.