### PR TITLE
url_pattern: append std::nullopt when there is no match

### DIFF
--- a/include/ada/url_pattern-inl.h
+++ b/include/ada/url_pattern-inl.h
@@ -42,9 +42,8 @@ url_pattern_component<regex_provider>::create_component_match_result(
   // We explicitly start iterating from 0 even though the spec
   // says we should start from 1. This case is handled by the
   // std_regex_provider which removes the full match from index 0.
-  // Use min() to guard against potential mismatches between
-  // exec_result size and group_name_list size.
-  const size_t size = std::min(exec_result.size(), group_name_list.size());
+  ADA_ASSERT_EQUAL(exec_result.size(), group_name_list.size(), "exec_result and group_name_list size mismatch");
+  const size_t size = exec_result.size();
   result.groups.reserve(size);
   for (size_t index = 0; index < size; index++) {
     result.groups.emplace(group_name_list[index],

--- a/src/url_pattern_regex.cpp
+++ b/src/url_pattern_regex.cpp
@@ -38,8 +38,11 @@ std_regex_provider::regex_search(std::string_view input,
   }
   matches.reserve(match_result.size());
   for (size_t i = 1; i < match_result.size(); ++i) {
-    if (auto entry = match_result[i]; entry.matched) {
+    auto entry = match_result[i];
+    if (entry.matched) {
       matches.emplace_back(entry.str());
+    } else {
+      matches.emplace_back(std::nullopt);
     }
   }
   return matches;


### PR DESCRIPTION
PR https://github.com/ada-url/ada/pull/1079 was merged as a fix for a potential OOB. I cannot reproduce an OOB. 

However, I can reproduce a case where we fail to fill the answer vector (and thus 'overallocate'). It looks to me like there is a logical mistake in the code, where unmatched components are *not* appended.