### PR TITLE
port validation and fix ignored set_port failures

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -735,8 +735,10 @@ bool url::set_host_or_hostname(const std::string_view input) {
       // Set url's host to host, buffer to the empty string, and state to port
       // state.
       std::string_view port_buffer = new_host.substr(location + 1);
-      if (!port_buffer.empty()) {
-        set_port(port_buffer);
+      if (!set_port(port_buffer)) {
+        host = std::move(previous_host);
+        update_base_port(previous_port);
+        return false;
       }
       return true;
     }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -599,8 +599,10 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
       // Set url's host to host, buffer to the empty string, and state to port
       // state.
       std::string_view port_buffer = new_host.substr(location + 1);
-      if (!port_buffer.empty()) {
-        set_port(port_buffer);
+      if (!set_port(port_buffer)) {
+        update_base_hostname(previous_host);
+        update_base_port(previous_port);
+        return false;
       }
       return true;
     }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -76,6 +76,28 @@ TYPED_TEST(basic_tests, set_host_should_return_true_sometimes) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, set_host_rejects_invalid_embedded_port) {
+  auto url = ada::parse<TypeParam>("https://example.com:1234/path");
+  ASSERT_TRUE(url);
+  const std::string previous_href(url->get_href());
+
+  ASSERT_FALSE(url->set_host("safe-host:+"));
+  ASSERT_EQ(url->get_href(), previous_href);
+  ASSERT_EQ(url->get_host(), "example.com:1234");
+  SUCCEED();
+}
+
+TYPED_TEST(basic_tests, set_host_with_empty_embedded_port_clears_port) {
+  auto url = ada::parse<TypeParam>("https://example.com:1234/path");
+  ASSERT_TRUE(url);
+
+  ASSERT_TRUE(url->set_host("safe-host:"));
+  ASSERT_EQ(url->get_host(), "safe-host");
+  ASSERT_EQ(url->get_port(), "");
+  ASSERT_EQ(url->get_href(), "https://safe-host/path");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, set_hostname_should_return_false_sometimes) {
   auto r = ada::parse<TypeParam>("mailto:a@b.com");
   ASSERT_FALSE(r->set_hostname("something"));


### PR DESCRIPTION
This patch fixes an internal validation in set_host_or_hostname where embedded port parsing results were ignored allowing invalid or inconsistent URL state.

Host updates containing embedded ports `host:port` are now always validated through set_port including when the port component is empty.

The return value of set_port is now enforced:
  - On failure, the operation is rolled back
  - set_host/set_host_or_hostname returns false
  - Host and port updates are now atomic 