### PR TITLE
Fix URLPattern tokenizer to prevent DoS on malformed UTF-8

### DIFF
--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -350,8 +350,10 @@ constexpr void Tokenizer::get_next_code_point() {
   ada_log("Tokenizer::get_next_code_point called with index=", next_index);
   ADA_ASSERT_TRUE(next_index < input.size());
   // this assumes that we have a valid, non-truncated UTF-8 stream.
+  invalid_code_point = false;
   code_point = 0;
   size_t number_bytes = 0;
+  const size_t initial_index = next_index;
   unsigned char first_byte = input[next_index];
 
   if ((first_byte & 0x80) == 0) {
@@ -379,10 +381,31 @@ constexpr void Tokenizer::get_next_code_point() {
     number_bytes = 4;
     ada_log("Tokenizer::get_next_code_point four bytes");
   }
-  ADA_ASSERT_TRUE(number_bytes + next_index <= input.size());
+
+  // Invalid leading byte (e.g., continuation byte outside a sequence).
+  if (number_bytes == 0) {
+    invalid_code_point = true;
+    code_point = first_byte;
+    next_index = initial_index + 1;
+    return;
+  }
+
+  // Truncated UTF-8 sequence.
+  if (number_bytes + next_index > input.size()) {
+    invalid_code_point = true;
+    code_point = first_byte;
+    next_index = initial_index + 1;
+    return;
+  }
 
   for (size_t i = 1 + next_index; i < number_bytes + next_index; ++i) {
     unsigned char byte = input[i];
+    if ((byte & 0xC0) != 0x80) {
+      invalid_code_point = true;
+      code_point = first_byte;
+      next_index = initial_index + 1;
+      return;
+    }
     ada_log("Tokenizer::get_next_code_point read byte=", uint32_t(byte));
     code_point = (code_point << 6) | (byte & 0x3F);
   }

--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -349,7 +349,9 @@ constexpr bool constructor_string_parser<regex_provider>::is_port_prefix()
 constexpr void Tokenizer::get_next_code_point() {
   ada_log("Tokenizer::get_next_code_point called with index=", next_index);
   ADA_ASSERT_TRUE(next_index < input.size());
-  // this assumes that we have a valid, non-truncated UTF-8 stream.
+  // Decode the next UTF-8 code point. If malformed or truncated, mark it as
+  // invalid, return the offending byte as the code point, and advance by one
+  // to guarantee forward progress.
   invalid_code_point = false;
   code_point = 0;
   size_t number_bytes = 0;
@@ -380,6 +382,15 @@ constexpr void Tokenizer::get_next_code_point() {
     code_point = first_byte & 0x07;
     number_bytes = 4;
     ada_log("Tokenizer::get_next_code_point four bytes");
+  }
+
+  // Invalid leading bytes that still match a multi-byte prefix.
+  if ((number_bytes == 2 && first_byte < 0xC2) ||
+      (number_bytes == 4 && first_byte > 0xF4)) {
+    invalid_code_point = true;
+    code_point = first_byte;
+    next_index = initial_index + 1;
+    return;
   }
 
   // Invalid leading byte (e.g., continuation byte outside a sequence).

--- a/include/ada/url_pattern_helpers.h
+++ b/include/ada/url_pattern_helpers.h
@@ -112,6 +112,9 @@ class Tokenizer {
   // @see https://urlpattern.spec.whatwg.org/#get-the-next-code-point
   constexpr void get_next_code_point();
 
+  // True when the most recent decoded unit was malformed UTF-8.
+  bool had_invalid_code_point() const { return invalid_code_point; }
+
   // @see https://urlpattern.spec.whatwg.org/#seek-and-get-the-next-code-point
   constexpr void seek_and_get_next_code_point(size_t index);
 
@@ -148,6 +151,8 @@ class Tokenizer {
   size_t next_index = 0;
   // has an associated code point, a Unicode code point, initially null.
   char32_t code_point{};
+  // Tracks whether the last decoded code point was malformed UTF-8.
+  bool invalid_code_point = false;
 };
 
 // @see https://urlpattern.spec.whatwg.org/#constructor-string-parser

--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -596,6 +596,16 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
     // index.
     tokenizer.seek_and_get_next_code_point(tokenizer.index);
 
+    // Malformed UTF-8 must not stall tokenization: report an invalid-char
+    // token (lenient) or fail fast (strict), while always making progress.
+    if (tokenizer.had_invalid_code_point()) {
+      if (auto error = tokenizer.process_tokenizing_error(tokenizer.next_index,
+                                                          tokenizer.index)) {
+        return tl::unexpected(*error);
+      }
+      continue;
+    }
+
     // If tokenizer's code point is U+002A (*):
     if (tokenizer.code_point == '*') {
       // Run add a token with default position and length given tokenizer and

--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -644,6 +644,13 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
       auto escaped_index = tokenizer.next_index;
       // Run get the next code point given tokenizer.
       tokenizer.get_next_code_point();
+      if (tokenizer.had_invalid_code_point()) {
+        if (auto error = tokenizer.process_tokenizing_error(tokenizer.next_index,
+                                                            escaped_index)) {
+          return tl::unexpected(*error);
+        }
+        continue;
+      }
       // Run add a token with default length given tokenizer, "escaped-char",
       // tokenizer's next index, and escaped index.
       tokenizer.add_token_with_default_length(
@@ -678,11 +685,20 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
       auto name_position = tokenizer.next_index;
       // Let name start be name position.
       auto name_start = name_position;
+      bool invalid_name = false;
       // While name position is less than tokenizer's input's code point length:
       while (name_position < tokenizer.input.size()) {
         // Run seek and get the next code point given tokenizer and name
         // position.
         tokenizer.seek_and_get_next_code_point(name_position);
+        if (tokenizer.had_invalid_code_point()) {
+          if (auto error = tokenizer.process_tokenizing_error(
+                  tokenizer.next_index, name_position)) {
+            return tl::unexpected(*error);
+          }
+          invalid_name = true;
+          break;
+        }
         // Let first code point be true if name position equals name start and
         // false otherwise.
         bool first_code_point = name_position == name_start;
@@ -697,6 +713,10 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
         if (!valid_code_point) break;
         // Set name position to tokenizer's next index.
         name_position = tokenizer.next_index;
+      }
+
+      if (invalid_name) {
+        continue;
       }
 
       // If name position is less than or equal to name start:
@@ -736,6 +756,14 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
         // Run seek and get the next code point given tokenizer and regexp
         // position.
         tokenizer.seek_and_get_next_code_point(regexp_position);
+        if (tokenizer.had_invalid_code_point()) {
+          if (auto process_error = tokenizer.process_tokenizing_error(
+                  tokenizer.next_index, regexp_position)) {
+            return tl::unexpected(*process_error);
+          }
+          error = true;
+          break;
+        }
 
         // TODO: Optimization opportunity: The next 2 if statements can be
         // merged. If the result of running is ASCII given tokenizer's code
@@ -781,7 +809,16 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
             break;
           }
           // Run get the next code point given tokenizer.
+          auto escaped_index = tokenizer.next_index;
           tokenizer.get_next_code_point();
+          if (tokenizer.had_invalid_code_point()) {
+            if (auto process_error = tokenizer.process_tokenizing_error(
+                    tokenizer.next_index, escaped_index)) {
+              return tl::unexpected(*process_error);
+            }
+            error = true;
+            break;
+          }
           // If the result of running is ASCII given tokenizer's code point is
           // false:
           if (!unicode::is_ascii(tokenizer.code_point)) {
@@ -833,6 +870,14 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
           auto temporary_position = tokenizer.next_index;
           // Run get the next code point given tokenizer.
           tokenizer.get_next_code_point();
+          if (tokenizer.had_invalid_code_point()) {
+            if (auto process_error = tokenizer.process_tokenizing_error(
+                    tokenizer.next_index, temporary_position)) {
+              return tl::unexpected(*process_error);
+            }
+            error = true;
+            break;
+          }
           // If tokenizer's code point is not U+003F (?):
           if (tokenizer.code_point != '?') {
             // Run process a tokenizing error given tokenizer, regexp start, and

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -9,6 +9,7 @@
 
 #include "ada.h"
 #include "ada/url_pattern.h"
+#include "ada/url_pattern_helpers.h"
 #include "ada/parser.h"
 
 using namespace simdjson;
@@ -308,6 +309,64 @@ TEST(wpt_urlpattern_tests, parser_tokenize_basic_tests) {
   auto tokenize_result =
       tokenize("*", ada::url_pattern_helpers::token_policy::strict);
   ASSERT_TRUE(tokenize_result);
+}
+
+TEST(wpt_urlpattern_tests, parser_tokenize_malformed_utf8_progress) {
+  std::string malformed("\x80*", 2);
+
+  auto strict_result = ada::url_pattern_helpers::tokenize(
+      malformed, ada::url_pattern_helpers::token_policy::strict);
+  ASSERT_FALSE(strict_result);
+  ASSERT_EQ(strict_result.error(), ada::errors::type_error);
+
+  auto lenient_result = ada::url_pattern_helpers::tokenize(
+      malformed, ada::url_pattern_helpers::token_policy::lenient);
+  ASSERT_TRUE(lenient_result);
+  ASSERT_GE(lenient_result->size(), 3u);
+  EXPECT_EQ((*lenient_result)[0].type,
+            ada::url_pattern_helpers::token_type::INVALID_CHAR);
+  EXPECT_EQ((*lenient_result)[0].value.size(), 1u);
+  EXPECT_EQ((*lenient_result)[1].type,
+            ada::url_pattern_helpers::token_type::ASTERISK);
+  EXPECT_EQ(lenient_result->back().type,
+            ada::url_pattern_helpers::token_type::END);
+}
+
+TEST(wpt_urlpattern_tests, tokenizer_advances_after_invalid_utf8_byte) {
+  using ada::url_pattern_helpers::Tokenizer;
+  using ada::url_pattern_helpers::token_policy;
+
+  // First byte is an invalid leading UTF-8 byte. The second byte is ASCII '*'.
+  // On the old implementation, the decoder could keep re-reading byte 0.
+  std::string malformed("\x80*", 2);
+  Tokenizer tokenizer(malformed, token_policy::lenient);
+
+  tokenizer.seek_and_get_next_code_point(0);
+  ASSERT_TRUE(tokenizer.had_invalid_code_point());
+
+  // This second decode only succeeds if the first call made forward progress.
+  tokenizer.get_next_code_point();
+  ASSERT_FALSE(tokenizer.had_invalid_code_point());
+}
+
+TEST(wpt_urlpattern_tests, malformed_utf8_large_payload_no_nonprogress) {
+  using ada::url_pattern_helpers::token_type;
+
+  // Attacker-controlled malformed bytes: each byte must consume one step.
+  constexpr size_t payload_size = 100000;
+  std::string payload(payload_size, '\x80');
+
+  auto result = ada::url_pattern_helpers::tokenize(
+      payload, ada::url_pattern_helpers::token_policy::lenient);
+  ASSERT_TRUE(result);
+
+  // One INVALID_CHAR token per byte, plus one END token.
+  ASSERT_EQ(result->size(), payload_size + 1);
+  EXPECT_EQ((*result)[0].type, token_type::INVALID_CHAR);
+  EXPECT_EQ((*result)[payload_size - 1].type, token_type::INVALID_CHAR);
+  EXPECT_EQ((*result)[payload_size - 1].index, payload_size - 1);
+  EXPECT_EQ((*result)[payload_size - 1].value.size(), 1u);
+  EXPECT_EQ(result->back().type, token_type::END);
 }
 
 TEST(wpt_urlpattern_tests, parse_pattern_string_basic_tests) {

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -333,8 +333,8 @@ TEST(wpt_urlpattern_tests, parser_tokenize_malformed_utf8_progress) {
 }
 
 TEST(wpt_urlpattern_tests, tokenizer_advances_after_invalid_utf8_byte) {
-  using ada::url_pattern_helpers::Tokenizer;
   using ada::url_pattern_helpers::token_policy;
+  using ada::url_pattern_helpers::Tokenizer;
 
   // First byte is an invalid leading UTF-8 byte. The second byte is ASCII '*'.
   // On the old implementation, the decoder could keep re-reading byte 0.

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -360,13 +360,16 @@ TEST(wpt_urlpattern_tests, malformed_utf8_large_payload_no_nonprogress) {
       payload, ada::url_pattern_helpers::token_policy::lenient);
   ASSERT_TRUE(result);
 
-  // One INVALID_CHAR token per byte, plus one END token.
-  ASSERT_EQ(result->size(), payload_size + 1);
-  EXPECT_EQ((*result)[0].type, token_type::INVALID_CHAR);
-  EXPECT_EQ((*result)[payload_size - 1].type, token_type::INVALID_CHAR);
-  EXPECT_EQ((*result)[payload_size - 1].index, payload_size - 1);
-  EXPECT_EQ((*result)[payload_size - 1].value.size(), 1u);
+  // Tokenization must make progress and cover the whole payload.
+  size_t invalid_bytes = 0;
+  ASSERT_GE(result->size(), 2u);
+  for (size_t i = 0; i + 1 < result->size(); ++i) {
+    EXPECT_EQ((*result)[i].type, token_type::INVALID_CHAR);
+    invalid_bytes += (*result)[i].value.size();
+  }
+  EXPECT_EQ(invalid_bytes, payload_size);
   EXPECT_EQ(result->back().type, token_type::END);
+  EXPECT_EQ(result->back().index, payload_size);
 }
 
 TEST(wpt_urlpattern_tests, parse_pattern_string_basic_tests) {


### PR DESCRIPTION
This fixes a security bug in URLPattern tokenization where malformed UTF-8 could leave the tokenizer cursor unchanged

Hardened UTF-8 decode logic to guarantee forward progress on malformed input by consuming at least one byte.

Added explicit malformed-sequence handling for:
 - invalid leading bytes
 - truncated multibyte sequences
 - invalid continuation bytes


Integrated malformed decode state into tokenizer loop error handling:
 - strict policy returns type error
 - lenient policy emits invalid-char token and continues with progress