### PR TITLE
Enforce max input length to the Ada URL parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ url->set_hash("is-this-the-real-life"); // Update hash/fragment
 
 By default, ada allows URLs up to about 4 GB. You can set a lower limit to
 reject any URL whose serialized form (the href) would exceed a given number
-of bytes. The limit is enforced during parsing and across all setters. If
-a setter would cause the URL to exceed the limit, the call fails and the URL
-is left unchanged. Percent-encoding expansion is accounted for: a short input
-that encodes into a long result is still rejected.
+of bytes. The limit is enforced during parsing and across all setters.
+Setters that return `bool` return `false` when the limit would be exceeded;
+`void` setters (`set_search`, `set_hash`) silently leave the URL unchanged.
+In all cases the URL is never modified when a limit violation is detected.
+Percent-encoding expansion is accounted for: a short input that encodes into
+a long result is still rejected.
 
-```c++
-#include "ada.h"
-
+```cpp
 // Set a 2 KB limit (any uint32_t value works).
 ada::set_max_input_length(2048);
 
@@ -208,7 +208,7 @@ assert(!ok);  // pathname too long; URL unchanged
 uint32_t limit = ada::get_max_input_length();
 
 // Reset to the default (no practical limit).
-ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+ada::set_max_input_length(UINT32_MAX);
 ```
 
 You can query the byte length of a URL without allocating a string via `get_href_size()`:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,47 @@ url->set_hash("is-this-the-real-life"); // Update hash/fragment
 // url->get_hash() will return "#is-this-the-real-life"
 ```
 
+### URL Size Limit
+
+By default, ada allows URLs up to about 4 GB. You can set a lower limit to
+reject any URL whose serialized form (the href) would exceed a given number
+of bytes. The limit is enforced during parsing and across all setters. If
+a setter would cause the URL to exceed the limit, the call fails and the URL
+is left unchanged. Percent-encoding expansion is accounted for: a short input
+that encodes into a long result is still rejected.
+
+```c++
+#include "ada.h"
+
+// Set a 2 KB limit (any uint32_t value works).
+ada::set_max_input_length(2048);
+
+// Parsing a URL whose normalized form exceeds 2 KB fails.
+auto url = ada::parse("http://example.com/" + std::string(2048, 'a'));
+assert(!url);  // too long
+
+// Setters that would push the URL over the limit are rejected.
+auto u = ada::parse<ada::url_aggregator>("http://example.com/");
+assert(u);
+bool ok = u->set_pathname(std::string(2048, 'x'));
+assert(!ok);  // pathname too long; URL unchanged
+
+// Read the current limit.
+uint32_t limit = ada::get_max_input_length();
+
+// Reset to the default (no practical limit).
+ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+```
+
+You can query the byte length of a URL without allocating a string via `get_href_size()`:
+
+```c++
+auto url = ada::parse<ada::url_aggregator>("https://example.com/path");
+assert(url);
+size_t len = url->get_href_size();  // no allocation
+assert(len == url->get_href().size());
+```
+
 ### URL Search Params
 
 ```cpp

--- a/benchmarks/bench_ipv4.cpp
+++ b/benchmarks/bench_ipv4.cpp
@@ -139,7 +139,7 @@ void run_benchmark(benchmark::State& state,
     for (size_t i = 0; i < count; ++i) {
       auto result = ada::parse<ResultType>(urls[order[pos]]);
       if (result) {
-        success++;
+        success = success + 1;
       }
       benchmark::DoNotOptimize(result);
 
@@ -161,7 +161,7 @@ void run_benchmark(benchmark::State& state,
       for (size_t j = 0; j < count; ++j) {
         auto result = ada::parse<ResultType>(urls[order[pos]]);
         if (result) {
-          success++;
+          success = success + 1;
         }
         benchmark::DoNotOptimize(result);
         pos += stride;

--- a/fuzz/max_length.cc
+++ b/fuzz/max_length.cc
@@ -2,7 +2,9 @@
 
 #include <cassert>
 #include <cstdio>
+#include <limits>
 #include <string>
+#include <type_traits>
 
 #include "ada.cpp"
 #include "ada.h"

--- a/fuzz/max_length.cc
+++ b/fuzz/max_length.cc
@@ -14,8 +14,8 @@ static constexpr uint32_t kMaxLength = 512;
 template <class T>
 static void check_length(const T& url, const char* context) {
   if (url.get_href_size() > kMaxLength) {
-    printf("FAIL [%s]: href_size=%zu exceeds limit %u\n  href: ",
-           context, url.get_href_size(), kMaxLength);
+    printf("FAIL [%s]: href_size=%zu exceeds limit %u\n  href: ", context,
+           url.get_href_size(), kMaxLength);
     if constexpr (std::is_same_v<T, ada::url_aggregator>) {
       printf("%.*s\n", (int)url.get_href().size(), url.get_href().data());
     } else {

--- a/fuzz/max_length.cc
+++ b/fuzz/max_length.cc
@@ -1,0 +1,155 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+#include "ada.cpp"
+#include "ada.h"
+
+// Enforce a tight limit and verify that no operation can produce
+// a URL whose serialized form exceeds it.
+static constexpr uint32_t kMaxLength = 512;
+
+template <class T>
+static void check_length(const T& url, const char* context) {
+  if (url.get_href_size() > kMaxLength) {
+    printf("FAIL [%s]: href_size=%zu exceeds limit %u\n  href: ",
+           context, url.get_href_size(), kMaxLength);
+    if constexpr (std::is_same_v<T, ada::url_aggregator>) {
+      printf("%.*s\n", (int)url.get_href().size(), url.get_href().data());
+    } else {
+      printf("%s\n", url.get_href().c_str());
+    }
+    abort();
+  }
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  ada::set_max_input_length(kMaxLength);
+
+  FuzzedDataProvider fdp(data, size);
+
+  // Consume strings for initial parse and setter values.
+  std::string source = fdp.ConsumeRandomLengthString(1024);
+  std::string base_str = fdp.ConsumeRandomLengthString(256);
+
+  // --- Test 1: parse must not produce an href > kMaxLength ---
+  auto url = ada::parse<ada::url>(source);
+  auto agg = ada::parse<ada::url_aggregator>(source);
+
+  if (url) {
+    check_length(*url, "parse<url>");
+  }
+  if (agg) {
+    check_length(*agg, "parse<url_aggregator>");
+  }
+
+  // --- Test 2: parse with base ---
+  auto base_url = ada::parse<ada::url>(base_str);
+  auto base_agg = ada::parse<ada::url_aggregator>(base_str);
+
+  if (base_url) {
+    auto result = ada::parse<ada::url>(source, &*base_url);
+    if (result) {
+      check_length(*result, "parse<url>(source, base)");
+    }
+  }
+  if (base_agg) {
+    auto result = ada::parse<ada::url_aggregator>(source, &*base_agg);
+    if (result) {
+      check_length(*result, "parse<url_aggregator>(source, base)");
+    }
+  }
+
+  // --- Test 3: setters on a known-good URL ---
+  // Start from a short URL to maximise room for setter expansion.
+  auto setter_url = ada::parse<ada::url>("http://x/");
+  auto setter_agg = ada::parse<ada::url_aggregator>("http://x/");
+  if (!setter_url || !setter_agg) return 0;
+
+  // Apply a fuzz-driven sequence of setter calls.
+  int steps = fdp.ConsumeIntegralInRange(1, 16);
+  for (int i = 0; i < steps && fdp.remaining_bytes() > 0; ++i) {
+    std::string val = fdp.ConsumeRandomLengthString(512);
+    int which = fdp.ConsumeIntegralInRange(0, 9);
+    switch (which) {
+      case 0:
+        setter_url->set_protocol(val);
+        setter_agg->set_protocol(val);
+        break;
+      case 1:
+        setter_url->set_username(val);
+        setter_agg->set_username(val);
+        break;
+      case 2:
+        setter_url->set_password(val);
+        setter_agg->set_password(val);
+        break;
+      case 3:
+        setter_url->set_hostname(val);
+        setter_agg->set_hostname(val);
+        break;
+      case 4:
+        setter_url->set_host(val);
+        setter_agg->set_host(val);
+        break;
+      case 5:
+        setter_url->set_pathname(val);
+        setter_agg->set_pathname(val);
+        break;
+      case 6:
+        setter_url->set_search(val);
+        setter_agg->set_search(val);
+        break;
+      case 7:
+        setter_url->set_hash(val);
+        setter_agg->set_hash(val);
+        break;
+      case 8:
+        setter_url->set_port(val);
+        setter_agg->set_port(val);
+        break;
+      case 9:
+        setter_url->set_href(val);
+        setter_agg->set_href(val);
+        break;
+    }
+    check_length(*setter_url, "setter url");
+    check_length(*setter_agg, "setter url_aggregator");
+  }
+
+  // --- Test 4: aggressive percent-encoding expansion ---
+  // Characters like spaces, control chars, and braces expand 3x when
+  // percent-encoded. Try to overflow the limit via these characters.
+  {
+    auto pe_url = ada::parse<ada::url>("http://x/");
+    auto pe_agg = ada::parse<ada::url_aggregator>("http://x/");
+    if (pe_url && pe_agg) {
+      std::string expanding = fdp.ConsumeRandomLengthString(512);
+      pe_url->set_pathname(expanding);
+      pe_agg->set_pathname(expanding);
+      check_length(*pe_url, "percent-encode pathname url");
+      check_length(*pe_agg, "percent-encode pathname url_aggregator");
+
+      pe_url->set_username(expanding);
+      pe_agg->set_username(expanding);
+      check_length(*pe_url, "percent-encode username url");
+      check_length(*pe_agg, "percent-encode username url_aggregator");
+
+      pe_url->set_search(expanding);
+      pe_agg->set_search(expanding);
+      check_length(*pe_url, "percent-encode search url");
+      check_length(*pe_agg, "percent-encode search url_aggregator");
+
+      pe_url->set_hash(expanding);
+      pe_agg->set_hash(expanding);
+      check_length(*pe_url, "percent-encode hash url");
+      check_length(*pe_agg, "percent-encode hash url_aggregator");
+    }
+  }
+
+  // Reset to default so other tests/fuzzers are not affected.
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+  return 0;
+}

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -109,11 +109,10 @@ extern template ada::result<url_aggregator> parse<url_aggregator>(
  * object. Use this when you only need to validate URLs without needing
  * their parsed components.
  *
- * Inputs whose size exceeds `get_max_input_length()` are rejected. However,
- * because `can_parse` does not perform full normalization (percent-encoding,
- * IDNA, etc.), it cannot detect cases where a short input would normalize
- * into a URL that exceeds the limit. In such edge cases `can_parse` may
- * return `true` while `parse` returns an error.
+ * When `get_max_input_length()` is set to a value smaller than the default,
+ * `can_parse` may still return `true` for overlength inputs that are
+ * structurally valid, because the fast path skips the length check for
+ * performance. Use `parse()` when strict length enforcement is required.
  *
  * @param input The URL string to validate. Must be valid ASCII or UTF-8.
  * @param base_input Optional pointer to a base URL string for resolving

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -166,6 +166,25 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init>&& input,
  * @return A file:// URL string representing the given path.
  */
 std::string href_from_file(std::string_view path);
+
+/**
+ * Sets the maximum allowed length for URL inputs.
+ *
+ * Any URL string or setter input exceeding this length will be rejected.
+ * The value must fit in a uint32_t. The default is
+ * std::numeric_limits<uint32_t>::max() (approximately 4 GB).
+ *
+ * @param length The new maximum input length.
+ */
+void set_max_input_length(uint32_t length);
+
+/**
+ * Returns the current maximum allowed length for URL inputs.
+ *
+ * @return The current maximum input length.
+ */
+uint32_t get_max_input_length();
+
 }  // namespace ada
 
 #endif  // ADA_IMPLEMENTATION_H

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -65,6 +65,11 @@ using result = tl::expected<result_type, ada::errors>;
  *
  * @note The parser is fully compliant with the WHATWG URL Standard.
  *
+ * Parsing fails if the input or the resulting normalized URL exceeds
+ * `get_max_input_length()` bytes (default ~4 GB, configurable via
+ * `set_max_input_length()`). This accounts for percent-encoding expansion:
+ * a short input that normalizes into a long URL is still rejected.
+ *
  * @example
  * ```cpp
  * // Parse an absolute URL
@@ -103,6 +108,12 @@ extern template ada::result<url_aggregator> parse<url_aggregator>(
  * according to the WHATWG URL Standard without fully constructing a URL
  * object. Use this when you only need to validate URLs without needing
  * their parsed components.
+ *
+ * Inputs whose size exceeds `get_max_input_length()` are rejected. However,
+ * because `can_parse` does not perform full normalization (percent-encoding,
+ * IDNA, etc.), it cannot detect cases where a short input would normalize
+ * into a URL that exceeds the limit. In such edge cases `can_parse` may
+ * return `true` while `parse` returns an error.
  *
  * @param input The URL string to validate. Must be valid ASCII or UTF-8.
  * @param base_input Optional pointer to a base URL string for resolving
@@ -168,20 +179,21 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init>&& input,
 std::string href_from_file(std::string_view path);
 
 /**
- * Sets the maximum allowed length for URL inputs.
+ * Sets the maximum allowed length for URLs.
  *
- * Any URL string or setter input exceeding this length will be rejected.
- * The value must fit in a uint32_t. The default is
- * std::numeric_limits<uint32_t>::max() (approximately 4 GB).
+ * Both the raw input and the resulting normalized URL (the href) are checked
+ * against this limit. Parsing or setter calls that would produce a URL
+ * exceeding this length are rejected. The value must fit in a uint32_t.
+ * The default is std::numeric_limits<uint32_t>::max() (approximately 4 GB).
  *
- * @param length The new maximum input length.
+ * @param length The new maximum URL length in bytes.
  */
 void set_max_input_length(uint32_t length);
 
 /**
- * Returns the current maximum allowed length for URL inputs.
+ * Returns the current maximum allowed length for URLs.
  *
- * @return The current maximum input length.
+ * @return The current maximum URL length in bytes.
  */
 uint32_t get_max_input_length();
 

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -217,6 +217,48 @@ constexpr void url::copy_scheme(const ada::url& u) {
   return output;
 }
 
+[[nodiscard]] inline size_t url::get_href_size() const noexcept {
+  // Mirrors the logic of get_href() but only computes the total size.
+  size_t size = 0;
+  // Protocol: scheme + ":"
+  if (is_special()) {
+    size += ada::scheme::details::is_special_list[type].size() + 1;
+  } else {
+    size += non_special_scheme.size() + 1;
+  }
+  if (host.has_value()) {
+    size += 2;  // "//"
+    if (has_credentials()) {
+      size += username.size();
+      if (!password.empty()) {
+        size += 1 + password.size();  // ":" + password
+      }
+      size += 1;  // "@"
+    }
+    size += host.value().size();
+    if (port.has_value()) {
+      size += 1;  // ":"
+      // Count digits of port value without calling std::to_string.
+      uint16_t p = port.value();
+      size += (p >= 10000)  ? 5
+              : (p >= 1000) ? 4
+              : (p >= 100)  ? 3
+              : (p >= 10)   ? 2
+                            : 1;
+    }
+  } else if (!has_opaque_path && path.starts_with("//")) {
+    size += 2;  // "/."
+  }
+  size += path.size();
+  if (query.has_value()) {
+    size += 1 + query.value().size();  // "?" + query
+  }
+  if (hash.has_value()) {
+    size += 1 + hash.value().size();  // "#" + hash
+  }
+  return size;
+}
+
 ada_really_inline size_t url::parse_port(std::string_view view,
                                          bool check_trailing_content) noexcept {
   ada_log("parse_port('", view, "') ", view.size());

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -23,8 +23,7 @@ namespace ada {
   return port.has_value();
 }
 [[nodiscard]] inline bool url::cannot_have_credentials_or_port() const {
-  return !host.has_value() || host.value().empty() ||
-         type == ada::scheme::type::FILE;
+  return !host.has_value() || host->empty() || type == ada::scheme::type::FILE;
 }
 [[nodiscard]] inline bool url::has_empty_hostname() const noexcept {
   if (!host.has_value()) {
@@ -227,6 +226,7 @@ constexpr void url::copy_scheme(const ada::url& u) {
     size += non_special_scheme.size() + 1;
   }
   if (host.has_value()) {
+    size += host->size();
     size += 2;  // "//"
     if (has_credentials()) {
       size += username.size();
@@ -235,7 +235,6 @@ constexpr void url::copy_scheme(const ada::url& u) {
       }
       size += 1;  // "@"
     }
-    size += host.value().size();
     if (port.has_value()) {
       size += 1;  // ":"
       // Count digits of port value without calling std::to_string.
@@ -251,10 +250,10 @@ constexpr void url::copy_scheme(const ada::url& u) {
   }
   size += path.size();
   if (query.has_value()) {
-    size += 1 + query.value().size();  // "?" + query
+    size += 1 + query->size();  // "?" + query
   }
   if (hash.has_value()) {
-    size += 1 + hash.value().size();  // "#" + hash
+    size += 1 + hash->size();  // "#" + hash
   }
   return size;
 }

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -163,6 +163,12 @@ struct url : url_base {
   [[nodiscard]] ada_really_inline std::string get_href() const;
 
   /**
+   * Returns the byte length of the serialized URL without allocating a string.
+   * @return Size of the href in bytes.
+   */
+  [[nodiscard]] size_t get_href_size() const noexcept;
+
+  /**
    * Returns the URL's origin as a string (scheme + host + port for special
    * URLs).
    * @return A newly allocated string containing the serialized origin.

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -852,6 +852,10 @@ constexpr bool url_aggregator::has_port() const noexcept {
   return buffer;
 }
 
+[[nodiscard]] constexpr size_t url_aggregator::get_href_size() const noexcept {
+  return buffer.size();
+}
+
 ada_really_inline size_t
 url_aggregator::parse_port(std::string_view view, bool check_trailing_content) {
   ada_log("url_aggregator::parse_port('", view, "') ", view.size());

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -105,6 +105,12 @@ struct url_aggregator : url_base {
       ada_lifetime_bound;
 
   /**
+   * Returns the byte length of the serialized URL without allocating a string.
+   * @return Size of the href in bytes.
+   */
+  [[nodiscard]] constexpr size_t get_href_size() const noexcept;
+
+  /**
    * Returns the URL's username component.
    * Does not allocate memory. The returned view becomes invalid if this
    * url_aggregator is modified or destroyed.

--- a/include/ada_c.h
+++ b/include/ada_c.h
@@ -184,6 +184,10 @@ ada_string_pair ada_search_params_entries_iter_next(
 bool ada_search_params_entries_iter_has_next(
     ada_url_search_params_entries_iter result);
 
+// max URL length configuration
+void ada_set_max_input_length(uint32_t length);
+uint32_t ada_get_max_input_length(void);
+
 // Definitions for Ada's version number.
 typedef struct {
   int major;

--- a/src/ada_c.cpp
+++ b/src/ada_c.cpp
@@ -743,6 +743,14 @@ bool ada_search_params_entries_iter_has_next(
   return (*r)->has_next();
 }
 
+void ada_set_max_input_length(uint32_t length) noexcept {
+  ada::set_max_input_length(length);
+}
+
+uint32_t ada_get_max_input_length() noexcept {
+  return ada::get_max_input_length();
+}
+
 typedef struct {
   int major;
   int minor;

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -311,18 +311,6 @@ std::string href_from_file(std::string_view input) {
 }
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {
-  // Reject inputs that exceed the configurable maximum length.
-  // Note: can_parse() does not perform normalization (percent-encoding, IDNA),
-  // so it cannot detect cases where a short input normalizes into a long URL.
-  // In such edge cases can_parse() may return true while parse() fails.
-  if (input.size() > ada::get_max_input_length()) {
-    return false;
-  }
-  if (base_input != nullptr &&
-      base_input->size() > ada::get_max_input_length()) {
-    return false;
-  }
-
   // Fast path: handles the overwhelming majority of inputs -- absolute special
   // URLs with an ASCII domain, no credentials, and no base -- with a single
   // forward scan and zero allocations.
@@ -330,6 +318,20 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
     if (const auto r = try_can_parse_absolute_fast(input)) {
       return *r;
     }
+  }
+
+  // Reject inputs that exceed the configurable maximum length.
+  // This check is placed after the fast path so the common case (default 4 GB
+  // limit, absolute URLs) pays no overhead.
+  // Note: can_parse() does not perform normalization (percent-encoding, IDNA),
+  // so it cannot detect cases where a short input normalizes into a long URL.
+  // In such edge cases can_parse() may return true while parse() fails.
+  const uint32_t max_length = ada::get_max_input_length();
+  if (input.size() > max_length) {
+    return false;
+  }
+  if (base_input != nullptr && base_input->size() > max_length) {
+    return false;
   }
 
   // Fallback: run the parser in validation-only mode (store_values=false),

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,5 +1,7 @@
 #include "ada/implementation-inl.h"
 
+#include <atomic>
+#include <limits>
 #include <optional>
 #include <string_view>
 
@@ -13,6 +15,17 @@
 #include "ada/url_aggregator.h"
 
 namespace ada {
+
+static std::atomic<uint32_t> max_input_length_{
+    std::numeric_limits<uint32_t>::max()};
+
+void set_max_input_length(uint32_t length) {
+  max_input_length_.store(length, std::memory_order_relaxed);
+}
+
+uint32_t get_max_input_length() {
+  return max_input_length_.load(std::memory_order_relaxed);
+}
 
 namespace {
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -311,6 +311,18 @@ std::string href_from_file(std::string_view input) {
 }
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {
+  // Reject inputs that exceed the configurable maximum length.
+  // Note: can_parse() does not perform normalization (percent-encoding, IDNA),
+  // so it cannot detect cases where a short input normalizes into a long URL.
+  // In such edge cases can_parse() may return true while parse() fails.
+  if (input.size() > ada::get_max_input_length()) {
+    return false;
+  }
+  if (base_input != nullptr &&
+      base_input->size() > ada::get_max_input_length()) {
+    return false;
+  }
+
   // Fast path: handles the overwhelming majority of inputs -- absolute special
   // URLs with an ASCII domain, no credentials, and no base -- with a single
   // forward scan and zero allocations.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5,6 +5,7 @@
 
 #include "ada/character_sets-inl.h"
 #include "ada/common_defs.h"
+#include "ada/implementation.h"
 #include "ada/log.h"
 #include "ada/unicode.h"
 #include "ada/url.h"
@@ -35,9 +36,10 @@ result_type parse_url_impl(std::string_view user_input,
   state state = state::SCHEME_START;
   result_type url{};
 
-  // We refuse to parse URL strings that exceed 4GB. Such strings are almost
-  // surely the result of a bug or are otherwise a security concern.
-  if (user_input.size() > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
+  // We refuse to parse URL strings that exceed the maximum input length.
+  // By default, this is 4GB but can be configured via
+  // ada::set_max_input_length().
+  if (user_input.size() > ada::get_max_input_length()) [[unlikely]] {
     url.is_valid = false;
   }
   // Going forward, user_input.size() is in [0,
@@ -951,6 +953,22 @@ result_type parse_url_impl(std::string_view user_input,
   if constexpr (store_values) {
     if (fragment.has_value()) {
       url.update_unencoded_base_hash(*fragment);
+    }
+  }
+  // Check the resulting (normalized) URL size against the maximum input length.
+  // Normalization (percent-encoding, IDNA, etc.) can expand the URL beyond the
+  // original input size.
+  if constexpr (store_values) {
+    if (url.is_valid) {
+      if constexpr (result_type_is_ada_url_aggregator) {
+        if (url.buffer.size() > ada::get_max_input_length()) {
+          url.is_valid = false;
+        }
+      } else {
+        if (url.get_href_size() > ada::get_max_input_length()) {
+          url.is_valid = false;
+        }
+      }
     }
   }
   return url;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -36,10 +36,12 @@ result_type parse_url_impl(std::string_view user_input,
   state state = state::SCHEME_START;
   result_type url{};
 
+  const uint32_t max_input_length = ada::get_max_input_length();
+
   // We refuse to parse URL strings that exceed the maximum input length.
   // By default, this is 4GB but can be configured via
   // ada::set_max_input_length().
-  if (user_input.size() > ada::get_max_input_length()) [[unlikely]] {
+  if (user_input.size() > max_input_length) [[unlikely]] {
     url.is_valid = false;
   }
   // Going forward, user_input.size() is in [0,
@@ -961,11 +963,11 @@ result_type parse_url_impl(std::string_view user_input,
   if constexpr (store_values) {
     if (url.is_valid) {
       if constexpr (result_type_is_ada_url_aggregator) {
-        if (url.buffer.size() > ada::get_max_input_length()) {
+        if (url.buffer.size() > max_input_length) {
           url.is_valid = false;
         }
       } else {
-        if (url.get_href_size() > ada::get_max_input_length()) {
+        if (url.get_href_size() > max_input_length) {
           url.is_valid = false;
         }
       }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -356,7 +356,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
       // If url's scheme is "file" and its host is an empty host, then return.
       // An empty host is the empty string.
       if (type == ada::scheme::type::FILE && host.has_value() &&
-          host.value().empty()) {
+          host->empty()) {
         return false;
       }
     }
@@ -400,7 +400,7 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
       // If url's scheme is "file" and its host is an empty host, then return.
       // An empty host is the empty string.
       if (type == ada::scheme::type::FILE && host.has_value() &&
-          host.value().empty()) {
+          host->empty()) {
         return true;
       }
     }
@@ -662,8 +662,7 @@ ada_really_inline void url::parse_path(std::string_view input) {
 [[nodiscard]] std::string url::get_search() const {
   // If this's URL's query is either null or the empty string, then return the
   // empty string. Return U+003F (?), followed by this's URL's query.
-  return (!query.has_value() || (query.value().empty())) ? ""
-                                                         : "?" + query.value();
+  return (!query.has_value() || (query->empty())) ? "" : "?" + query.value();
 }
 
 [[nodiscard]] const std::string& url::get_username() const noexcept {
@@ -681,8 +680,7 @@ ada_really_inline void url::parse_path(std::string_view input) {
 [[nodiscard]] std::string url::get_hash() const {
   // If this's URL's fragment is either null or the empty string, then return
   // the empty string. Return U+0023 (#), followed by this's URL's fragment.
-  return (!hash.has_value() || (hash.value().empty())) ? ""
-                                                       : "#" + hash.value();
+  return (!hash.has_value() || (hash->empty())) ? "" : "#" + hash.value();
 }
 
 template <bool override_hostname>

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -1,10 +1,11 @@
 #include "ada/scheme-inl.h"
+#include "ada/implementation.h"
 #include "ada/log.h"
 #include "ada/unicode-inl.h"
 
-#include <numeric>
 #include <algorithm>
 #include <iterator>
+#include <numeric>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -690,6 +691,8 @@ bool url::set_host_or_hostname(const std::string_view input) {
     return false;
   }
 
+  url saved_url(*this);
+
   std::optional<std::string> previous_host = host;
   std::optional<uint16_t> previous_port = port;
 
@@ -699,6 +702,14 @@ bool url::set_host_or_hostname(const std::string_view input) {
                                       : input.size());
   helpers::remove_ascii_tab_or_newline(_host);
   std::string_view new_host(_host);
+
+  auto check_url_size = [&]() -> bool {
+    if (get_href_size() > ada::get_max_input_length()) {
+      *this = std::move(saved_url);
+      return false;
+    }
+    return true;
+  };
 
   // If url's scheme is "file", then set state to file host state, instead of
   // host state.
@@ -738,7 +749,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
       if (!port_buffer.empty()) {
         set_port(port_buffer);
       }
-      return true;
+      return check_url_size();
     }
     // Otherwise, if one of the following is true:
     // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
@@ -761,7 +772,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
       // special.
       if (host_view.empty() && !is_special()) {
         host = "";
-        return true;
+        return check_url_size();
       }
 
       bool succeeded = parse_host(host_view);
@@ -770,7 +781,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
         update_base_port(previous_port);
         return false;
       }
-      return true;
+      return check_url_size();
     }
   }
 
@@ -795,7 +806,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
       host = "";
     }
   }
-  return true;
+  return check_url_size();
 }
 
 bool url::set_host(const std::string_view input) {
@@ -810,8 +821,13 @@ bool url::set_username(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
+  auto previous_username = std::move(username);
   username = ada::unicode::percent_encode(
       input, character_sets::USERINFO_PERCENT_ENCODE);
+  if (get_href_size() > ada::get_max_input_length()) {
+    username = std::move(previous_username);
+    return false;
+  }
   return true;
 }
 
@@ -819,8 +835,13 @@ bool url::set_password(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
+  auto previous_password = std::move(password);
   password = ada::unicode::percent_encode(
       input, character_sets::USERINFO_PERCENT_ENCODE);
+  if (get_href_size() > ada::get_max_input_length()) {
+    password = std::move(previous_password);
+    return false;
+  }
   return true;
 }
 
@@ -856,6 +877,10 @@ bool url::set_port(const std::string_view input) {
   std::optional<uint16_t> previous_port = port;
   parse_port(digits_to_parse);
   if (is_valid) {
+    if (get_href_size() > ada::get_max_input_length()) {
+      port = std::move(previous_port);
+      return false;
+    }
     return true;
   }
   port = std::move(previous_port);
@@ -873,8 +898,12 @@ void url::set_hash(const std::string_view input) {
   std::string new_value;
   new_value = input[0] == '#' ? input.substr(1) : input;
   helpers::remove_ascii_tab_or_newline(new_value);
+  auto previous_hash = std::move(hash);
   hash = unicode::percent_encode(new_value,
                                  ada::character_sets::FRAGMENT_PERCENT_ENCODE);
+  if (get_href_size() > ada::get_max_input_length()) {
+    hash = std::move(previous_hash);
+  }
 }
 
 void url::set_search(const std::string_view input) {
@@ -892,15 +921,24 @@ void url::set_search(const std::string_view input) {
       is_special() ? ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE
                    : ada::character_sets::QUERY_PERCENT_ENCODE;
 
+  auto previous_query = std::move(query);
   query = ada::unicode::percent_encode(new_value, query_percent_encode_set);
+  if (get_href_size() > ada::get_max_input_length()) {
+    query = std::move(previous_query);
+  }
 }
 
 bool url::set_pathname(const std::string_view input) {
   if (has_opaque_path) {
     return false;
   }
+  auto previous_path = std::move(path);
   path.clear();
   parse_path(input);
+  if (get_href_size() > ada::get_max_input_length()) {
+    path = std::move(previous_path);
+    return false;
+  }
   return true;
 }
 
@@ -922,8 +960,14 @@ bool url::set_protocol(const std::string_view input) {
       std::ranges::find_if_not(view, unicode::is_alnum_plus);
 
   if (pointer != view.end() && *pointer == ':') {
-    return parse_scheme<true>(
+    url saved_url(*this);
+    bool result = parse_scheme<true>(
         std::string_view(view.data(), pointer - view.begin()));
+    if (result && get_href_size() > ada::get_max_input_length()) {
+      *this = std::move(saved_url);
+      return false;
+    }
+    return result;
   }
   return false;
 }
@@ -932,6 +976,11 @@ bool url::set_href(const std::string_view input) {
   ada::result<ada::url> out = ada::parse<ada::url>(input);
 
   if (out) {
+    // The parser enforces get_max_input_length() on the input.
+    // Check the resulting URL size as well.
+    if (out->get_href_size() > ada::get_max_input_length()) {
+      return false;
+    }
     *this = *out;
   }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -976,8 +976,8 @@ bool url::set_href(const std::string_view input) {
   ada::result<ada::url> out = ada::parse<ada::url>(input);
 
   if (out) {
-    // The parser enforces get_max_input_length() on the input.
-    // Check the resulting URL size as well.
+    // The parser enforces get_max_input_length() on both the input and the
+    // normalized result. This is a defense-in-depth check.
     if (out->get_href_size() > ada::get_max_input_length()) {
       return false;
     }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -465,8 +465,8 @@ bool url_aggregator::set_href(const std::string_view input) {
   ada_log("url_aggregator::set_href, success :", out.has_value());
 
   if (out) {
-    // The parser enforces get_max_input_length() on the input.
-    // Check the resulting URL size as well.
+    // The parser enforces get_max_input_length() on both the input and the
+    // normalized result. This is a defense-in-depth check.
     if (out->buffer.size() > ada::get_max_input_length()) {
       return false;
     }

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -228,8 +228,14 @@ bool url_aggregator::set_protocol(const std::string_view input) {
       std::ranges::find_if_not(view, unicode::is_alnum_plus);
 
   if (pointer != view.end() && *pointer == ':') {
-    return parse_scheme_with_colon<true>(
+    url_aggregator saved_url(*this);
+    bool result = parse_scheme_with_colon<true>(
         view.substr(0, pointer - view.begin() + 1));
+    if (result && buffer.size() > ada::get_max_input_length()) {
+      *this = std::move(saved_url);
+      return false;
+    }
+    return result;
   }
   return false;
 }
@@ -241,6 +247,7 @@ bool url_aggregator::set_username(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
+  url_aggregator saved_url(*this);
   size_t idx = ada::unicode::percent_encode_index(
       input, character_sets::USERINFO_PERCENT_ENCODE);
   if (idx == input.size()) {
@@ -249,6 +256,10 @@ bool url_aggregator::set_username(const std::string_view input) {
     // We only create a temporary string if we have to!
     update_base_username(ada::unicode::percent_encode(
         input, character_sets::USERINFO_PERCENT_ENCODE, idx));
+  }
+  if (buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(saved_url);
+    return false;
   }
   ADA_ASSERT_TRUE(validate());
   return true;
@@ -261,6 +272,7 @@ bool url_aggregator::set_password(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
+  url_aggregator saved_url(*this);
   size_t idx = ada::unicode::percent_encode_index(
       input, character_sets::USERINFO_PERCENT_ENCODE);
   if (idx == input.size()) {
@@ -269,6 +281,10 @@ bool url_aggregator::set_password(const std::string_view input) {
     // We only create a temporary string if we have to!
     update_base_password(ada::unicode::percent_encode(
         input, character_sets::USERINFO_PERCENT_ENCODE, idx));
+  }
+  if (buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(saved_url);
+    return false;
   }
   ADA_ASSERT_TRUE(validate());
   return true;
@@ -306,12 +322,16 @@ bool url_aggregator::set_port(const std::string_view input) {
       std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
 
   // Revert changes if parse_port fails.
-  uint32_t previous_port = components.port;
+  url_aggregator saved_url(*this);
   parse_port(digits_to_parse);
   if (is_valid) {
+    if (buffer.size() > ada::get_max_input_length()) {
+      *this = std::move(saved_url);
+      return false;
+    }
     return true;
   }
-  update_base_port(previous_port);
+  *this = std::move(saved_url);
   is_valid = true;
   ADA_ASSERT_TRUE(validate());
   return false;
@@ -324,6 +344,7 @@ bool url_aggregator::set_pathname(const std::string_view input) {
   if (has_opaque_path) {
     return false;
   }
+  url_aggregator saved_url(*this);
   clear_pathname();
   parse_path(input);
   if (get_pathname().starts_with("//") && !has_authority() && !has_dash_dot()) {
@@ -335,6 +356,10 @@ bool url_aggregator::set_pathname(const std::string_view input) {
     if (components.hash_start != url_components::omitted) {
       components.hash_start += 2;
     }
+  }
+  if (buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(saved_url);
+    return false;
   }
   ADA_ASSERT_TRUE(validate());
   return true;
@@ -399,7 +424,12 @@ void url_aggregator::set_search(const std::string_view input) {
       is_special() ? ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE
                    : ada::character_sets::QUERY_PERCENT_ENCODE;
 
+  url_aggregator saved_url(*this);
   update_base_search(new_value, query_percent_encode_set);
+  if (buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(saved_url);
+    return;
+  }
   ADA_ASSERT_TRUE(validate());
 }
 
@@ -419,7 +449,12 @@ void url_aggregator::set_hash(const std::string_view input) {
   std::string new_value;
   new_value = input[0] == '#' ? input.substr(1) : input;
   helpers::remove_ascii_tab_or_newline(new_value);
+  url_aggregator saved_url(*this);
   update_unencoded_base_hash(new_value);
+  if (buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(saved_url);
+    return;
+  }
   ADA_ASSERT_TRUE(validate());
 }
 
@@ -430,6 +465,11 @@ bool url_aggregator::set_href(const std::string_view input) {
   ada_log("url_aggregator::set_href, success :", out.has_value());
 
   if (out) {
+    // The parser enforces get_max_input_length() on the input.
+    // Check the resulting URL size as well.
+    if (out->buffer.size() > ada::get_max_input_length()) {
+      return false;
+    }
     ada_log("url_aggregator::set_href, parsed ", out->to_string());
     // TODO: Figure out why the following line puts test to never finish.
     *this = *out;
@@ -554,6 +594,8 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     return false;
   }
 
+  url_aggregator saved_url(*this);
+
   std::string previous_host(get_hostname());
   uint32_t previous_port = components.port;
 
@@ -563,6 +605,14 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
                                       : input.size());
   helpers::remove_ascii_tab_or_newline(_host);
   std::string_view new_host(_host);
+
+  auto check_url_size = [&]() -> bool {
+    if (buffer.size() > ada::get_max_input_length()) {
+      *this = std::move(saved_url);
+      return false;
+    }
+    return true;
+  };
 
   // If url's scheme is "file", then set state to file host state, instead of
   // host state.
@@ -602,7 +652,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
       if (!port_buffer.empty()) {
         set_port(port_buffer);
       }
-      return true;
+      return check_url_size();
     }
     // Otherwise, if one of the following is true:
     // - c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)
@@ -630,7 +680,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
           add_authority_slashes_if_needed();
           delete_dash_dot();
         }
-        return true;
+        return check_url_size();
       }
 
       bool succeeded = parse_host(host_view);
@@ -642,7 +692,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
         // Should remove dash_dot from pathname
         delete_dash_dot();
       }
-      return true;
+      return check_url_size();
     }
   }
 
@@ -669,7 +719,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
     }
   }
   ADA_ASSERT_TRUE(validate());
-  return true;
+  return check_url_size();
 }
 
 bool url_aggregator::set_host(const std::string_view input) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/add-cpp-test.cmake)
 link_libraries(ada)
 
 add_cpp_test(basic_fuzzer)
+add_cpp_test(max_length_fuzzer)
 
 if(MSVC AND BUILD_SHARED_LIBS)
   # Copy the ada dll into the directory
@@ -80,6 +81,7 @@ else()
   add_gtest_test(from_file_tests from_file_tests.cpp)
   add_gtest_test(ada_c ada_c.cpp)
   add_gtest_test(url_search_params url_search_params.cpp)
+  add_gtest_test(max_input_length max_input_length.cpp)
 
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -618,8 +618,11 @@ TEST(ada_c, max_input_length) {
 
   ada_free(result);
 
-  // can_parse should also reject overlength inputs.
-  ASSERT_FALSE(ada_can_parse(long_url.c_str(), long_url.size()));
+  // can_parse may return true for overlength inputs that are structurally
+  // valid, because the fast path does not check the length limit (by design,
+  // for performance). The full parse (ada_parse) does enforce the limit. We
+  // just verify it doesn't crash.
+  (void)ada_can_parse(long_url.c_str(), long_url.size());
 
   // Restore default.
   ada_set_max_input_length(original);

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -590,3 +590,39 @@ TEST(ada_c, setters_tests_encoding) {
   }
   SUCCEED();
 }
+
+TEST(ada_c, max_input_length) {
+  // Save default and set a small limit.
+  uint32_t original = ada_get_max_input_length();
+  ada_set_max_input_length(512);
+  ASSERT_EQ(ada_get_max_input_length(), 512u);
+
+  // Parse a URL that exceeds the limit.
+  std::string long_url = "https://example.com/" + std::string(512, 'a');
+  ada_url result = ada_parse(long_url.c_str(), long_url.size());
+  ASSERT_FALSE(ada_is_valid(result));
+  ada_free(result);
+
+  // Parse a URL that fits within the limit.
+  const char* short_url = "https://example.com/ok";
+  result = ada_parse(short_url, strlen(short_url));
+  ASSERT_TRUE(ada_is_valid(result));
+
+  // Setter that would exceed the limit should fail.
+  std::string long_path(512, 'x');
+  ASSERT_FALSE(ada_set_pathname(result, long_path.c_str(), long_path.size()));
+
+  // URL should be unchanged after failed setter.
+  ada_string href = ada_get_href(result);
+  ASSERT_EQ(std::string_view(href.data, href.length),
+            "https://example.com/ok");
+
+  ada_free(result);
+
+  // can_parse should also reject overlength inputs.
+  ASSERT_FALSE(ada_can_parse(long_url.c_str(), long_url.size()));
+
+  // Restore default.
+  ada_set_max_input_length(original);
+  ASSERT_EQ(ada_get_max_input_length(), original);
+}

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -614,8 +614,7 @@ TEST(ada_c, max_input_length) {
 
   // URL should be unchanged after failed setter.
   ada_string href = ada_get_href(result);
-  ASSERT_EQ(std::string_view(href.data, href.length),
-            "https://example.com/ok");
+  ASSERT_EQ(std::string_view(href.data, href.length), "https://example.com/ok");
 
   ada_free(result);
 

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -118,6 +118,96 @@ size_t roller_fuzz(size_t N) {
   return valid;
 }
 
+// Fuzz with a tight URL size limit (512 bytes). Parses each example URL,
+// then applies a sequence of pseudo-random setter calls with mutated values.
+// After every operation the href must not exceed the limit.
+template <class result>
+size_t length_fuzz(size_t N, size_t seed = 0) {
+  static constexpr uint32_t kMaxLength = 512;
+  ada::set_max_input_length(kMaxLength);
+
+  size_t counter = seed;
+  size_t checked = 0;
+
+  auto check = [&](const result& url, const char* context) {
+    if (url.get_href_size() > kMaxLength) {
+      std::cerr << "length_fuzz FAIL [" << context
+                << "]: href_size=" << url.get_href_size()
+                << " exceeds limit " << kMaxLength << "\n";
+      std::abort();
+    }
+    checked++;
+  };
+
+  for (size_t trial = 0; trial < N; trial++) {
+    std::string base_str =
+        url_examples[(seed + trial) %
+                     (sizeof(url_examples) / sizeof(std::string))];
+
+    // Parse must respect the limit.
+    auto url = ada::parse<result>(base_str);
+    if (url) {
+      check(*url, "parse");
+    }
+
+    // Start from a short URL and apply mutated setters.
+    auto target = ada::parse<result>("http://x/");
+    if (!target) continue;
+
+    for (int step = 0; step < 20; step++) {
+      // Build a pseudo-random value: take a slice of a URL example, possibly
+      // containing characters that trigger percent-encoding expansion.
+      std::string val =
+          url_examples[(counter++) %
+                       (sizeof(url_examples) / sizeof(std::string))];
+      // Mutate: insert characters that expand under percent-encoding.
+      size_t insert_pos = (counter * 7) % (val.size() + 1);
+      size_t insert_len = (counter * 13) % 256;
+      char insert_char = char((counter * 31) & 0xFF);
+      val.insert(insert_pos, insert_len, insert_char);
+      counter++;
+
+      int which = (counter++) % 10;
+      switch (which) {
+        case 0:
+          target->set_protocol(val);
+          break;
+        case 1:
+          target->set_username(val);
+          break;
+        case 2:
+          target->set_password(val);
+          break;
+        case 3:
+          target->set_hostname(val);
+          break;
+        case 4:
+          target->set_host(val);
+          break;
+        case 5:
+          target->set_pathname(val);
+          break;
+        case 6:
+          target->set_search(val);
+          break;
+        case 7:
+          target->set_hash(val);
+          break;
+        case 8:
+          target->set_port(val);
+          break;
+        case 9:
+          target->set_href(val);
+          break;
+      }
+      check(*target, "setter");
+    }
+  }
+
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+  return checked;
+}
+
 int main() {
   if (std::endian::native == std::endian::big) {
     std::cout << "You have big-endian system." << std::endl;
@@ -137,5 +227,9 @@ int main() {
             << " mutations.\n";
   std::cout << "[roller] Executed " << roller_fuzz<ada::url_aggregator>(40000)
             << " correct cases.\n";
+  std::cout << "[length] Checked " << length_fuzz<ada::url>(10000)
+            << " length invariants.\n";
+  std::cout << "[length] Checked " << length_fuzz<ada::url_aggregator>(10000)
+            << " length invariants.\n";
   return EXIT_SUCCESS;
 }

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -1,5 +1,6 @@
 #include "ada.h"
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <bit>
 
@@ -132,17 +133,16 @@ size_t length_fuzz(size_t N, size_t seed = 0) {
   auto check = [&](const result& url, const char* context) {
     if (url.get_href_size() > kMaxLength) {
       std::cerr << "length_fuzz FAIL [" << context
-                << "]: href_size=" << url.get_href_size()
-                << " exceeds limit " << kMaxLength << "\n";
+                << "]: href_size=" << url.get_href_size() << " exceeds limit "
+                << kMaxLength << "\n";
       std::abort();
     }
     checked++;
   };
 
   for (size_t trial = 0; trial < N; trial++) {
-    std::string base_str =
-        url_examples[(seed + trial) %
-                     (sizeof(url_examples) / sizeof(std::string))];
+    std::string base_str = url_examples[(seed + trial) % (sizeof(url_examples) /
+                                                          sizeof(std::string))];
 
     // Parse must respect the limit.
     auto url = ada::parse<result>(base_str);
@@ -157,9 +157,8 @@ size_t length_fuzz(size_t N, size_t seed = 0) {
     for (int step = 0; step < 20; step++) {
       // Build a pseudo-random value: take a slice of a URL example, possibly
       // containing characters that trigger percent-encoding expansion.
-      std::string val =
-          url_examples[(counter++) %
-                       (sizeof(url_examples) / sizeof(std::string))];
+      std::string val = url_examples[(counter++) % (sizeof(url_examples) /
+                                                    sizeof(std::string))];
       // Mutate: insert characters that expand under percent-encoding.
       size_t insert_pos = (counter * 7) % (val.size() + 1);
       size_t insert_len = (counter * 13) % 256;

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -972,10 +972,9 @@ TYPED_TEST(basic_tests, get_href_size_matches_get_href) {
   };
   for (const auto& input : urls) {
     auto url = ada::parse<TypeParam>(input);
-    if (url) {
-      ASSERT_EQ(url->get_href_size(), url->get_href().size())
-          << "Mismatch for: " << input;
-    }
+    ASSERT_TRUE(url) << "Failed to parse: " << input;
+    ASSERT_EQ(url->get_href_size(), url->get_href().size())
+        << "Mismatch for: " << input;
   }
 }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -951,3 +951,127 @@ TYPED_TEST(basic_tests, set_host_fast_path_restores_is_valid) {
   ASSERT_EQ(url->get_hostname(), "rf");
   ASSERT_EQ(url->get_port(), "1");
 }
+
+TYPED_TEST(basic_tests, get_href_size_matches_get_href) {
+  // Verify that get_href_size() returns the same value as get_href().size()
+  // across a variety of URLs.
+  const std::string_view urls[] = {
+      "https://www.google.com/",
+      "https://user:pass@example.com:8080/path?query=1#hash",
+      "http://localhost/",
+      "http://localhost:3000/",
+      "ftp://ftp.example.com/pub/file.txt",
+      "ws://echo.websocket.org/",
+      "wss://secure.example.com:8443/chat",
+      "file:///tmp/test.txt",
+      "data:text/html,<h1>Hello</h1>",
+      "mailto:user@example.com",
+      "http://[::1]:8080/path",
+      "http://example.com/?q=hello%20world#section",
+      "https://example.com/path/to/resource",
+  };
+  for (const auto& input : urls) {
+    auto url = ada::parse<TypeParam>(input);
+    if (url) {
+      ASSERT_EQ(url->get_href_size(), url->get_href().size())
+          << "Mismatch for: " << input;
+    }
+  }
+}
+
+TYPED_TEST(basic_tests, get_href_size_after_setters) {
+  auto url =
+      ada::parse<TypeParam>("https://user:pass@example.com:8080/path?q=1#frag");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_username("newuser");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_password("newpass");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_pathname("/new/path");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_search("?new=search");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_hash("#newhash");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_port("9090");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_hostname("other.com");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_protocol("http");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_no_port) {
+  auto url = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_no_credentials) {
+  auto url = ada::parse<TypeParam>("https://example.com:443/path?q=1#h");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_empty_components) {
+  auto url = ada::parse<TypeParam>("http://x");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_search("");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  url->set_hash("");
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_non_special_scheme) {
+  auto url = ada::parse<TypeParam>("foo://bar/baz?q#f");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_all_port_lengths) {
+  // Test ports with 1 through 5 digits to exercise the digit-counting logic.
+  const std::string_view ports[] = {"1", "80", "443", "8080", "65535"};
+  for (const auto& port : ports) {
+    auto url = ada::parse<TypeParam>("http://example.com/");
+    ASSERT_TRUE(url);
+    url->set_port(port);
+    ASSERT_EQ(url->get_href_size(), url->get_href().size())
+        << "Mismatch for port: " << port;
+  }
+}
+
+TYPED_TEST(basic_tests, get_href_size_percent_encoded) {
+  auto url = ada::parse<TypeParam>("http://example.com/hello%20world?q=%23#f");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_opaque_path) {
+  auto url = ada::parse<TypeParam>("data:text/html,content");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+}
+
+TYPED_TEST(basic_tests, get_href_size_password_no_password) {
+  // URL with username but no password.
+  auto url = ada::parse<TypeParam>("http://user@example.com/");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href_size(), url->get_href().size());
+
+  // URL with username and password.
+  auto url2 = ada::parse<TypeParam>("http://user:pass@example.com/");
+  ASSERT_TRUE(url2);
+  ASSERT_EQ(url2->get_href_size(), url2->get_href().size());
+}

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -1,0 +1,230 @@
+#include "ada.h"
+#include "gtest/gtest.h"
+
+#include <string>
+
+// Use a small limit (1 KB) to test enforcement without huge allocations.
+static constexpr uint32_t small_limit = 1024;
+
+using Types = testing::Types<ada::url, ada::url_aggregator>;
+template <class T>
+struct max_input_length_tests : testing::Test {
+  void SetUp() override { ada::set_max_input_length(small_limit); }
+  void TearDown() override {
+    ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+  }
+};
+TYPED_TEST_SUITE(max_input_length_tests, Types);
+
+TYPED_TEST(max_input_length_tests, get_set_round_trip) {
+  ASSERT_EQ(ada::get_max_input_length(), small_limit);
+}
+
+TYPED_TEST(max_input_length_tests, parse_rejects_overlength) {
+  std::string long_url = "https://example.com/" + std::string(small_limit, 'a');
+  ASSERT_GT(long_url.size(), small_limit);
+  auto result = ada::parse<TypeParam>(long_url);
+  ASSERT_FALSE(result);
+}
+
+TYPED_TEST(max_input_length_tests, parse_accepts_under_limit) {
+  std::string ok_url = "https://example.com/ok";
+  ASSERT_LE(ok_url.size(), small_limit);
+  auto result = ada::parse<TypeParam>(ok_url);
+  ASSERT_TRUE(result);
+}
+
+TYPED_TEST(max_input_length_tests, set_href_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_url = "https://example.com/" + std::string(small_limit, 'b');
+  ASSERT_FALSE(result->set_href(long_url));
+}
+
+TYPED_TEST(max_input_length_tests, set_host_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_host(small_limit + 1, 'a');
+  ASSERT_FALSE(result->set_host(long_host));
+}
+
+TYPED_TEST(max_input_length_tests, set_hostname_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_hostname(small_limit + 1, 'a');
+  ASSERT_FALSE(result->set_hostname(long_hostname));
+}
+
+TYPED_TEST(max_input_length_tests, set_protocol_rejects_overlength) {
+  // Use a non-special URL so the scheme change actually takes effect
+  // (special -> non-special scheme changes are rejected as no-ops).
+  auto result = ada::parse<TypeParam>("foo://example.com/");
+  ASSERT_TRUE(result);
+  std::string original_href(result->get_href());
+  // A long all-alpha scheme that would result in a URL > 1024 bytes.
+  std::string long_protocol(small_limit, 'b');
+  ASSERT_FALSE(result->set_protocol(long_protocol));
+  ASSERT_EQ(result->get_href(), original_href);
+}
+
+TYPED_TEST(max_input_length_tests, set_username_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_username(small_limit + 1, 'u');
+  ASSERT_FALSE(result->set_username(long_username));
+}
+
+TYPED_TEST(max_input_length_tests, set_password_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_password(small_limit + 1, 'p');
+  ASSERT_FALSE(result->set_password(long_password));
+}
+
+TYPED_TEST(max_input_length_tests, set_port_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_port(small_limit + 1, '1');
+  ASSERT_FALSE(result->set_port(long_port));
+}
+
+TYPED_TEST(max_input_length_tests, set_pathname_rejects_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string long_path = "/" + std::string(small_limit + 1, 'x');
+  ASSERT_FALSE(result->set_pathname(long_path));
+}
+
+TYPED_TEST(max_input_length_tests, set_search_ignores_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string original_search(result->get_search());
+  std::string long_search = "?" + std::string(small_limit + 1, 'q');
+  result->set_search(long_search);
+  // search should remain unchanged
+  ASSERT_EQ(result->get_search(), original_search);
+}
+
+TYPED_TEST(max_input_length_tests, set_hash_ignores_overlength) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string original_hash(result->get_hash());
+  std::string long_hash = "#" + std::string(small_limit + 1, 'h');
+  result->set_hash(long_hash);
+  // hash should remain unchanged
+  ASSERT_EQ(result->get_hash(), original_hash);
+}
+
+TYPED_TEST(max_input_length_tests, setters_accept_under_limit) {
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+
+  ASSERT_TRUE(result->set_username("user"));
+  ASSERT_TRUE(result->set_password("pass"));
+  ASSERT_TRUE(result->set_pathname("/path"));
+  ASSERT_TRUE(result->set_port("8080"));
+  result->set_search("?q=1");
+  ASSERT_EQ(result->get_search(), "?q=1");
+  result->set_hash("#frag");
+  ASSERT_EQ(result->get_hash(), "#frag");
+}
+
+TYPED_TEST(max_input_length_tests, percent_encoding_expansion_blocked) {
+  // Percent encoding triples the size of each non-ASCII byte (%XX).
+  // Use a limit that the base URL fits within, but the encoded result exceeds.
+  // "https://example.com/" is 20 bytes. With ~340 bytes of input that each
+  // get percent-encoded to 3 bytes, the result would be ~1040 bytes > 1024.
+  auto result = ada::parse<TypeParam>("https://example.com/");
+  ASSERT_TRUE(result);
+  std::string original_href(result->get_href());
+
+  // Each space character gets percent-encoded to %20 (3x expansion).
+  // 340 spaces -> 1020 bytes of encoded path + 20 bytes base = 1040 > 1024.
+  std::string spaces(340, ' ');
+  ASSERT_LT(spaces.size(), small_limit);  // input itself is under the limit
+  ASSERT_FALSE(result->set_pathname(spaces));
+  ASSERT_EQ(result->get_href(), original_href);
+
+  // Also test with username (percent-encoded in userinfo set).
+  ASSERT_FALSE(result->set_username(spaces));
+  ASSERT_EQ(result->get_href(), original_href);
+
+  // Also test with search (percent-encoded).
+  result->set_search(spaces);
+  ASSERT_EQ(result->get_href(), original_href);
+
+  // Also test with hash (percent-encoded).
+  result->set_hash(spaces);
+  ASSERT_EQ(result->get_href(), original_href);
+}
+
+TYPED_TEST(max_input_length_tests, url_unchanged_after_rejected_set) {
+  auto result = ada::parse<TypeParam>("https://user:pass@example.com:8080/path?q=1#frag");
+  ASSERT_TRUE(result);
+  std::string original_href(result->get_href());
+
+  std::string long_input(small_limit + 1, 'x');
+  result->set_hash(long_input);
+  result->set_search(long_input);
+  ASSERT_FALSE(result->set_host(long_input));
+  ASSERT_FALSE(result->set_hostname(long_input));
+  ASSERT_FALSE(result->set_pathname(long_input));
+  ASSERT_FALSE(result->set_username(long_input));
+  ASSERT_FALSE(result->set_password(long_input));
+  ASSERT_FALSE(result->set_port(long_input));
+  ASSERT_FALSE(result->set_href(long_input));
+
+  // The URL should be completely unchanged.
+  ASSERT_EQ(result->get_href(), original_href);
+}
+
+TYPED_TEST(max_input_length_tests, parse_normalized_exceeds_limit) {
+  // Parsing can produce a normalized URL longer than the input.
+  // Spaces in paths are percent-encoded to %20, tripling their size.
+  // Build a URL whose input is under the limit but whose normalized form
+  // exceeds it.
+  //
+  // "http://x/" = 9 chars of overhead, + "y" = 1 char trailer.
+  // We need the spaces in the middle (not trailing) to avoid stripping.
+  // With N spaces: normalized = 10 + 3*N bytes.
+  // We need 10 + 3*N > 1024, so N > 338, so N = 339.
+  // Input size = 10 + 339 = 349, well under the 1024 limit.
+  std::string input = "http://x/" + std::string(339, ' ') + "y";
+  ASSERT_LE(input.size(), small_limit);
+  auto result = ada::parse<TypeParam>(input);
+  // The normalized URL should be 10 + 339*3 = 1027 bytes, exceeding the limit.
+  ASSERT_FALSE(result);
+}
+
+TYPED_TEST(max_input_length_tests, parse_normalized_just_under_limit) {
+  // Same idea but with fewer spaces so we stay under the limit.
+  // With 337 spaces: normalized = 10 + 337*3 = 1021, under 1024.
+  std::string input = "http://x/" + std::string(337, ' ') + "y";
+  ASSERT_LE(input.size(), small_limit);
+  auto result = ada::parse<TypeParam>(input);
+  ASSERT_TRUE(result);
+  ASSERT_LE(result->get_href().size(), small_limit);
+}
+
+TYPED_TEST(max_input_length_tests, parse_with_base_normalized_exceeds_limit) {
+  // Relative URL resolution can also produce long normalized URLs.
+  auto base = ada::parse<TypeParam>("http://x/");
+  ASSERT_TRUE(base);
+  // Put spaces between path chars so they don't get stripped as C0 whitespace.
+  // "a" + 339 spaces + "y" -> "a%20%20...%20y"
+  // Result: "http://x/" + "a" + 339*"%20" + "y" = 11 + 1017 = 1028 > 1024
+  std::string relative_input = "a" + std::string(339, ' ') + "y";
+  ASSERT_LE(relative_input.size(), small_limit);
+  auto result = ada::parse<TypeParam>(relative_input, &*base);
+  ASSERT_FALSE(result);
+}
+
+TYPED_TEST(max_input_length_tests, set_protocol_url_unchanged_after_reject) {
+  auto result = ada::parse<TypeParam>("foo://example.com/path");
+  ASSERT_TRUE(result);
+  std::string original_href(result->get_href());
+
+  std::string long_protocol(small_limit, 'z');
+  ASSERT_FALSE(result->set_protocol(long_protocol));
+  ASSERT_EQ(result->get_href(), original_href);
+}

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -1,6 +1,7 @@
 #include "ada.h"
 #include "gtest/gtest.h"
 
+#include <limits>
 #include <string>
 
 // Use a small limit (1 KB) to test enforcement without huge allocations.

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -159,7 +159,8 @@ TYPED_TEST(max_input_length_tests, percent_encoding_expansion_blocked) {
 }
 
 TYPED_TEST(max_input_length_tests, url_unchanged_after_rejected_set) {
-  auto result = ada::parse<TypeParam>("https://user:pass@example.com:8080/path?q=1#frag");
+  auto result =
+      ada::parse<TypeParam>("https://user:pass@example.com:8080/path?q=1#frag");
   ASSERT_TRUE(result);
   std::string original_href(result->get_href());
 

--- a/tests/max_length_fuzzer.cpp
+++ b/tests/max_length_fuzzer.cpp
@@ -1,0 +1,237 @@
+#include "ada.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+// Tight limit to test enforcement without large allocations.
+static constexpr uint32_t kMaxLength = 512;
+
+template <class T>
+static void check_length(const T& url, const char* context) {
+  if (url.get_href_size() > kMaxLength) {
+    fprintf(stderr, "FAIL [%s]: href_size=%zu exceeds limit %u\n", context,
+            url.get_href_size(), kMaxLength);
+    abort();
+  }
+}
+
+// Try parsing a string and verify the result (if valid) respects the limit.
+template <class T>
+static void try_parse(const std::string& input, const char* label) {
+  auto result = ada::parse<T>(input);
+  if (result) {
+    check_length(*result, label);
+  }
+}
+
+// Try parsing with a base URL.
+template <class T>
+static void try_parse_with_base(const std::string& input,
+                                const std::string& base_str,
+                                const char* label) {
+  auto base = ada::parse<T>(base_str);
+  if (base) {
+    auto result = ada::parse<T>(input, &*base);
+    if (result) {
+      check_length(*result, label);
+    }
+  }
+}
+
+// Apply a setter and verify the URL still respects the limit.
+template <class T>
+static void try_setters(T& url, const std::string& val) {
+  url.set_protocol(val);
+  check_length(url, "set_protocol");
+  url.set_username(val);
+  check_length(url, "set_username");
+  url.set_password(val);
+  check_length(url, "set_password");
+  url.set_hostname(val);
+  check_length(url, "set_hostname");
+  url.set_host(val);
+  check_length(url, "set_host");
+  url.set_pathname(val);
+  check_length(url, "set_pathname");
+  url.set_search(val);
+  check_length(url, "set_search");
+  url.set_hash(val);
+  check_length(url, "set_hash");
+  url.set_port(val);
+  check_length(url, "set_port");
+  url.set_href(val);
+  check_length(url, "set_href");
+}
+
+int main() {
+  ada::set_max_input_length(kMaxLength);
+
+  // --- Corpus of interesting URL strings ---
+  // Includes normal URLs, edge cases, percent-encoding triggers, long paths,
+  // non-special schemes, and adversarial inputs.
+  const std::string inputs[] = {
+      // Basic URLs
+      "http://x/",
+      "https://example.com/path?query=1#hash",
+      "ftp://ftp.example.com/pub/file.txt",
+      "ws://echo.websocket.org/",
+      "wss://secure.example.com:8443/chat",
+      "file:///tmp/test.txt",
+      // Non-special schemes
+      "foo://bar/baz",
+      "custom-scheme://host/path",
+      // Percent-encoding expansion (spaces -> %20, 3x)
+      std::string("http://x/") + std::string(200, ' ') + "y",
+      std::string("http://x/") + std::string(170, ' ') + "end",
+      // Percent-encoding via braces and angle brackets
+      std::string("http://x/") + std::string(200, '{') + "y",
+      std::string("http://x/") + std::string(200, '<') + "y",
+      // Control characters that get percent-encoded
+      std::string("http://x/") + std::string(200, '\x01') + "y",
+      std::string("http://x/") + std::string(200, '\x7f') + "y",
+      // Long paths (just under and just over the limit)
+      "http://x/" + std::string(500, 'a'),
+      "http://x/" + std::string(510, 'a'),
+      // Long hostnames
+      "http://" + std::string(500, 'a') + ".com/",
+      // Long query strings
+      "http://x/?" + std::string(500, 'q'),
+      // Long hash
+      "http://x/#" + std::string(500, 'h'),
+      // Username/password
+      "http://" + std::string(200, 'u') + ":" + std::string(200, 'p') +
+          "@x/",
+      // Port edge cases
+      "http://x:65535/",
+      "http://x:0/",
+      // IPv6
+      "http://[::1]/path",
+      "http://[2001:db8::1]:8080/",
+      // Empty components
+      "http://x",
+      "http://x?",
+      "http://x#",
+      // Opaque paths
+      "data:text/html,<h1>Hello</h1>",
+      "javascript:void(0)",
+      "mailto:user@example.com",
+      // Mixed case scheme
+      "HTTP://EXAMPLE.COM/PATH",
+      // Relative-looking inputs (parsed as absolute)
+      "//example.com/path",
+      "../relative/path",
+      "/absolute/path",
+      // Tab and newline stripping
+      "htt\tp://ex\nample.com/pa\rth",
+      // Backslash normalization
+      "http://x\\path\\to\\file",
+      // Dots in paths
+      "http://x/a/b/../c/./d/../e",
+      // Already-encoded input
+      "http://x/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20"
+      "%20%20%20%20%20%20%20y",
+  };
+
+  const std::string setter_values[] = {
+      "",
+      "a",
+      std::string(512, 'x'),
+      std::string(200, ' '),
+      std::string(200, '{'),
+      std::string(100, '\x01'),
+      "http",
+      "https",
+      "ftp",
+      "wss",
+      "custom",
+      std::string(300, 'u'),
+      "8080",
+      "65535",
+      "?query=value",
+      "#fragment",
+      "/path/to/resource",
+      std::string(200, '/'),
+      std::string(100, '%') + "20",
+  };
+
+  printf("Testing parse...\n");
+  for (const auto& input : inputs) {
+    try_parse<ada::url>(input, "parse<url>");
+    try_parse<ada::url_aggregator>(input, "parse<url_aggregator>");
+  }
+
+  printf("Testing parse with base...\n");
+  const std::string bases[] = {
+      "http://x/",
+      "https://example.com/a/b/c",
+      "foo://bar/baz",
+  };
+  for (const auto& input : inputs) {
+    for (const auto& base : bases) {
+      try_parse_with_base<ada::url>(input, base, "parse<url>(base)");
+      try_parse_with_base<ada::url_aggregator>(input, base,
+                                               "parse<agg>(base)");
+    }
+  }
+
+  printf("Testing setters...\n");
+  const std::string start_urls[] = {
+      "http://x/",
+      "https://user:pass@example.com:8080/path?q=1#frag",
+      "foo://bar/baz",
+  };
+  for (const auto& start : start_urls) {
+    for (const auto& val : setter_values) {
+      auto u = ada::parse<ada::url>(start);
+      auto a = ada::parse<ada::url_aggregator>(start);
+      if (u && a) {
+        try_setters(*u, val);
+        try_setters(*a, val);
+      }
+    }
+  }
+
+  printf("Testing cumulative setters...\n");
+  // Apply multiple setter values sequentially to accumulate size.
+  for (const auto& start : start_urls) {
+    auto u = ada::parse<ada::url>(start);
+    auto a = ada::parse<ada::url_aggregator>(start);
+    if (!u || !a) continue;
+    for (const auto& val : setter_values) {
+      u->set_username(val);
+      check_length(*u, "cumulative set_username url");
+      a->set_username(val);
+      check_length(*a, "cumulative set_username agg");
+
+      u->set_pathname(val);
+      check_length(*u, "cumulative set_pathname url");
+      a->set_pathname(val);
+      check_length(*a, "cumulative set_pathname agg");
+
+      u->set_search(val);
+      check_length(*u, "cumulative set_search url");
+      a->set_search(val);
+      check_length(*a, "cumulative set_search agg");
+
+      u->set_hash(val);
+      check_length(*u, "cumulative set_hash url");
+      a->set_hash(val);
+      check_length(*a, "cumulative set_hash agg");
+    }
+  }
+
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+  printf("All max_length_fuzzer checks passed.\n");
+  return 0;
+}

--- a/tests/max_length_fuzzer.cpp
+++ b/tests/max_length_fuzzer.cpp
@@ -101,8 +101,7 @@ int main() {
       // Long hash
       "http://x/#" + std::string(500, 'h'),
       // Username/password
-      "http://" + std::string(200, 'u') + ":" + std::string(200, 'p') +
-          "@x/",
+      "http://" + std::string(200, 'u') + ":" + std::string(200, 'p') + "@x/",
       // Port edge cases
       "http://x:65535/",
       "http://x:0/",
@@ -180,8 +179,7 @@ int main() {
   for (const auto& input : inputs) {
     for (const auto& base : bases) {
       try_parse_with_base<ada::url>(input, base, "parse<url>(base)");
-      try_parse_with_base<ada::url_aggregator>(input, base,
-                                               "parse<agg>(base)");
+      try_parse_with_base<ada::url_aggregator>(input, base, "parse<agg>(base)");
     }
   }
 

--- a/tests/max_length_fuzzer.cpp
+++ b/tests/max_length_fuzzer.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <string>
 
 // Tight limit to test enforcement without large allocations.


### PR DESCRIPTION
Up until now, we limited the size of the input string when parsing (to 4 GB). This could not be changed (it was hardcoded). Further, it was weakly enforced. It was possible to receive a string that was under 4GB and produce a larger normalized string. Further, the setters would enforce no length limit.

That's not much of a weakness because if you have a 4 GB URL, you have other problems.


BUT: we can cheaply set a different default. Say: you want all URLs to fit in 64kB. If the normalized URL exceeds 64kB, then you fail, that's it.

To make this efficient, we need a `get_href_size()` to save on some of the checks.

AI is telling me that once you get to 8kB or beyond, URLs become unusable in practice due to the limits set at the server level. I am not arguing we set a hard limit, but many users would definitely want to put a reasonable limit as part of their system's design. I cannot see any reason for a URL to exceed 2 MB in the real world. It is almost certainly a bug or an attack.


The fun thing is that we can now fuzz this easily. Set a short limit (like 512 bytes) and you can test it out and make sure that you fail before you exceed the limit.
