### PR TITLE
incomplete IDNA Bidi validation allowing invalid LTR labels with disallowed trailing code points

### DIFF
--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -9407,18 +9407,19 @@ bool is_label_valid(const std::u32string_view label) {
 
       // In an LTR label, only characters with the Bidi properties L, EN,
       // ES, CS, ET, ON, BN, or NSM are allowed.
-      for (size_t i = 0; i < last_non_nsm_char; i++) {
+      for (size_t i = 0; i <= last_non_nsm_char; i++) {
         const direction d = find_direction(label[i]);
         if (!(d == direction::L || d == direction::EN || d == direction::ES ||
               d == direction::CS || d == direction::ET || d == direction::ON ||
               d == direction::BN || d == direction::NSM)) {
           return false;
         }
+      }
 
-        if ((i == last_non_nsm_char) &&
-            !(d == direction::L || d == direction::EN)) {
-          return false;
-        }
+      // The last non-NSM code point in an LTR label must be L or EN.
+      const direction last_non_nsm = find_direction(label[last_non_nsm_char]);
+      if (!(last_non_nsm == direction::L || last_non_nsm == direction::EN)) {
+        return false;
       }
 
       return true;

--- a/tests/wpt/toascii.json
+++ b/tests/wpt/toascii.json
@@ -107,6 +107,36 @@
     "output": null
   },
   {
+    "comment": "CheckBidi: LTR label ending with RTL code point",
+    "input": "a\u05D0",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: LTR label ending with AL code point",
+    "input": "a\u0627",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: LTR label ending with AN code point",
+    "input": "a\u0661",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: LTR label with multiple trailing RTL code points",
+    "input": "a\u05D0\u05D1",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: NSM before trailing RTL code point",
+    "input": "a\u0301\u05D0",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: trailing NSM after RTL code point",
+    "input": "a\u05D0\u0301",
+    "output": null
+  },
+  {
     "input": "xn--a-yoc",
     "output": null
   },


### PR DESCRIPTION
This change fixes incomplete IDNA Bidi validation for LTR labels where the last non-NSM code point was not being validated.

The issue was caused by the loop stopping before last_non_nsm_char, which skipped validation of the final non-NSM character. As a result, labels ending with disallowed Bidi classes were incorrectly accepted.

For example:

a\u05D0 (ends with RTL)
a\u0627 (ends with AL)
a\u0661 (ends with AN)

This violates RFC 5893 rules requiring that all characters in LTR labels must belong to allowed classes and that the final non-NSM character must be L or EN.

The fix extends validation to include the last non-NSM code point and explicitly enforces that it must be L or EN. No other logic is changed.

Regression tests have been added to cover:

LTR labels ending in RTL, AL, and AN
Multiple trailing RTL characters
NSM interactions

All new test cases fail before the fix and pass after it. The full test suite was run and no regressions were observed.

The change is limited to LTR Bidi validation logic in ada_idna.cpp with corresponding test additions in toascii.json.