### PR TITLE
Harden IDNA post-decode label validation

### DIFF
--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -9727,6 +9727,7 @@ std::string to_unicode(std::string_view input) {
 
   size_t label_start = 0;
   std::u32string tmp_buffer;
+  std::u32string post_map;
   while (label_start < input.size()) {
     size_t loc_dot = input.find('.', label_start);
     bool is_last_label = (loc_dot == std::string_view::npos);
@@ -9738,21 +9739,45 @@ std::string to_unicode(std::string_view input) {
       label_view.remove_prefix(4);
       tmp_buffer.clear();
       if (ada::idna::punycode_to_utf32(label_view, tmp_buffer)) {
+        bool accept_decoded = true;
+        if (ada::idna::is_ascii(tmp_buffer)) {
+          accept_decoded = false;
+        } else {
+          post_map.clear();
+          if (!ada::idna::map(tmp_buffer, post_map) || post_map != tmp_buffer) {
+            accept_decoded = false;
+          }
+          if (accept_decoded) {
+            normalize(post_map);
+            if (post_map != tmp_buffer || post_map.empty() ||
+                !is_label_valid(post_map)) {
+              accept_decoded = false;
+            }
+          }
+        }
+
+        if (accept_decoded) {
 #ifdef ADA_USE_SIMDUTF
-        auto utf8_size = simdutf::utf8_length_from_utf32(tmp_buffer.data(),
-                                                         tmp_buffer.size());
-        size_t old_size = output.size();
-        output.resize(old_size + utf8_size);
-        simdutf::convert_utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
-                                       output.data() + old_size);
-#else
-        auto utf8_size = ada::idna::utf8_length_from_utf32(tmp_buffer.data(),
+          auto utf8_size = simdutf::utf8_length_from_utf32(tmp_buffer.data(),
                                                            tmp_buffer.size());
-        size_t old_size = output.size();
-        output.resize(old_size + utf8_size);
-        ada::idna::utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
-                                 output.data() + old_size);
+          size_t old_size = output.size();
+          output.resize(old_size + utf8_size);
+          simdutf::convert_utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
+                                         output.data() + old_size);
+#else
+          auto utf8_size = ada::idna::utf8_length_from_utf32(tmp_buffer.data(),
+                                                             tmp_buffer.size());
+          size_t old_size = output.size();
+          output.resize(old_size + utf8_size);
+          ada::idna::utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
+                                   output.data() + old_size);
 #endif
+        } else {
+          // ToUnicode never fails. If any step fails, return the original
+          // input sequence for the label.
+          output.append(
+              std::string_view(input.data() + label_start, label_size));
+        }
       } else {
         // ToUnicode never fails.  If any step fails, then the original input
         // sequence is returned immediately in that step.

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -186,8 +186,16 @@ TEST(ada_c, ada_idna) {
       ada_idna_to_unicode(unicode_input.data(), unicode_input.length());
   ASSERT_EQ(std::string_view(unicode.data, unicode.length), ascii_input);
 
+  // Labels that decode to pure ASCII should stay in punycode form.
+  std::string_view ascii_punycode = "xn--abc-";
+  ada_owned_string unicode_ascii = ada_idna_to_unicode(
+      ascii_punycode.data(), ascii_punycode.length());
+  ASSERT_EQ(std::string_view(unicode_ascii.data, unicode_ascii.length),
+            ascii_punycode);
+
   ada_free_owned_string(ascii);
   ada_free_owned_string(unicode);
+  ada_free_owned_string(unicode_ascii);
   SUCCEED();
 }
 


### PR DESCRIPTION
Harden the IDNA ToUnicode pipeline by validating decoded punycode labels before emitting Unicode output.

Previously, labels produced by the punycode decoder were emitted directly after decoding. This patch adds defensive post-decode validation to ensure decoded labels preserve expected IDNA normalization and validity invariants before conversion to UTF-8.

If validation fails the original ACE/punycode label is preserved instead of emitting a potentially malformed or non-canonical Unicode label.

## Changes

* add post-decode validation for punycode labels
* reject ASCII-only decoded labels
* verify mapping stability after decode
* verify normalization stability after decode
* validate decoded labels before UTF-8 emission
* preserve safe fallback behavior by returning the original ACE label when validation fails
* add regression coverage for malformed decoded punycode labels

## Security Impact

This improves the safety and auditability of the IDNA canonicalization pipeline by preventing malformed or non-canonical decoded labels from being emitted as trusted Unicode output.

The change reduces ambiguity in hostname canonicalization and strengthens invariant enforcement in security-sensitive URL and IDNA processing paths.
