### PR TITLE
Fix set_protocol slow-path return consistency

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -384,24 +384,21 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
     unicode::to_lower_ascii(_buffer.data(), _buffer.size());
 
     if constexpr (has_state_override) {
-      // If url's scheme is a special scheme and buffer is not a special scheme,
-      // then return. If url's scheme is not a special scheme and buffer is a
-      // special scheme, then return.
+      // The state-override validation errors below ("return" in the WHATWG URL
+      // parser) leave the URL unchanged. The setter contract is
+      // "true on success, false if the scheme is invalid" -- the fast path
+      // above already returns false here, so the slow path must agree.
       if (is_special() != ada::scheme::is_special(_buffer)) {
-        return true;
+        return false;
       }
 
-      // If url includes credentials or has a non-null port, and buffer is
-      // "file", then return.
       if ((has_credentials() || port.has_value()) && _buffer == "file") {
-        return true;
+        return false;
       }
 
-      // If url's scheme is "file" and its host is an empty host, then return.
-      // An empty host is the empty string.
       if (type == ada::scheme::type::FILE && host.has_value() &&
           host->empty()) {
-        return true;
+        return false;
       }
     }
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -388,14 +388,22 @@ ada_really_inline bool url::parse_scheme(const std::string_view input) {
       // parser) leave the URL unchanged. The setter contract is
       // "true on success, false if the scheme is invalid" -- the fast path
       // above already returns false here, so the slow path must agree.
+
+      // If url's scheme is a special scheme and buffer is not a special scheme,
+      // then return. If url's scheme is not a special scheme and buffer is a
+      // special scheme, then return.
       if (is_special() != ada::scheme::is_special(_buffer)) {
         return false;
       }
 
+      // If url includes credentials or has a non-null port, and buffer is
+      // "file", then return.
       if ((has_credentials() || port.has_value()) && _buffer == "file") {
         return false;
       }
 
+      // If url's scheme is "file" and its host is an empty host, then return.
+      // An empty host is the empty string.
       if (type == ada::scheme::type::FILE && host.has_value() &&
           host->empty()) {
         return false;

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -90,25 +90,22 @@ template <bool has_state_override>
     unicode::to_lower_ascii(_buffer.data(), _buffer.size());
 
     if constexpr (has_state_override) {
-      // If url's scheme is a special scheme and buffer is not a special scheme,
-      // then return. If url's scheme is not a special scheme and buffer is a
-      // special scheme, then return.
+      // The state-override validation errors below ("return" in the WHATWG URL
+      // parser) leave the URL unchanged. The setter contract is
+      // "true on success, false if the scheme is invalid" -- the fast path
+      // above already returns false here, so the slow path must agree.
       if (is_special() != ada::scheme::is_special(_buffer)) {
-        return true;
+        return false;
       }
 
-      // If url includes credentials or has a non-null port, and buffer is
-      // "file", then return.
       if ((has_credentials() || components.port != url_components::omitted) &&
           _buffer == "file") {
-        return true;
+        return false;
       }
 
-      // If url's scheme is "file" and its host is an empty host, then return.
-      // An empty host is the empty string.
       if (type == ada::scheme::type::FILE &&
           components.host_start == components.host_end) {
-        return true;
+        return false;
       }
     }
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -94,15 +94,23 @@ template <bool has_state_override>
       // parser) leave the URL unchanged. The setter contract is
       // "true on success, false if the scheme is invalid" -- the fast path
       // above already returns false here, so the slow path must agree.
+
+      // If url's scheme is a special scheme and buffer is not a special scheme,
+      // then return. If url's scheme is not a special scheme and buffer is a
+      // special scheme, then return.
       if (is_special() != ada::scheme::is_special(_buffer)) {
         return false;
       }
 
+      // If url includes credentials or has a non-null port, and buffer is
+      // "file", then return.
       if ((has_credentials() || components.port != url_components::omitted) &&
           _buffer == "file") {
         return false;
       }
 
+      // If url's scheme is "file" and its host is an empty host, then return.
+      // An empty host is the empty string.
       if (type == ada::scheme::type::FILE &&
           components.host_start == components.host_end) {
         return false;

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -140,6 +140,36 @@ TYPED_TEST(basic_tests, set_protocol_should_return_false_sometimes) {
   SUCCEED();
 }
 
+// Companion to set_protocol_should_return_false_sometimes: the same
+// WHATWG state-override validation errors apply when the target scheme
+// is non-special. parse_scheme's fast path (special target) and slow
+// path (non-special target) must agree.
+TYPED_TEST(basic_tests, set_protocol_non_special_target_returns_false) {
+  // file: with empty host -> cannot change scheme (validation error #4).
+  {
+    auto url = ada::parse<TypeParam>("file:");
+    ASSERT_EQ(url->set_protocol("foo"), false);
+    ASSERT_EQ(url->get_protocol(), "file:");
+  }
+
+  // Special -> non-special is also a validation error (#1, mirror of the
+  // existing readme3 test which goes special -> special and succeeds).
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/");
+    ASSERT_EQ(url->set_protocol("foo"), false);
+    ASSERT_EQ(url->get_protocol(), "https:");
+    ASSERT_EQ(url->get_href(), "https://example.com/");
+  }
+
+  // Non-special -> non-special must still succeed.
+  {
+    auto url = ada::parse<TypeParam>("git://example.com/");
+    ASSERT_EQ(url->set_protocol("svn"), true);
+    ASSERT_EQ(url->get_protocol(), "svn:");
+  }
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, set_protocol_should_return_true_sometimes) {
   auto url = ada::parse<TypeParam>("file:");
   ASSERT_EQ(url->set_host("google.com"), true);


### PR DESCRIPTION
Fix inconsistent return values in the slow-path state-override handling for:

- `url::parse_scheme<true>`
- `url_aggregator::parse_scheme_with_colon<true>`

Several WHATWG validation failures correctly rejected the protocol change and left the URL unchanged, but incorrectly returned `true` when the target scheme was non-special.

The equivalent fast-path logic already returned `false` for the same rejected mutations, resulting in inconsistent API behavior.

This patch aligns both paths with the documented setter contract:
- return `true` on successful mutation
- return `false` when the scheme change is rejected

## Tests

Adds coverage for rejected non-special target scheme mutations and verifies:
- rejected mutations return `false`
- URL state remains unchanged
- valid non-special to non-special transitions still succeed

## Impact

Behavioral consistency fix only.
No changes to successful parsing or mutation behavior.