### PR TITLE
fix(url_pattern): bound check tokenizer against truncated/invalid UTF-8

### DIFF
--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -379,6 +379,17 @@ constexpr void Tokenizer::get_next_code_point() {
     number_bytes = 4;
     ada_log("Tokenizer::get_next_code_point four bytes");
   }
+  // The ADA_ASSERT_TRUE below is compiled out in release builds, so without
+  // an explicit runtime check an invalid leading byte (no branch matched, so
+  // number_bytes is still 0) or a truncated multi-byte sequence at the end
+  // of input would read past the end of the std::string_view in the loop
+  // below. Treat such bytes as a single raw byte to guarantee forward
+  // progress and stay within bounds.
+  if (number_bytes == 0 || number_bytes > input.size() - next_index) {
+    code_point = first_byte;
+    next_index++;
+    return;
+  }
   ADA_ASSERT_TRUE(number_bytes + next_index <= input.size());
 
   for (size_t i = 1 + next_index; i < number_bytes + next_index; ++i) {


### PR DESCRIPTION
## Bug

`ada::url_pattern_helpers::Tokenizer::get_next_code_point()`
(`include/ada/url_pattern_helpers-inl.h:349`) decodes a UTF-8 code point from
its `std::string_view input` and is documented as assuming a "valid,
non-truncated UTF-8 stream." It guards the multi-byte read path with

```
ADA_ASSERT_TRUE(number_bytes + next_index <= input.size());
```

but `ADA_ASSERT_TRUE` is compiled to a no-op when `NDEBUG` is defined
(`include/ada/common_defs.h:223-226`), i.e. in every release build of the
library. With the check gone, two cases over-read the buffer:

1. A truncated multi-byte leader at the end of `input` (e.g. a trailing
   `0xC2`, `0xE0`, `0xF0`): the leader matches one of the `if` branches and
   `number_bytes` is set to 2/3/4, but there are not that many bytes left.
2. A byte that is not a valid leader at all (e.g. `0xFF`, or a bare
   continuation byte like `0x80`): none of the branches match, `number_bytes`
   stays `0`, and the assertion `number_bytes + next_index <= input.size()`
   is vacuously true – but `code_point` ends up uninitialised relative to
   the input, `next_index` does not advance, and on the `\\`-escape path
   the caller has already committed to consuming "the next code point".

The decode loop

```cpp
for (size_t i = 1 + next_index; i < number_bytes + next_index; ++i) {
  unsigned char byte = input[i];
  code_point = (code_point << 6) | (byte & 0x3F);
}
```

then reads `input[input.size()]` and beyond, since the loop bound is
`number_bytes + next_index` rather than `input.size()`. The tokenizer is
fed raw user-provided bytes from `parse_pattern_string` /
`constructor_string_parser::parse` (`include/ada/url_pattern_helpers-inl.h:865`)
without any UTF-8 sanitisation, so the byte sequence is fully attacker-
controlled.

## Reproducer

Built with `-fsanitize=address` against the upstream sources:

```cpp
#include "ada.h"
int main() {
  const size_t n = 2;
  char *data = (char*)malloc(n);
  data[0] = '\\';
  data[1] = (char)0xC2;          // 2-byte UTF-8 leader, no continuation
  std::string_view input(data, n);
  std::variant<std::string_view, ada::url_pattern_init> v{input};
  auto p = ada::parse_url_pattern<
      ada::url_pattern_regex::std_regex_provider>(std::move(v));
  free(data);
}
```

ASAN output:

```
==67232==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1 at 0x602000000112 thread T0
    #0 ada::url_pattern_helpers::tokenize(...) url_pattern_helpers.cpp:636
    #1 ada::url_pattern_helpers::constructor_string_parser<...>::parse(...)
       url_pattern_helpers-inl.h:865
    #2 ada::parser::parse_url_pattern_impl<...>(...)         parser-inl.h:29
    #3 ada::parse_url_pattern<...>(...)              implementation-inl.h:23
    #4 main                                              oob_repro.cpp:36
0x602000000112 is located 0 bytes after 2-byte region
```

The same crash reproduces for any truncated 3- or 4-byte leader at the end
of input, and for invalid leaders / lone continuation bytes (`0xFF`, `0x80`,
`0xF8`).

## Fix

Add an explicit runtime bounds check inside `get_next_code_point()` that
covers both failure modes:

* `number_bytes == 0`            – leading byte didn't match any branch.
* `number_bytes > input.size() - next_index` – not enough bytes remain.

In both cases the byte is treated as a raw single-byte code point and
`next_index` is advanced by one, guaranteeing forward progress and keeping
all subsequent reads inside the buffer. This mirrors what other decoders
do for ill-formed sequences and removes the dependence on `NDEBUG`.

The change is local to the callee in `include/ada/url_pattern_helpers-inl.h`
and does not require callers to pre-sanitise their input.

## Verification

* Repro program: ASAN report disappears; `parse_url_pattern` simply
  returns an error result for the malformed pattern.
* `cmake --build build -j && ctest --output-on-failure -j` – all 279
  tests pass.
* Additional spot-check on `0xFF`, `0x80`, `0xC2`, `0xE0`, `0xF0`,
  `0xF8` single-byte inputs: all return cleanly (no OOB) with
  `parsed=0`.