### PR TITLE
enforce bidi first-character rule in is_label_valid

### DIFF
--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -9426,6 +9426,13 @@ bool is_label_valid(const std::u32string_view label) {
     } else {
       // Eval as RTL
 
+      // The first character must be R or AL; a leading AN (or any other
+      // direction) does not start a valid RTL label.
+      const direction first_dir = find_direction(label[0]);
+      if (first_dir != direction::R && first_dir != direction::AL) {
+        return false;
+      }
+
       bool has_an = false;
       bool has_en = false;
       for (size_t i = 0; i <= last_non_nsm_char; i++) {

--- a/tests/wpt/toascii.json
+++ b/tests/wpt/toascii.json
@@ -137,6 +137,21 @@
     "output": null
   },
   {
+    "comment": "CheckBidi: Bidi label starting with EN code point",
+    "input": "1\u0627",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: Bidi label starting with AN code point",
+    "input": "\u0660",
+    "output": null
+  },
+  {
+    "comment": "CheckBidi: Bidi label starting with AN followed by AL",
+    "input": "\u0660\u0627",
+    "output": null
+  },
+  {
     "input": "xn--a-yoc",
     "output": null
   },


### PR DESCRIPTION
Comparing ada's IDNA output against a strict RFC 5893 reference turned up a gap in is_label_valid: a bidi label whose first code point is AN or EN (`1ا`, `٠`, `٠ا`) is accepted, though condition 1 requires the leading character to be L, R, or AL. The RTL branch never checked the leading direction, so reject there. The added toascii cases match the reference, and the existing suite stays green.