### PR TITLE
fix out-of-bounds read in valid_name_code_point

### DIFF
--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -10413,7 +10413,7 @@ bool valid_name_code_point(char32_t code_point, bool first) {
     auto iter = std::lower_bound(
         std::begin(id_continue), std::end(id_continue), code_point,
         [](const uint32_t* range, uint32_t cp) { return range[1] < cp; });
-    return iter != std::end(id_start) && code_point >= (*iter)[0];
+    return iter != std::end(id_continue) && code_point >= (*iter)[0];
   }
 }
 }  // namespace ada::idna

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -372,6 +372,22 @@ TEST(wpt_urlpattern_tests, malformed_utf8_large_payload_no_nonprogress) {
   EXPECT_EQ(result->back().index, payload_size);
 }
 
+TEST(wpt_urlpattern_tests, name_code_point_above_id_continue_in_bounds) {
+  // A code point greater than the last id_continue range (> U+E01EF) must be
+  // rejected as a non-first name code point without reading past the table.
+  EXPECT_FALSE(ada::idna::valid_name_code_point(char32_t(0x10FFFF), false));
+  EXPECT_FALSE(ada::idna::valid_name_code_point(char32_t(0xE01F0), false));
+  // A real ID_Continue code point still validates.
+  EXPECT_TRUE(ada::idna::valid_name_code_point(U'a', false));
+
+  // End-to-end: a ":name" whose second code point is U+10FFFF (F4 8F BF BF)
+  // tokenizes without an out-of-bounds read.
+  std::string pattern(":a\xF4\x8F\xBF\xBF", 6);
+  auto tokens = ada::url_pattern_helpers::tokenize(
+      pattern, ada::url_pattern_helpers::token_policy::lenient);
+  ASSERT_TRUE(tokens);
+}
+
 TEST(wpt_urlpattern_tests, parse_pattern_string_basic_tests) {
   auto part_list = ada::url_pattern_helpers::parse_pattern_string(
       "*", ada::url_pattern_compile_component_options::DEFAULT,


### PR DESCRIPTION
Found while fuzzing the URLPattern constructor parser. valid_name_code_point's non-first branch runs std::lower_bound over id_continue but then checks the result against std::end(id_start), a different array. A name code point past the last id_continue range (above U+E01EF, e.g. U+10FFFF in a `:name`) makes lower_bound return end(id_continue), so the wrong end check passes and `(*iter)[0]` reads one element past id_continue.