### PR TITLE
emit nullopt for unmatched groups in std_regex_provider::regex_search

### DIFF
--- a/src/url_pattern_regex.cpp
+++ b/src/url_pattern_regex.cpp
@@ -46,6 +46,12 @@ std_regex_provider::regex_search(std::string_view input,
   for (size_t i = 1; i < match_result.size(); ++i) {
     if (auto entry = match_result[i]; entry.matched) {
       matches.emplace_back(entry.str());
+    } else {
+      // A capture group that did not participate in the match is undefined,
+      // not absent. Emitting nullopt keeps the result aligned by position with
+      // the component's group name list; dropping it shifts every later group
+      // onto the wrong name.
+      matches.emplace_back(std::nullopt);
     }
   }
   return matches;

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -147,6 +147,29 @@ TEST(wpt_urlpattern_tests, multiple_capture_groups_correct_mapping) {
   SUCCEED();
 }
 
+// An optional capture group that does not participate in the match is
+// undefined, not absent. The reported groups must stay aligned by position
+// with the group name list, so a later group is not attributed to the
+// skipped group's name.
+TEST(wpt_urlpattern_tests, unmatched_optional_group_keeps_alignment) {
+  auto init = ada::url_pattern_init{};
+  init.pathname = "(a)?(b)";
+  auto pattern = ada::parse_url_pattern<regex_provider>(init);
+  ASSERT_TRUE(pattern) << "Pattern should parse successfully";
+
+  auto input = ada::url_pattern_init{};
+  input.pathname = "b";
+  auto result = pattern->exec(input, nullptr);
+  ASSERT_TRUE(result) << "exec should succeed";
+  ASSERT_TRUE(result->has_value()) << "should have a match";
+
+  auto& pathname_groups = result->value().pathname.groups;
+  ASSERT_EQ(pathname_groups.size(), 2u);
+  EXPECT_FALSE(pathname_groups.at("0").has_value())
+      << "skipped optional group must be undefined";
+  EXPECT_EQ(pathname_groups.at("1").value_or(""), "b");
+}
+
 // Verify that patterns with parentheses in regex values don't parse
 // (URLPattern spec doesn't allow unescaped parentheses in custom regex).
 // This documents the expected behavior and ensures we don't crash.


### PR DESCRIPTION
Noticed regex_search only pushes capture groups whose submatch participated, while create_component_match_result maps the returned vector onto the group name list by position. An optional group that does not match (e.g. pathname `(a)?(b)` against `b`) drops a slot, so `b` is reported under name "0" instead of "1" and group "1" disappears. Push nullopt for non-participating groups so undefined groups stay aligned with their names. The harness already skips WPT cases with null group values, which is why this was not caught.