### PR TITLE
Remove the Nim wrapper from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ The following libraries are maintained by the Ada team and available under [Ada 
 - [Python](https://github.com/TkTech/can_ada): Python bindings for Ada
 - [React Native](https://github.com/KusStar/react-native-fast-url): A Fast URL and URLSearchParams polyfill for React Native.
 - [D](https://github.com/kassane/ada-d): D bindings for Ada, `@nogc`, `nothrow` and `@safe` compat.
-- [Nim](https://github.com/ferus-web/nim-ada): High-level Nim abstraction over Ada, uses ORC move semantics to safely and efficiently handle memory.
 
 ## Usage
 


### PR DESCRIPTION
I'm no longer maintaining [the wrapper for Ada in Nim](https://github.com/ferus-web/nim-ada), and it seems to be broken when compiled against recent versions of Ada.

Sorry for that!
