### PR TITLE
fix: normalized Windows drive letter must be exactly two code points

### DIFF
--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -47,7 +47,7 @@ constexpr bool is_windows_drive_letter(std::string_view input) noexcept {
 
 constexpr bool is_normalized_windows_drive_letter(
     std::string_view input) noexcept {
-  return input.size() >= 2 && (is_alpha(input[0]) && (input[1] == ':'));
+  return input.size() == 2 && (is_alpha(input[0]) && (input[1] == ':'));
 }
 
 ada_really_inline constexpr uint64_t try_parse_ipv4_fast(

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -108,6 +108,18 @@ TYPED_TEST(basic_tests, readme2) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, file_shorten_path_normalized_drive_letter_only) {
+  // https://url.spec.whatwg.org/#shorten-a-urls-path : a file path's first
+  // segment is protected from ".." only when it is a *normalized Windows drive
+  // letter*, which is exactly two code points (an ASCII alpha followed by ":").
+  // Longer segments that merely start with "<alpha>:" must be popped.
+  ASSERT_EQ(ada::parse<TypeParam>("file:c:x/..")->get_href(), "file:///");
+  ASSERT_EQ(ada::parse<TypeParam>("file:u:p@h/..")->get_href(), "file:///");
+  // A real drive letter is still preserved.
+  ASSERT_EQ(ada::parse<TypeParam>("file:c:/..")->get_href(), "file:///c:/");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, readme2free) {
   auto url = ada::parse("https://www.google.com");
   url->set_username("username");


### PR DESCRIPTION
`is_normalized_windows_drive_letter` accepted any input of length `>= 2` beginning with `<ASCII alpha>:`. Per the URL Standard a [normalized Windows drive letter](https://url.spec.whatwg.org/#normalized-windows-drive-letter) is a [Windows drive letter](https://url.spec.whatwg.org/#windows-drive-letter), which is two code points, so the check should require exactly two.

The loose length let [shorten a url's path](https://url.spec.whatwg.org/#shorten-a-urls-path) treat a longer first segment that merely starts with `<alpha>:` as a drive letter and skip popping it on `..`:

```
ada::parse("file:c:x/..")    -> "file:///c:x/"    (expected "file:///")
ada::parse("file:u:p@h/..")  -> "file:///u:p@h/"  (expected "file:///")
```

A real drive letter is unaffected: `file:c:/..` still yields `file:///c:/`.

The fix changes `>= 2` to `== 2`. All three call sites (`shorten_path` and the base-path drive-letter check in `parser.cpp`) pass a single path segment that should match only an exact drive letter, so the tighter check is correct for each.

Verified against the full WHATWG URL web-platform-tests `urltestdata` (no regressions) and added a regression test.