### PR TITLE
fix: set empty host on a non-special URL without an authority

### DIFF
--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -677,6 +677,10 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
         } else if (has_dash_dot()) {
           add_authority_slashes_if_needed();
           delete_dash_dot();
+        } else {
+          // The url has no authority yet (e.g. "foo:/bar"); setting an empty
+          // host must still give it an (empty) authority, matching ada::url.
+          add_authority_slashes_if_needed();
         }
         return check_url_size();
       }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -120,6 +120,20 @@ TYPED_TEST(basic_tests, file_shorten_path_normalized_drive_letter_only) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, set_empty_host_on_non_special_without_authority) {
+  // A non-special URL with a non-opaque path but no authority (e.g. "foo:/bar")
+  // must gain an empty authority when its host is set to the empty string. The
+  // WHATWG host setter only returns early for an opaque path, and ada::url
+  // already behaves this way; url_aggregator must match.
+  auto a = ada::parse<TypeParam>("non-special:/x");
+  ASSERT_TRUE(a->set_host(""));
+  ASSERT_EQ(a->get_href(), "non-special:///x");
+  auto b = ada::parse<TypeParam>("sc:/x");
+  ASSERT_TRUE(b->set_hostname(""));
+  ASSERT_EQ(b->get_href(), "sc:///x");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, readme2free) {
   auto url = ada::parse("https://www.google.com");
   url->set_username("username");


### PR DESCRIPTION
`url_aggregator::set_host` / `set_hostname` leaves the URL unchanged when an empty host is set on a non-special URL that has a non-opaque path but no authority (e.g. `foo:/bar`). `ada::url` already gives it an empty authority, so the two implementations disagree:

```cpp
auto a = ada::parse<ada::url>("non-special:/x");
a->set_host("");            // -> "non-special:///x"  (correct)

auto b = ada::parse<ada::url_aggregator>("non-special:/x");
b->set_host("");            // -> "non-special:/x"    (wrong, no-op)
```

Per the [host setter](https://url.spec.whatwg.org/#dom-url-host) steps the early return only happens for an opaque path. `non-special:/x` has a list path (`has_opaque_path()` is false), so an empty host must be set, which for a URL without an authority means adding one. `jsdom/whatwg-url` (the spec reference implementation, passing all wpt setter cases) also yields `non-special:///x`.

In `set_host_or_hostname` the empty-host / non-special branch handled the existing-hostname and dash-dot cases but otherwise fell through to a no-op. It now calls `add_authority_slashes_if_needed()`, matching `ada::url`.

Verified against the full WHATWG URL web-platform-tests `urltestdata` and `setters_tests` for both `url` and `url_aggregator` (no regressions), plus a typed regression test.