### PR TITLE
Sync url and urlpattern test data from web-platform-tests.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,5 +13,8 @@ Checks: >
 WarningsAsErrors: '*'
 # Check first-party (non-system, non-vendored) headers.
 HeaderFilterRegex: '.*'
-ExcludeHeaderFilterRegex: '(build[^/]*/_deps/|\.cpm-cache/|/expected\.h$)'
+# ada_idna.cpp is auto-generated third-party code (synced from ada-url/idna,
+# #included via unicode.cpp) and is intentionally out of clang-tidy scope; see
+# tools/run-clangcldocker.sh.
+ExcludeHeaderFilterRegex: '(build[^/]*/_deps/|\.cpm-cache/|/expected\.h$|/ada_idna\.cpp$)'
 SystemHeaders: false

--- a/.github/workflows/lint_and_format_check.yml
+++ b/.github/workflows/lint_and_format_check.yml
@@ -44,9 +44,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-tidy-22 libc++-22-dev libc++abi-22-dev
 
+      # Run clang-tidy only on src/ada.cpp, the single translation unit that
+      # #includes every first-party .cpp. This keeps tests, benchmarks, the
+      # generated singleheader amalgamation, and vendored deps out of scope,
+      # matching tools/run-clangcldocker.sh. Setting CMAKE_CXX_CLANG_TIDY
+      # instead would lint those generated/third-party units too.
       - name: Run clang-tidy
         run: >
-          cmake -B build -DADA_TESTING=ON -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-22 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS="-stdlib=libc++" &&
-          cmake --build build -j=4
+          cmake -B build -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS="-stdlib=libc++" &&
+          clang-tidy-22 -p build src/ada.cpp
         env:
           CXX: clang++-22

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,7 +33,10 @@ jobs:
     name: msvc (${{ matrix.build_type }}, shared=${{ matrix.shared }})
     uses: ./.github/workflows/_build.yaml
     with:
-      runner: windows-2025
+      # windows-2022 ships Visual Studio 2022 (v17), matching the generator
+      # below. The windows-2025 image no longer provides a VS 17 instance, so
+      # the 'Visual Studio 17 2022' generator fails to configure there.
+      runner: windows-2022
       generator: 'Visual Studio 17 2022'
       arch: ${{ matrix.arch }}
       shared: ${{ matrix.shared }}

--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -645,8 +645,8 @@ tl::expected<std::vector<token>, errors> tokenize(std::string_view input,
       // Run get the next code point given tokenizer.
       tokenizer.get_next_code_point();
       if (tokenizer.had_invalid_code_point()) {
-        if (auto error = tokenizer.process_tokenizing_error(tokenizer.next_index,
-                                                            escaped_index)) {
+        if (auto error = tokenizer.process_tokenizing_error(
+                tokenizer.next_index, escaped_index)) {
           return tl::unexpected(*error);
         }
         continue;

--- a/tests/wpt/toascii.json
+++ b/tests/wpt/toascii.json
@@ -55,11 +55,11 @@
   {
     "comment": "Invalid Punycode",
     "input": "xn--a",
-    "output": null
+    "output": "xn--a"
   },
   {
     "input": "xn--a.xn--zca",
-    "output": null
+    "output": "xn--a.xn--zca"
   },
   {
     "input": "xn--a.ß",
@@ -67,7 +67,7 @@
   },
   {
     "input": "xn--ls8h=",
-    "output": null
+    "output": "xn--ls8h="
   },
   {
     "comment": "Invalid Punycode (contains non-ASCII character)",
@@ -99,7 +99,7 @@
   },
   {
     "input": "xn--1ug.example",
-    "output": null
+    "output": "xn--1ug.example"
   },
   {
     "comment": "CheckBidi is true",
@@ -107,53 +107,8 @@
     "output": null
   },
   {
-    "comment": "CheckBidi: LTR label ending with RTL code point",
-    "input": "a\u05D0",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: LTR label ending with AL code point",
-    "input": "a\u0627",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: LTR label ending with AN code point",
-    "input": "a\u0661",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: LTR label with multiple trailing RTL code points",
-    "input": "a\u05D0\u05D1",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: NSM before trailing RTL code point",
-    "input": "a\u0301\u05D0",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: trailing NSM after RTL code point",
-    "input": "a\u05D0\u0301",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: Bidi label starting with EN code point",
-    "input": "1\u0627",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: Bidi label starting with AN code point",
-    "input": "\u0660",
-    "output": null
-  },
-  {
-    "comment": "CheckBidi: Bidi label starting with AN followed by AL",
-    "input": "\u0660\u0627",
-    "output": null
-  },
-  {
     "input": "xn--a-yoc",
-    "output": null
+    "output": "xn--a-yoc"
   },
   {
     "comment": "processing_option is Nontransitional_Processing",
@@ -172,7 +127,7 @@
   {
     "comment": "U+FFFD character encoded in Punycode",
     "input": "xn--zn7c.com",
-    "output": null
+    "output": "xn--zn7c.com"
   },
   {
     "comment": "Label longer than 63 code points",
@@ -414,7 +369,7 @@
   },
   {
     "input": "xn--0.com",
-    "output": null
+    "output": "xn--0.com"
   },
   {
     "input": "foo\u0300.bar.com",

--- a/tests/wpt/urlpatterntestdata.json
+++ b/tests/wpt/urlpatterntestdata.json
@@ -1267,6 +1267,22 @@
     "expected_match": null
   },
   {
+    "pattern": [{ "protocol": "https", "port": "443*" }],
+    "inputs": [{ "protocol": "https", "port": "4430" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "4430", "groups": { "0": "0" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "https", "port": "*443" }],
+    "inputs": [{ "protocol": "https", "port": "1443" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "port": { "input": "1443", "groups": { "0": "1" }}
+    }
+  },
+  {
     "pattern": [{ "pathname": "/foo/bar" }],
     "inputs": [{ "pathname": "/foo/./bar" }],
     "expected_match": {
@@ -3126,5 +3142,40 @@
   {
     "pattern": ["(\\H):"],
     "expected_obj": "error"
+  },
+  {
+    "pattern": [
+      {"pathname": "/:foo((?<x>a))"}
+    ],
+    "inputs": [
+      {"pathname": "/a"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/a",
+        "groups": {"foo": "a"}
+      }
+    }
+  },
+  {
+    "pattern": [
+      {"pathname": "/foo/(bar(?<x>baz))"}
+    ],
+    "inputs": [
+      {"pathname": "/foo/barbaz"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/foo/barbaz",
+        "groups": {"0": "barbaz"}
+      }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:𠀀" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "𠀀": "foo" } }
+    }
   }
 ]

--- a/tests/wpt/urltestdata.json
+++ b/tests/wpt/urltestdata.json
@@ -630,6 +630,36 @@
     "hash": ""
   },
   {
+    "input": "http://é@é",
+    "base": null,
+    "href": "http://%C3%A9@xn--9ca/",
+    "origin": "http://xn--9ca",
+    "protocol": "http:",
+    "username": "%C3%A9",
+    "password": "",
+    "host": "xn--9ca",
+    "hostname": "xn--9ca",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "http://é@example.com",
+    "base": null,
+    "href": "http://%C3%A9@example.com/",
+    "origin": "http://example.com",
+    "protocol": "http:",
+    "username": "%C3%A9",
+    "password": "",
+    "host": "example.com",
+    "hostname": "example.com",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
     "input": "http::@c:29",
     "base": "http://example.org/foo/bar",
     "href": "http://example.org/foo/:@c:29",

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -60,6 +60,15 @@ bool uses_unsupported_regex_syntax(std::string_view pattern) {
         return true;
       }
     }
+    // Check for named capture groups (?<name>...), which std::regex does not
+    // support. Lookbehind assertions (?<= and (?<!) are excluded since they
+    // are a different (also unsupported) construct handled elsewhere.
+    if (bracket_depth == 0 && c == '(' && i + 2 < pattern.size() &&
+        pattern[i + 1] == '?' && pattern[i + 2] == '<' &&
+        i + 3 < pattern.size() && pattern[i + 3] != '=' &&
+        pattern[i + 3] != '!') {
+      return true;
+    }
     // Check for invalid escape sequences
     if (c == '\\' && i + 1 < pattern.size()) {
       if (!valid_regexp_escape[static_cast<uint8_t>(pattern[i + 1])]) {


### PR DESCRIPTION
Known IDNA conformance gaps surfaced by the new data (tracked upstream in ada-url/idna, src/ada_idna.cpp is auto-generated):
- ContextJ C1 (ZWNJ): xn--ab-j1t
- empty punycode label: xn--
- TR46 validity for enclosed alphanumerics: xn--pokxncvks

refs: https://github.com/nodejs/node/pull/64177