### PR TITLE
ci: build Windows MSVC with Visual Studio 2026 and CMake 4.2

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -57,6 +57,10 @@ on:
         type: string
         required: false
         default: ''
+      cmake_version:
+        type: string
+        required: false
+        default: ''
 
       # Post-build actions
       run_tests:
@@ -124,6 +128,14 @@ jobs:
       - name: Setup Runner
         if: ${{ !inputs.use_run_on_arch }}
         uses: ./.github/actions/setup-runner
+
+      # Some generators (e.g. 'Visual Studio 18 2026') need a newer CMake than
+      # the runner ships. When cmake_version is set, install that exact version.
+      - name: Setup CMake
+        if: ${{ !inputs.use_run_on_arch && inputs.cmake_version != '' }}
+        uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
+        with:
+          cmakeVersion: ${{ inputs.cmake_version }}
 
       - name: Setup environment
         if: ${{ !inputs.use_run_on_arch && inputs.setup_script != '' }}

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -129,8 +129,8 @@ jobs:
         if: ${{ !inputs.use_run_on_arch }}
         uses: ./.github/actions/setup-runner
 
-      # Some generators (e.g. 'Visual Studio 18 2026') need a newer CMake than
-      # the runner ships. When cmake_version is set, install that exact version.
+      # Some generators (e.g. 'Visual Studio 18 2026') require CMake >= 4.2.
+      # When cmake_version is set, install that exact version for determinism.
       - name: Setup CMake
         if: ${{ !inputs.use_run_on_arch && inputs.cmake_version != '' }}
         uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,11 +33,14 @@ jobs:
     name: msvc (${{ matrix.build_type }}, shared=${{ matrix.shared }})
     uses: ./.github/workflows/_build.yaml
     with:
-      # windows-2022 ships Visual Studio 2022 (v17), matching the generator
-      # below. The windows-2025 image no longer provides a VS 17 instance, so
-      # the 'Visual Studio 17 2022' generator fails to configure there.
-      runner: windows-2022
-      generator: 'Visual Studio 17 2022'
+      # windows-2025 now ships Visual Studio 2026 (v18); the windows-2022 label
+      # has been retired and redirects to the VS 2026 image, so the old
+      # 'Visual Studio 17 2022' generator can no longer find a VS instance.
+      # The 'Visual Studio 18 2026' generator requires CMake >= 4.2, so we pin
+      # CMake to a matching version via cmake_version below.
+      runner: windows-2025
+      generator: 'Visual Studio 18 2026'
+      cmake_version: '4.2.6'
       arch: ${{ matrix.arch }}
       shared: ${{ matrix.shared }}
       build_type: ${{ matrix.build_type }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,11 +33,11 @@ jobs:
     name: msvc (${{ matrix.build_type }}, shared=${{ matrix.shared }})
     uses: ./.github/workflows/_build.yaml
     with:
-      # windows-2025 now ships Visual Studio 2026 (v18); the windows-2022 label
-      # has been retired and redirects to the VS 2026 image, so the old
-      # 'Visual Studio 17 2022' generator can no longer find a VS instance.
-      # The 'Visual Studio 18 2026' generator requires CMake >= 4.2, so we pin
-      # CMake to a matching version via cmake_version below.
+      # windows-2025 ships Visual Studio 2026 (v18), so we run MSVC builds on
+      # that image and use the matching Visual Studio generator below.
+      # The 'Visual Studio 18 2026' generator requires CMake >= 4.2; optionally
+      # pin CMake via cmake_version for determinism / to enforce that minimum.
+      # (cmake_version is opt-in; other jobs keep the runner default CMake)
       runner: windows-2025
       generator: 'Visual Studio 18 2026'
       cmake_version: '4.2.6'


### PR DESCRIPTION
## Problem

The Windows `msvc` CI jobs are failing at the **Configure** step:

```
CMake Error at CMakeLists.txt:3 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

GitHub has retired the `windows-2022` runner label — it now provisions the `windows-2025-vs2026` image (Windows Server 2025 with **Visual Studio 2026 only**). The `Visual Studio 17 2022` generator therefore has no VS 2022 instance to target. (`clangcl` was unaffected because it uses Ninja + clang-cl, not the VS generator.)

## Fix

- **`windows.yml`**: switch the `msvc` job from `windows-2022` / `Visual Studio 17 2022` to `windows-2025` / `Visual Studio 18 2026`.
- **`_build.yaml`**: the `Visual Studio 18 2026` generator requires CMake >= 4.2, so add an optional `cmake_version` input and a `Setup CMake` step (SHA-pinned `lukka/get-cmake`). Pin the `msvc` job to CMake **4.2.6**.

The `cmake_version` input is opt-in (empty default), so all other jobs (Linux, macOS, clangcl, cross-compile) are unchanged.

## Notes

- The runner's default CMake is already 4.3.4, so the pin is primarily for determinism / to guarantee the >= 4.2 floor the generator needs.
- YAML validated locally. Real verification is the Windows workflow run on this PR.
