### PR TITLE
keep explicit port 0 when set_protocol targets a non-special scheme

### DIFF
--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -76,10 +76,12 @@ template <bool has_state_override>
       // This is uncommon.
       uint16_t urls_scheme_port = get_special_port();
 
-      // If url's port is url's scheme's default port, then set url's port to
-      // null.
-      if (components.port == urls_scheme_port) {
-        clear_port();
+      if (urls_scheme_port) {
+        // If url's port is url's scheme's default port, then set url's port to
+        // null.
+        if (components.port == urls_scheme_port) {
+          clear_port();
+        }
       }
     }
   } else {  // slow path
@@ -123,10 +125,12 @@ template <bool has_state_override>
       // This is uncommon.
       uint16_t urls_scheme_port = get_special_port();
 
-      // If url's port is url's scheme's default port, then set url's port to
-      // null.
-      if (components.port == urls_scheme_port) {
-        clear_port();
+      if (urls_scheme_port) {
+        // If url's port is url's scheme's default port, then set url's port to
+        // null.
+        if (components.port == urls_scheme_port) {
+          clear_port();
+        }
       }
     }
   }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -178,6 +178,17 @@ TYPED_TEST(basic_tests, set_protocol_should_return_true_sometimes) {
   SUCCEED();
 }
 
+// Changing to a non-special scheme (default port 0) must not drop an explicit
+// port of 0. The port is only cleared when it equals the target scheme's
+// default port, and a non-special scheme has none.
+TYPED_TEST(basic_tests, set_protocol_keeps_zero_port_non_special_target) {
+  auto url = ada::parse<TypeParam>("a://h:0");
+  ASSERT_EQ(url->set_protocol("b"), true);
+  ASSERT_EQ(url->get_port(), "0");
+  ASSERT_EQ(url->get_href(), "b://h:0");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, readme4) {
   auto url = ada::parse<TypeParam>("https://www.google.com");
   url->set_host("github.com");


### PR DESCRIPTION
When set_protocol changes to a non-special scheme, url_aggregator::parse_scheme still runs the step that clears the port if it equals the scheme's default port, but get_special_port() returns 0 for a non-special scheme, so a URL with an explicit port of 0 has that port dropped (a://h:0 set to b: becomes b://h, while ada::url keeps b://h:0). ada::url already guards the clear with a non-zero check, so this adds the same guard to both parse_scheme paths and the two backends agree again.