### PR TITLE
fix canonicalize_hostname fast path skipping ipv4 and idna

### DIFF
--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "ada/character_sets.h"
+#include "ada/checkers.h"
 #include "ada/helpers.h"
 #include "ada/scheme.h"
 #include "ada/unicode.h"
@@ -314,13 +315,19 @@ tl::expected<std::string, errors> canonicalize_hostname(
     return "";
   }
 
-  // Fast path: simple hostnames (lowercase ASCII, digits, -, .) need no IDNA
+  // Fast path: simple hostnames (lowercase ASCII, digits, -, .) need no IDNA.
+  // The simple character set also covers IPv4-shaped hosts and "xn--" labels,
+  // which the slow path rewrites: it reserializes the address ("0" ->
+  // "0.0.0.0", "0x7f.1" -> "127.0.0.1") and runs IDNA/punycode validation
+  // (rejecting an invalid ACE label such as "xn--a"). Exclude those so the fast
+  // path can't return a non-canonical or wrongly-accepted hostname.
   bool needs_processing = false;
   for (char c : input) {
     needs_processing |=
         !(char_class_table[static_cast<uint8_t>(c)] & CHAR_SIMPLE_HOSTNAME);
   }
-  if (!needs_processing) {
+  if (!needs_processing && !checkers::is_ipv4(input) &&
+      input.find("xn--") == std::string_view::npos) {
     return std::string(input);
   }
 

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -429,6 +429,48 @@ TEST(wpt_urlpattern_tests, basic_tests) {
   SUCCEED();
 }
 
+// A plain hostname must be canonicalized the same way regardless of whether it
+// hits the fast path in canonicalize_hostname. IPv4-shaped hosts are
+// reserialized and "xn--" labels are IDNA-validated, so the fast path must not
+// return them verbatim.
+TEST(wpt_urlpattern_tests, hostname_ipv4_and_idna_canonicalization) {
+  {
+    auto init = ada::url_pattern_init{};
+    init.hostname = "0";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_hostname(), "0.0.0.0");
+    // The compiled pattern must match the canonical form of the same host.
+    auto input = ada::url_pattern_init{};
+    input.hostname = "0.0.0.0";
+    auto matched = url->test(input, nullptr);
+    ASSERT_TRUE(matched);
+    EXPECT_TRUE(*matched);
+  }
+  {
+    auto init = ada::url_pattern_init{};
+    init.hostname = "0x7f.1";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_hostname(), "127.0.0.1");
+  }
+  {
+    // Invalid ACE label: the slow path rejects it, the fast path must too.
+    auto init = ada::url_pattern_init{};
+    init.hostname = "xn--a";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    EXPECT_FALSE(url);
+  }
+  {
+    // A normal domain still takes the fast path unchanged.
+    auto init = ada::url_pattern_init{};
+    init.hostname = "example.com";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_hostname(), "example.com");
+  }
+}
+
 // Tests are taken from WPT
 // https://github.com/web-platform-tests/wpt/blob/0c1d19546fd4873bb9f4147f0bbf868e7b4f91b7/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 TEST(wpt_urlpattern_tests, has_regexp_groups) {


### PR DESCRIPTION
canonicalize_hostname takes a fast path that returns the input unchanged when every byte is lowercase ascii, a digit, '-' or '.'. that set also matches ipv4-shaped hosts and xn-- labels, but the slow path it skips runs the value through a special-scheme dummy url which reserializes the address and validates idna, so the fast path leaves '0' as '0' instead of '0.0.0.0', '0x7f.1' instead of '127.0.0.1', and accepts an invalid ace label like 'xn--a' that set_hostname rejects. that makes a urlpattern built from a bare-number or punycode hostname disagree with its own canonical form. keep the fast path but fall through to the slow path when checkers::is_ipv4 is true or the value contains 'xn--'.