### PR TITLE
normalize leading-zero ports in canonicalize_port

### DIFF
--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -391,8 +391,18 @@ tl::expected<std::string, errors> canonicalize_port(
   std::string_view digits_to_parse =
       std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
 
-  // Here we have that a range of ASCII digit characters identified
-  // by digits_to_parse. It is none empty.
+  // Here we have a range of ASCII digit characters identified by
+  // digits_to_parse. It is non-empty. The port state of the URL parser reads
+  // it as an integer, so leading zeros are part of the number: "0080" is 80
+  // and "065535" is 65535, not a six-digit overflow. Only the significant
+  // digits count toward the 5-digit maximum, matching the fast path in
+  // implementation.cpp.
+  size_t first_significant = digits_to_parse.find_first_not_of('0');
+  if (first_significant == std::string_view::npos) {
+    // The value is all zeros, i.e. port 0.
+    return "0";
+  }
+  digits_to_parse.remove_prefix(first_significant);
   // We want to determine whether it is a valid port number (0-65535).
   // Clearly, if the length is greater than 5, it is invalid.
   // If the length is 5, we need to compare lexicographically to "65535".
@@ -402,10 +412,6 @@ tl::expected<std::string, errors> canonicalize_port(
       return tl::unexpected(errors::type_error);
     }
   } else if (digits_to_parse.size() > 5) {
-    return tl::unexpected(errors::type_error);
-  }
-  if (digits_to_parse[0] == '0' && digits_to_parse.size() > 1) {
-    // Leading zeros are not allowed for multi-digit ports
     return tl::unexpected(errors::type_error);
   }
   // It is valid! Most times, we do not need to parse it into an integer.

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -471,6 +471,33 @@ TEST(wpt_urlpattern_tests, hostname_ipv4_and_idna_canonicalization) {
   }
 }
 
+TEST(wpt_urlpattern_tests, port_leading_zeros_canonicalization) {
+  // The URL port state reads the port as an integer, so leading zeros are
+  // part of the value: "0080" is 80 and "065535" is 65535, both valid.
+  for (const auto& [input, expected] :
+       std::vector<std::pair<std::string, std::string>>{
+           {"80", "80"},
+           {"0080", "80"},
+           {"065535", "65535"},
+           {"0000001", "1"},
+           {"0000000000000", "0"},
+           {"0", "0"},
+       }) {
+    auto init = ada::url_pattern_init{};
+    init.port = input;
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url) << "port \"" << input << "\" should be accepted";
+    EXPECT_EQ(url->get_port(), expected) << "port \"" << input << "\"";
+  }
+  {
+    // Still out of range after stripping leading zeros.
+    auto init = ada::url_pattern_init{};
+    init.port = "065536";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    EXPECT_FALSE(url);
+  }
+}
+
 // Tests are taken from WPT
 // https://github.com/web-platform-tests/wpt/blob/0c1d19546fd4873bb9f4147f0bbf868e7b4f91b7/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 TEST(wpt_urlpattern_tests, has_regexp_groups) {


### PR DESCRIPTION
canonicalize_port in the URLPattern helpers validates the port with a hand-rolled length check and rejects any multi-digit run that starts with a zero. The URL parser reads a port as an integer though, so leading zeros belong to the value: `0080` is 80 and `065535` is 65535, both valid, matching what `new URL("https://x:0080").port` gives. As a result a URLPattern built with `{ port: "0080" }` throws while the equivalent URL parses fine, and the five-digit cap also miscounts because it includes the zeros. Strip leading zeros before the range check and return `0` for an all-zero value, the same way the fast path in implementation.cpp already does. canonicalize_port_with_protocol parses through from_chars and was already correct.