### PR TITLE
roll back set_host_or_hostname fully when host parse fails

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -696,9 +696,6 @@ bool url::set_host_or_hostname(const std::string_view input) {
 
   url saved_url(*this);
 
-  std::optional<std::string> previous_host = host;
-  std::optional<uint16_t> previous_port = port;
-
   size_t host_end_pos = input.find('#');
   std::string _host(input.data(), host_end_pos != std::string_view::npos
                                       ? host_end_pos
@@ -741,8 +738,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
       // Let host be the result of host parsing buffer with url is not special.
       bool succeeded = parse_host(buffer);
       if (!succeeded) {
-        host = std::move(previous_host);
-        update_base_port(previous_port);
+        *this = std::move(saved_url);
         return false;
       }
 
@@ -780,8 +776,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
 
       bool succeeded = parse_host(host_view);
       if (!succeeded) {
-        host = std::move(previous_host);
-        update_base_port(previous_port);
+        *this = std::move(saved_url);
         return false;
       }
       return check_url_size();
@@ -799,8 +794,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
   } else {
     // Let host be the result of host parsing buffer with url is not special.
     if (!parse_host(new_host)) {
-      host = std::move(previous_host);
-      update_base_port(previous_port);
+      *this = std::move(saved_url);
       return false;
     }
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -594,9 +594,6 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
 
   url_aggregator saved_url(*this);
 
-  std::string previous_host(get_hostname());
-  uint32_t previous_port = components.port;
-
   size_t host_end_pos = input.find('#');
   std::string _host(input.data(), host_end_pos != std::string_view::npos
                                       ? host_end_pos
@@ -639,8 +636,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
       // Let host be the result of host parsing buffer with url is not special.
       bool succeeded = parse_host(host_buffer);
       if (!succeeded) {
-        update_base_hostname(previous_host);
-        update_base_port(previous_port);
+        *this = std::move(saved_url);
         return false;
       }
 
@@ -687,8 +683,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
 
       bool succeeded = parse_host(host_view);
       if (!succeeded) {
-        update_base_hostname(previous_host);
-        update_base_port(previous_port);
+        *this = std::move(saved_url);
         return false;
       } else if (has_dash_dot()) {
         // Should remove dash_dot from pathname
@@ -709,8 +704,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
   } else {
     // Let host be the result of host parsing buffer with url is not special.
     if (!parse_host(new_host)) {
-      update_base_hostname(previous_host);
-      update_base_port(previous_port);
+      *this = std::move(saved_url);
       return false;
     }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -76,6 +76,19 @@ TYPED_TEST(basic_tests, set_host_should_return_true_sometimes) {
   SUCCEED();
 }
 
+// A failed set_host on a non-special URL that has no authority must leave the
+// URL untouched. url_aggregator used to roll back through update_base_hostname,
+// which re-added the "//" authority ("non-spec:/x" -> "non-spec:///x").
+TYPED_TEST(basic_tests, failed_set_host_keeps_authority_less_url) {
+  auto r = ada::parse<TypeParam>("non-spec:/x");
+  ASSERT_TRUE(r);
+  ASSERT_FALSE(r->set_host("@\b["));
+  ASSERT_EQ(r->get_href(), "non-spec:/x");
+  ASSERT_FALSE(r->set_hostname("@\b["));
+  ASSERT_EQ(r->get_href(), "non-spec:/x");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, set_hostname_should_return_false_sometimes) {
   auto r = ada::parse<TypeParam>("mailto:a@b.com");
   ASSERT_FALSE(r->set_hostname("something"));

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1032,6 +1032,21 @@ TYPED_TEST(basic_tests, set_host_fast_path_restores_is_valid) {
   ASSERT_EQ(url->get_port(), "1");
 }
 
+TYPED_TEST(basic_tests, failed_set_host_does_not_poison_set_port) {
+  auto url = ada::parse<TypeParam>(
+      "https://user:pass@example.com:8080/path?query=1#hash");
+  ASSERT_TRUE(url);
+
+  // A rejected set_host must leave the URL fully usable. Rolling back through
+  // update_base_port left is_valid=false, which made the following set_port
+  // fail (port stuck at 8080) instead of updating it.
+  ASSERT_FALSE(url->set_host("7\x03"));
+  ASSERT_TRUE(url->set_port("1"));
+  ASSERT_EQ(url->get_port(), "1");
+  ASSERT_EQ(url->get_href(),
+            "https://user:pass@example.com:1/path?query=1#hash");
+}
+
 TYPED_TEST(basic_tests, get_href_size_matches_get_href) {
   // Verify that get_href_size() returns the same value as get_href().size()
   // across a variety of URLs.


### PR DESCRIPTION
set_host_or_hostname rolls back a failed host parse by calling update_base_hostname with the previous host, but that helper always runs add_authority_slashes_if_needed, so a rejected set_host or set_hostname on an authority-less non-special URL like `non-spec:/x` leaves a stray `//` behind (`non-spec:///x`) while ada::url leaves it untouched. Restore the saved_url snapshot the function already takes on entry, which is the same rollback every other setter in this file uses.