### PR TITLE
reject overlong and surrogate utf-8 in tokenizer decoder

### DIFF
--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -409,6 +409,20 @@ constexpr void Tokenizer::get_next_code_point() {
     return;
   }
 
+  // Constrain the first continuation byte per RFC 3629 so overlong encodings,
+  // UTF-16 surrogates, and code points above U+10FFFF are rejected rather than
+  // decoded into a spurious code point (e.g. E0 80 A8 becoming U+0028 '(').
+  const unsigned char second_byte = input[next_index + 1];
+  if ((first_byte == 0xE0 && second_byte < 0xA0) ||
+      (first_byte == 0xED && second_byte > 0x9F) ||
+      (first_byte == 0xF0 && second_byte < 0x90) ||
+      (first_byte == 0xF4 && second_byte > 0x8F)) {
+    invalid_code_point = true;
+    code_point = first_byte;
+    next_index = initial_index + 1;
+    return;
+  }
+
   for (size_t i = 1 + next_index; i < number_bytes + next_index; ++i) {
     unsigned char byte = input[i];
     if ((byte & 0xC0) != 0x80) {

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -404,6 +404,59 @@ TEST(wpt_urlpattern_tests, malformed_utf8_large_payload_no_nonprogress) {
   EXPECT_EQ(result->back().index, payload_size);
 }
 
+TEST(wpt_urlpattern_tests, tokenizer_rejects_overlong_and_surrogate_utf8) {
+  using ada::url_pattern_helpers::token_policy;
+  using ada::url_pattern_helpers::Tokenizer;
+
+  // Ill-formed UTF-8 must be flagged, not decoded into a code point. An
+  // overlong "(" (E0 80 A8) would otherwise become U+0028 and open a group.
+  const std::string malformed[] = {
+      std::string("\xE0\x80\xA8", 3),      // overlong '('
+      std::string("\xE0\x80\xBA", 3),      // overlong ':'
+      std::string("\xED\xA0\x80", 3),      // U+D800 surrogate
+      std::string("\xF0\x80\x80\xA8", 4),  // overlong four-byte '('
+      std::string("\xF4\x90\x80\x80", 4),  // above U+10FFFF
+  };
+  for (const auto& seq : malformed) {
+    Tokenizer tokenizer(seq, token_policy::lenient);
+    tokenizer.seek_and_get_next_code_point(0);
+    EXPECT_TRUE(tokenizer.had_invalid_code_point());
+  }
+
+  // Well-formed boundary sequences must still decode.
+  const std::string valid[] = {
+      std::string("\xE0\xA0\x80", 3),      // U+0800, shortest three-byte
+      std::string("\xED\x9F\xBF", 3),      // U+D7FF, just below surrogates
+      std::string("\xF0\x9F\x98\x80", 4),  // U+1F600 emoji
+      std::string("\xF4\x8F\xBF\xBF", 4),  // U+10FFFF
+  };
+  for (const auto& seq : valid) {
+    Tokenizer tokenizer(seq, token_policy::lenient);
+    tokenizer.seek_and_get_next_code_point(0);
+    EXPECT_FALSE(tokenizer.had_invalid_code_point());
+  }
+}
+
+TEST(wpt_urlpattern_tests, tokenizer_overlong_open_paren_not_a_group) {
+  using ada::url_pattern_helpers::token_type;
+
+  // "(x)" with the "(" smuggled as an overlong encoding: E0 80 A8 'x' ')'. The
+  // overlong bytes must not be read as U+0028, so no group token is produced.
+  std::string smuggled("\xE0\x80\xA8x)", 5);
+  auto lenient = ada::url_pattern_helpers::tokenize(
+      smuggled, ada::url_pattern_helpers::token_policy::lenient);
+  ASSERT_TRUE(lenient);
+  for (const auto& token : *lenient) {
+    EXPECT_NE(token.type, token_type::OPEN);
+    EXPECT_NE(token.type, token_type::REGEXP);
+  }
+
+  // Strict mode rejects the ill-formed input outright.
+  auto strict = ada::url_pattern_helpers::tokenize(
+      smuggled, ada::url_pattern_helpers::token_policy::strict);
+  EXPECT_FALSE(strict);
+}
+
 TEST(wpt_urlpattern_tests, parse_pattern_string_basic_tests) {
   auto part_list = ada::url_pattern_helpers::parse_pattern_string(
       "*", ada::url_pattern_compile_component_options::DEFAULT,


### PR DESCRIPTION
Tokenizer::get_next_code_point only rejects overlong two-byte leads and four-byte leads above 0xF4, so overlong three and four-byte encodings, UTF-16 surrogates, and code points past U+10FFFF still decode. That means E0 80 A8 turns into U+0028 and the tokenizer reads it as a literal '(' opening a regexp group, so a pattern with ill-formed bytes tokenizes differently from the same characters written plainly. Constrain the first continuation byte per RFC 3629 (E0<A0, ED>9F, F0<90, F4>8F) so those sequences are flagged invalid alongside the other malformed cases already handled here.