### PR TITLE
keep query and fragment delimiter in canonicalize search and hash

### DIFF
--- a/src/url_pattern.cpp
+++ b/src/url_pattern.cpp
@@ -118,22 +118,28 @@ tl::expected<url_pattern_init, errors> url_pattern_init::process(
     // "search", then:
     if (!init.protocol && !init.hostname && !init.port && !init.pathname &&
         !init.search) {
-      // Let baseQuery be baseURL's query.
+      // Let baseQuery be baseURL's query. get_search() carries the leading "?"
+      // delimiter, but the spec inherits the query itself, so drop it.
+      std::string_view base_query = base_url->get_search();
+      if (base_query.starts_with("?")) base_query.remove_prefix(1);
       // Set result["search"] to the result of processing a base URL string
       // given baseQuery and type.
-      result.search = url_pattern_helpers::process_base_url_string(
-          base_url->get_search(), type);
+      result.search =
+          url_pattern_helpers::process_base_url_string(base_query, type);
     }
 
     // If init contains none of "protocol", "hostname", "port", "pathname",
     // "search", and "hash", then:
     if (!init.protocol && !init.hostname && !init.port && !init.pathname &&
         !init.search && !init.hash) {
-      // Let baseFragment be baseURL's fragment.
+      // Let baseFragment be baseURL's fragment. get_hash() carries the leading
+      // "#" delimiter, but the spec inherits the fragment itself, so drop it.
+      std::string_view base_fragment = base_url->get_hash();
+      if (base_fragment.starts_with("#")) base_fragment.remove_prefix(1);
       // Set result["hash"] to the result of processing a base URL string given
       // baseFragment and type.
-      result.hash = url_pattern_helpers::process_base_url_string(
-          base_url->get_hash(), type);
+      result.hash =
+          url_pattern_helpers::process_base_url_string(base_fragment, type);
     }
   }
 

--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -545,9 +545,10 @@ tl::expected<std::string, errors> canonicalize_search(std::string_view input) {
   if (input.empty()) [[unlikely]] {
     return "";
   }
-  // Remove leading '?' if present
-  std::string new_value;
-  new_value = input[0] == '?' ? input.substr(1) : input;
+  // A leading '?' is a valid query code point here: it is the caller (process a
+  // search) that removes a single delimiter, not this step, which mirrors the
+  // basic URL parser's query state.
+  std::string new_value(input);
   // Remove ASCII tab or newline characters
   helpers::remove_ascii_tab_or_newline(new_value);
 
@@ -574,9 +575,10 @@ tl::expected<std::string, errors> canonicalize_hash(std::string_view input) {
   if (input.empty()) [[unlikely]] {
     return "";
   }
-  // Remove leading '#' if present
-  std::string new_value;
-  new_value = input[0] == '#' ? input.substr(1) : input;
+  // A leading '#' is a valid fragment code point here: it is the caller
+  // (process a hash) that removes a single delimiter, not this step, which
+  // mirrors the basic URL parser's fragment state.
+  std::string new_value(input);
   // Remove ASCII tab or newline characters
   helpers::remove_ascii_tab_or_newline(new_value);
 

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -498,6 +498,50 @@ TEST(wpt_urlpattern_tests, port_leading_zeros_canonicalization) {
   }
 }
 
+TEST(wpt_urlpattern_tests, search_and_hash_keep_leading_delimiter) {
+  // "canonicalize a search" runs the URL parser in query state, and
+  // "canonicalize a hash" in fragment state. Neither strips a leading
+  // delimiter: '?' is a valid query code point and '#' a valid fragment code
+  // point. The single delimiter is removed earlier, by process a search/hash.
+  {
+    auto search = ada::url_pattern_helpers::canonicalize_search("?x");
+    ASSERT_TRUE(search);
+    EXPECT_EQ(*search, "?x");
+    auto hash = ada::url_pattern_helpers::canonicalize_hash("#h");
+    ASSERT_TRUE(hash);
+    EXPECT_EQ(*hash, "#h");
+  }
+  {
+    // An escaped delimiter in a component pattern is a literal that must be
+    // kept, so the pattern matches the delimiter and nothing else.
+    auto init = ada::url_pattern_init{};
+    init.search = "\\?x";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    // A concrete URL whose query is exactly "?x".
+    auto ok = url->test(std::string_view("https://example.com/??x"), nullptr);
+    ASSERT_TRUE(ok);
+    EXPECT_TRUE(*ok);
+    auto dropped =
+        url->test(std::string_view("https://example.com/?x"), nullptr);
+    ASSERT_TRUE(dropped);
+    EXPECT_FALSE(*dropped);
+  }
+  {
+    auto init = ada::url_pattern_init{};
+    init.hash = "\\#h";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    auto ok = url->test(std::string_view("https://example.com/##h"), nullptr);
+    ASSERT_TRUE(ok);
+    EXPECT_TRUE(*ok);
+    auto dropped =
+        url->test(std::string_view("https://example.com/#h"), nullptr);
+    ASSERT_TRUE(dropped);
+    EXPECT_FALSE(*dropped);
+  }
+}
+
 // Tests are taken from WPT
 // https://github.com/web-platform-tests/wpt/blob/0c1d19546fd4873bb9f4147f0bbf868e7b4f91b7/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 TEST(wpt_urlpattern_tests, has_regexp_groups) {


### PR DESCRIPTION
canonicalize_search and canonicalize_hash strip a leading "?"/"#", but per the URLPattern spec that single delimiter is removed by process a search / process a hash, while these encoders run the URL parser in query state / fragment state where "?" and "#" are ordinary code points. The extra strip drops an escaped literal, so URLPattern({search: "\\?x"}) compiles a pattern that matches a search of "x" instead of "?x", and canonicalize_search("?x") returns "x" rather than "?x". The effect was hidden for base-URL inheritance because url_pattern_init::process passed get_search()/get_hash() with their delimiters straight into process a base URL string, so the two strips cancelled. This drops the strip from both encoders and feeds the raw query/fragment (leading delimiter removed) when inheriting from a base URL, matching the spec's "baseURL's query" / "baseURL's fragment". Added a regression test; the full WPT urlpattern suite stays green.