### PR TITLE
percent-encode ? and # in url pattern canonicalize_pathname

### DIFF
--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -500,25 +500,33 @@ tl::expected<std::string, errors> canonicalize_pathname(
   const bool leading_slash = input.starts_with("/");
   // Let modified value be "/-" if leading slash is false and otherwise the
   // empty string.
-  const auto modified_value = leading_slash ? "" : "/-";
-  const auto full_url =
-      std::string("fake://fake-url") + modified_value + std::string(input);
-  if (auto url = ada::parse<url_aggregator>(full_url, nullptr)) {
-    const auto pathname = url->get_pathname();
-    // If leading slash is false, then set result to the code point substring
-    // from 2 to the end of the string within result.
-    if (!leading_slash) {
-      // pathname should start with "/-" but path traversal (e.g. "../../")
-      // can reduce it to just "/" which is shorter than 2 characters.
-      if (pathname.size() < 2) {
-        return tl::unexpected(errors::type_error);
-      }
-      return std::string(pathname.substr(2));
-    }
-    return std::string(pathname);
+  const auto modified_value =
+      (leading_slash ? std::string() : std::string("/-")) + std::string(input);
+  // The spec runs the basic URL parser with the path in state override, where
+  // '?' and '#' are ordinary path code points (percent-encoded) and leading or
+  // trailing C0 control or space is kept. Building a full URL string and
+  // parsing it (no state override) instead let '?' and '#' start the
+  // query/fragment, so the pathname was silently truncated at the first literal
+  // '?' or '#'. set_pathname runs the parser in path state override, matching
+  // how canonicalize_hostname uses set_hostname.
+  auto url = ada::parse<url_aggregator>("fake://fake-url", nullptr);
+  ADA_ASSERT_TRUE(url);
+  if (!url->set_pathname(modified_value)) {
+    // If parseResult is failure, then throw a TypeError.
+    return tl::unexpected(errors::type_error);
   }
-  // If parseResult is failure, then throw a TypeError.
-  return tl::unexpected(errors::type_error);
+  const auto pathname = url->get_pathname();
+  // If leading slash is false, then set result to the code point substring
+  // from 2 to the end of the string within result.
+  if (!leading_slash) {
+    // pathname should start with "/-" but path traversal (e.g. "../../")
+    // can reduce it to just "/" which is shorter than 2 characters.
+    if (pathname.size() < 2) {
+      return tl::unexpected(errors::type_error);
+    }
+    return std::string(pathname.substr(2));
+  }
+  return std::string(pathname);
 }
 
 tl::expected<std::string, errors> canonicalize_opaque_pathname(

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -542,6 +542,42 @@ TEST(wpt_urlpattern_tests, search_and_hash_keep_leading_delimiter) {
   }
 }
 
+TEST(wpt_urlpattern_tests, pathname_encodes_query_and_fragment_delimiters) {
+  // "canonicalize a pathname" runs the URL parser in path state override, where
+  // '?' and '#' are ordinary path code points (percent-encoded) rather than
+  // query/fragment delimiters. A literal '?' or '#' in a pathname component
+  // must survive as %3F/%23; dropping everything from it onward would widen the
+  // pattern.
+  for (const auto& [input, expected] :
+       std::vector<std::pair<std::string, std::string>>{
+           {"/a?b", "/a%3Fb"},
+           {"/a#b", "/a%23b"},
+           {"/foo?", "/foo%3F"},
+           {"foo?bar", "foo%3Fbar"},
+           {"/a/../b", "/b"},
+       }) {
+    auto pathname = ada::url_pattern_helpers::canonicalize_pathname(input);
+    ASSERT_TRUE(pathname) << "pathname \"" << input << "\"";
+    EXPECT_EQ(*pathname, expected) << "pathname \"" << input << "\"";
+  }
+  {
+    // An escaped '?' in a pathname pattern is a literal, so the pattern matches
+    // the encoded delimiter and nothing shorter.
+    auto init = ada::url_pattern_init{};
+    init.pathname = "/a\\?b";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_pathname(), "/a%3Fb");
+    auto ok = url->test(std::string_view("https://example.com/a%3Fb"), nullptr);
+    ASSERT_TRUE(ok);
+    EXPECT_TRUE(*ok);
+    auto truncated =
+        url->test(std::string_view("https://example.com/a"), nullptr);
+    ASSERT_TRUE(truncated);
+    EXPECT_FALSE(*truncated);
+  }
+}
+
 // Tests are taken from WPT
 // https://github.com/web-platform-tests/wpt/blob/0c1d19546fd4873bb9f4147f0bbf868e7b4f91b7/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 TEST(wpt_urlpattern_tests, has_regexp_groups) {


### PR DESCRIPTION
canonicalize_pathname concatenates the component value into a `fake://fake-url...` string and runs the full basic url parser, but the url pattern spec canonicalizes a pathname with the path in state override, where `?` and `#` are ordinary path code points that percent-encode rather than starting the query or fragment. without state override a literal `?` or `#` ended the path early, so `new URLPattern({pathname: "/a\\?b"})` compiled to match `/a` instead of `/a%3Fb`, a broader match than written; leading and trailing c0-control-or-space was stripped too. route the value through set_pathname, which runs path state override, matching how canonicalize_hostname already uses set_hostname. added a regression test.