### PR TITLE
Remove Stars section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,3 @@ Our tests include third-party code and data. The benchmarking code includes thir
 
 * Yagiz Nizipli, Daniel Lemire, [Parsing Millions of URLs per Second](https://doi.org/10.1002/spe.3296), Software: Practice and Experience 54(5) May 2024.
 
-## Stars
-
-
-[![Star History Chart](https://api.star-history.com/svg?repos=ada-url/ada&type=Date)](https://www.star-history.com/#ada-url/ada&Date)


### PR DESCRIPTION
Removed the Stars section and its related content from the README. GH has restricted access to the data and it no longer works. We could keep it by embedding a token in the readme, but it seems too  much trouble.