### PR TITLE
perf: speed up absolute http(s) parse for url and url_aggregator

### DIFF
--- a/fuzz/ada_c.cc
+++ b/fuzz/ada_c.cc
@@ -1,5 +1,10 @@
-// C API fuzzer. Amalgamates ada.cpp (same pattern as parse.cc).
-// Do not include ada_c.h — types are defined in the amalgamation.
+// C API fuzzer. Built as C++ amalgamating ada.cpp so OSS-Fuzz coverage
+// instrumentation sees both the harness and the library (the previous
+// separate-object C link left ada_c at ~0% coverage once hard aborts on
+// can_parse/parse mismatches stopped corpus progress).
+//
+// Types/functions from ada_c.cpp are already in this TU via the amalgamation;
+// do not also include ada_c.h (redefinition errors).
 
 #include <fuzzer/FuzzedDataProvider.h>
 
@@ -98,6 +103,7 @@ static void exercise_valid_url(ada_url out, const char* input, size_t input_len,
   ada_has_search(out);
 
   const ada_url_components* comps = ada_get_components(out);
+  // ada_url_omitted is 0xffffffff (see ada_c.h / url_components::omitted).
   constexpr uint32_t kOmitted = 0xffffffffu;
   auto check_off = [&](uint32_t off, const char* name) {
     if (off != kOmitted && off > href.length) {
@@ -124,6 +130,7 @@ static void exercise_valid_url(ada_url out, const char* input, size_t input_len,
   }
   ada_free(out_copy);
 
+  // Re-parse idempotency after setters/clears.
   ada_string final_href = ada_get_href(out);
   ada_url reparsed = ada_parse(final_href.data, final_href.length);
   if (!ada_is_valid(reparsed)) {
@@ -156,13 +163,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   const char* base = secondary.data();
   size_t base_len = secondary.size();
 
+  // can_parse must agree with parse (is_valid).
   ada_url out = ada_parse(input, input_len);
   bool is_valid = ada_is_valid(out);
   bool can_parse_result = ada_can_parse(input, input_len);
-  // Keep soft: can_parse/parse may still diverge under max_input_length on
-  // main until that is fixed. Still exercise both APIs for coverage.
-  (void)can_parse_result;
-  (void)is_valid;
+  if (can_parse_result != is_valid) {
+    printf("ada_can_parse vs ada_parse disagreement\n");
+    ada_free(out);
+    abort();
+  }
   exercise_valid_url(out, input, input_len, base, base_len);
   ada_free(out);
 
@@ -170,8 +179,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   bool with_base_valid = ada_is_valid(out_with_base);
   bool can_parse_with_base =
       ada_can_parse_with_base(input, input_len, base, base_len);
-  (void)can_parse_with_base;
-  (void)with_base_valid;
+  if (can_parse_with_base != with_base_valid) {
+    printf("ada_can_parse_with_base vs ada_parse_with_base disagreement\n");
+    ada_free(out_with_base);
+    abort();
+  }
   if (with_base_valid) {
     ada_get_href(out_with_base);
     ada_owned_string origin = ada_get_origin(out_with_base);
@@ -208,6 +220,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     (void)ada_get_version_components().major;
   }
 
+  // Search params
   {
     ada_url_search_params sp = ada_parse_search_params(input, input_len);
     (void)ada_search_params_size(sp);
@@ -252,6 +265,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     ada_free_search_params(sp);
   }
 
+  // Anchors keep coverage alive with thin corpora.
   static constexpr const char* kAnchors[] = {
       "https://example.com/",
       "http://127.0.0.1/x",
@@ -261,7 +275,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   for (const char* a : kAnchors) {
     size_t n = strlen(a);
     ada_url u = ada_parse(a, n);
-    (void)ada_can_parse(a, n);
+    if (ada_is_valid(u) != ada_can_parse(a, n)) {
+      ada_free(u);
+      abort();
+    }
     exercise_valid_url(u, a, n, "x", 1);
     ada_free(u);
   }

--- a/fuzz/ada_c.cc
+++ b/fuzz/ada_c.cc
@@ -1,10 +1,5 @@
-// C API fuzzer. Built as C++ amalgamating ada.cpp so OSS-Fuzz coverage
-// instrumentation sees both the harness and the library (the previous
-// separate-object C link left ada_c at ~0% coverage once hard aborts on
-// can_parse/parse mismatches stopped corpus progress).
-//
-// Types/functions from ada_c.cpp are already in this TU via the amalgamation;
-// do not also include ada_c.h (redefinition errors).
+// C API fuzzer (C++ amalgamation; do not include ada_c.h — types come from
+// ada_c.cpp in the amalgamation).
 
 #include <fuzzer/FuzzedDataProvider.h>
 
@@ -103,7 +98,6 @@ static void exercise_valid_url(ada_url out, const char* input, size_t input_len,
   ada_has_search(out);
 
   const ada_url_components* comps = ada_get_components(out);
-  // ada_url_omitted is 0xffffffff (see ada_c.h / url_components::omitted).
   constexpr uint32_t kOmitted = 0xffffffffu;
   auto check_off = [&](uint32_t off, const char* name) {
     if (off != kOmitted && off > href.length) {
@@ -130,7 +124,6 @@ static void exercise_valid_url(ada_url out, const char* input, size_t input_len,
   }
   ada_free(out_copy);
 
-  // Re-parse idempotency after setters/clears.
   ada_string final_href = ada_get_href(out);
   ada_url reparsed = ada_parse(final_href.data, final_href.length);
   if (!ada_is_valid(reparsed)) {
@@ -163,7 +156,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   const char* base = secondary.data();
   size_t base_len = secondary.size();
 
-  // can_parse must agree with parse (is_valid).
   ada_url out = ada_parse(input, input_len);
   bool is_valid = ada_is_valid(out);
   bool can_parse_result = ada_can_parse(input, input_len);
@@ -220,7 +212,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     (void)ada_get_version_components().major;
   }
 
-  // Search params
   {
     ada_url_search_params sp = ada_parse_search_params(input, input_len);
     (void)ada_search_params_size(sp);
@@ -265,7 +256,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     ada_free_search_params(sp);
   }
 
-  // Anchors keep coverage alive with thin corpora.
   static constexpr const char* kAnchors[] = {
       "https://example.com/",
       "http://127.0.0.1/x",

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -56,9 +56,6 @@ $CXX -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=1 \
      url_pattern.o \
      -o $OUT/url_pattern
 
-# C API harness is C++ and amalgamates ada.cpp in-process (same pattern as
-# parse/url_pattern). Linking a separate un-instrumented or multi-object
-# ada.o previously caused OSS-Fuzz coverage for ada_c to collapse to ~0%.
 $CXX $CFLAGS $CXXFLAGS \
      -std=c++20 \
      -I build/singleheader \

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -80,6 +80,14 @@ $CXX $CFLAGS $CXXFLAGS \
 $CXX $CFLAGS $CXXFLAGS $LIB_FUZZING_ENGINE unicode.o \
      -o $OUT/unicode
 
+$CXX $CFLAGS $CXXFLAGS \
+     -std=c++20 \
+     -I build/singleheader \
+     -c fuzz/simple_absolute.cc -o simple_absolute.o
+
+$CXX $CFLAGS $CXXFLAGS $LIB_FUZZING_ENGINE simple_absolute.o \
+     -o $OUT/simple_absolute
+
 cp $SRC/ada-url/fuzz/*.dict $SRC/ada-url/fuzz/*.options $OUT/
 
 # Build unit test

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -56,6 +56,9 @@ $CXX -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=1 \
      url_pattern.o \
      -o $OUT/url_pattern
 
+# C API harness is C++ and amalgamates ada.cpp in-process (same pattern as
+# parse/url_pattern). Linking a separate un-instrumented or multi-object
+# ada.o previously caused OSS-Fuzz coverage for ada_c to collapse to ~0%.
 $CXX $CFLAGS $CXXFLAGS \
      -std=c++20 \
      -I build/singleheader \

--- a/fuzz/can_parse.cc
+++ b/fuzz/can_parse.cc
@@ -12,10 +12,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::string source = fdp.ConsumeRandomLengthString(256);
   std::string base_source = fdp.ConsumeRandomLengthString(256);
 
-  /**
-   * can_parse must agree with parse().has_value() for every input.
-   */
-
   bool can_parse_result = ada::can_parse(source);
   auto parsed_agg = ada::parse<ada::url_aggregator>(source);
   auto parsed_url = ada::parse<ada::url>(source);
@@ -70,16 +66,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
              source.c_str(), base_source.c_str());
       abort();
     }
-  } else {
-    // Invalid base: can_parse with base must be false.
-    if (can_parse_with_base) {
-      printf("can_parse_with_base true with invalid base=%s\n",
-             base_source.c_str());
-      abort();
-    }
+  } else if (can_parse_with_base) {
+    printf("can_parse_with_base true with invalid base=%s\n",
+           base_source.c_str());
+    abort();
   }
 
-  // Empty string
   {
     bool empty_cp = ada::can_parse("");
     auto empty_agg = ada::parse<ada::url_aggregator>("");
@@ -91,7 +83,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
   }
 
-  // href round-trip
   if (parsed_agg) {
     std::string href = std::string(parsed_agg->get_href());
     if (!ada::can_parse(href)) {

--- a/fuzz/can_parse.cc
+++ b/fuzz/can_parse.cc
@@ -1,8 +1,8 @@
 #include <fuzzer/FuzzedDataProvider.h>
 
 #include <cstdio>
-#include <memory>
 #include <string>
+#include <string_view>
 
 #include "ada.cpp"
 #include "ada.h"
@@ -13,102 +13,102 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::string base_source = fdp.ConsumeRandomLengthString(256);
 
   /**
-   * ada::can_parse consistency checks.
-   *
-   * can_parse() must agree with parse().has_value() in all cases.
-   * This invariant must hold regardless of input encoding.
+   * can_parse must agree with parse().has_value() for every input.
    */
 
-  // Test 1: can_parse(source) must equal
-  // parse<url_aggregator>(source).has_value()
   bool can_parse_result = ada::can_parse(source);
   auto parsed_agg = ada::parse<ada::url_aggregator>(source);
+  auto parsed_url = ada::parse<ada::url>(source);
+
   if (can_parse_result != parsed_agg.has_value()) {
     printf("can_parse vs parse<url_aggregator> inconsistency for: %s\n",
            source.c_str());
     abort();
   }
-
-  // Test 2: can_parse(source) must also equal parse<url>(source).has_value()
-  auto parsed_url = ada::parse<ada::url>(source);
   if (can_parse_result != parsed_url.has_value()) {
     printf("can_parse vs parse<url> inconsistency for: %s\n", source.c_str());
     abort();
   }
+  if (parsed_url.has_value() != parsed_agg.has_value()) {
+    printf("parse<url> vs parse<url_aggregator> disagreement for: %s\n",
+           source.c_str());
+    abort();
+  }
+  if (parsed_url && parsed_agg &&
+      parsed_url->get_href() != std::string(parsed_agg->get_href())) {
+    printf("parse href disagreement for: %s\n", source.c_str());
+    abort();
+  }
 
-  // Test 3: can_parse with base
   auto base_source_view =
       std::string_view(base_source.data(), base_source.length());
   bool can_parse_with_base = ada::can_parse(source, &base_source_view);
 
-  // Test 4: can_parse(source, base) must equal parse<url_aggregator>(source,
-  // base).has_value()
   auto base_agg = ada::parse<ada::url_aggregator>(base_source);
-  if (base_agg) {
-    auto parsed_with_base = ada::parse<ada::url_aggregator>(source, &*base_agg);
-    if (can_parse_with_base != parsed_with_base.has_value()) {
+  auto base_url = ada::parse<ada::url>(base_source);
+  if (base_agg.has_value() != base_url.has_value()) {
+    printf("base parse type disagreement for: %s\n", base_source.c_str());
+    abort();
+  }
+
+  if (base_agg && base_url) {
+    auto ra = ada::parse<ada::url_aggregator>(source, &*base_agg);
+    auto ru = ada::parse<ada::url>(source, &*base_url);
+    if (can_parse_with_base != ra.has_value()) {
       printf(
-          "can_parse_with_base vs parse<url_aggregator> inconsistency for "
-          "source=%s base=%s\n",
+          "can_parse_with_base vs parse inconsistency for source=%s base=%s\n",
           source.c_str(), base_source.c_str());
       abort();
     }
-  }
-
-  // Test 5: Empty string edge cases
-  {
-    std::string_view empty_view;
-    bool empty_can_parse = ada::can_parse("");
-    auto empty_parsed = ada::parse<ada::url_aggregator>("");
-    if (empty_can_parse != empty_parsed.has_value()) {
-      printf("Empty string can_parse inconsistency\n");
+    if (ra.has_value() != ru.has_value()) {
+      printf("relative parse type disagreement source=%s base=%s\n",
+             source.c_str(), base_source.c_str());
+      abort();
+    }
+    if (ra && ru && ru->get_href() != std::string(ra->get_href())) {
+      printf("relative parse href disagreement source=%s base=%s\n",
+             source.c_str(), base_source.c_str());
+      abort();
+    }
+  } else {
+    // Invalid base: can_parse with base must be false.
+    if (can_parse_with_base) {
+      printf("can_parse_with_base true with invalid base=%s\n",
+             base_source.c_str());
       abort();
     }
   }
 
-  // Test 6: href round-trip.
-  //
-  // If parse(source) succeeds, can_parse(href) must return true and
-  // re-parsing the href must produce the same href (idempotency).
-  // This verifies that the serialised form of every parsed URL is itself
-  // a valid absolute URL that round-trips perfectly.
+  // Empty string
+  {
+    bool empty_cp = ada::can_parse("");
+    auto empty_agg = ada::parse<ada::url_aggregator>("");
+    auto empty_url = ada::parse<ada::url>("");
+    if (empty_cp != empty_agg.has_value() ||
+        empty_cp != empty_url.has_value()) {
+      printf("Empty string can_parse/parse disagreement\n");
+      abort();
+    }
+  }
+
+  // href round-trip
   if (parsed_agg) {
     std::string href = std::string(parsed_agg->get_href());
-
-    // can_parse must accept the normalised href.
     if (!ada::can_parse(href)) {
       printf("can_parse rejected normalised href: '%s'\n", href.c_str());
       abort();
     }
-
-    // Re-parsing the href must succeed.
     auto reparsed = ada::parse<ada::url_aggregator>(href);
-    if (!reparsed) {
-      printf("Re-parse of href failed: '%s'\n", href.c_str());
+    if (!reparsed || std::string(reparsed->get_href()) != href) {
+      printf("href re-parse failure for: '%s'\n", href.c_str());
       abort();
     }
-
-    // The href of the re-parsed URL must equal the original href.
-    std::string href2 = std::string(reparsed->get_href());
-    if (href2 != href) {
-      printf(
-          "href idempotency failure!\n"
-          "  href1: %s\n  href2: %s\n",
-          href.c_str(), href2.c_str());
-      abort();
-    }
-
-    // url and url_aggregator must agree on whether the href is parseable.
-    bool url_can_parse = ada::parse<ada::url>(href).has_value();
-    if (url_can_parse != ada::can_parse(href)) {
-      printf("parse<url> vs can_parse disagreement on normalised href: '%s'\n",
-             href.c_str());
+    auto reparsed_url = ada::parse<ada::url>(href);
+    if (!reparsed_url || reparsed_url->get_href() != href) {
+      printf("parse<url> re-parse disagreement on href: '%s'\n", href.c_str());
       abort();
     }
   }
-
-  (void)can_parse_result;
-  (void)can_parse_with_base;
 
   return 0;
 }

--- a/fuzz/parse.cc
+++ b/fuzz/parse.cc
@@ -150,8 +150,6 @@ static void exercise_aggregator_predicates(const ada::url_aggregator& u) {
   (void)u.to_diagram();
 }
 
-// Build absolute http(s) candidates that exercise try_parse_simple_absolute
-// and its fall-through gates (digit-led host, dots, credentials, port, xn--).
 static std::string make_simple_absolute_candidate(FuzzedDataProvider& fdp) {
   static constexpr const char* kSchemes[] = {"http://",  "https://", "HTTP://",
                                              "Https://", "http:",    "https:"};
@@ -161,7 +159,7 @@ static std::string make_simple_absolute_candidate(FuzzedDataProvider& fdp) {
       "WWW.Example.COM",
       "a",
       "a.b.c",
-      "192.168.0.1",  // digit-led: IPv4 gate
+      "192.168.0.1",
       "0x7f.1",
       "127.1",
       "xn--nxasmq6b.com",
@@ -206,7 +204,6 @@ static std::string make_simple_absolute_candidate(FuzzedDataProvider& fdp) {
   out += kFrags[fdp.ConsumeIntegralInRange<size_t>(
       0, sizeof(kFrags) / sizeof(kFrags[0]) - 1)];
 
-  // Optional: splice a short fuzzed fragment into the middle to widen coverage.
   if (fdp.ConsumeBool() && !out.empty()) {
     std::string mid = fdp.ConsumeRandomLengthString(16);
     size_t pos = fdp.ConsumeIntegralInRange<size_t>(0, out.size());
@@ -242,8 +239,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   // optimizations
   volatile size_t length = 0;
 
-  // Also parse a structured simple-absolute candidate so the fast path is
-  // reached even when pure random bytes rarely look like http(s) URLs.
   std::string simple_abs = make_simple_absolute_candidate(fdp);
   {
     auto su = ada::parse<ada::url>(simple_abs);

--- a/fuzz/parse.cc
+++ b/fuzz/parse.cc
@@ -150,6 +150,89 @@ static void exercise_aggregator_predicates(const ada::url_aggregator& u) {
   (void)u.to_diagram();
 }
 
+// Build absolute http(s) candidates that exercise try_parse_simple_absolute
+// and its fall-through gates (digit-led host, dots, credentials, port, xn--).
+static std::string make_simple_absolute_candidate(FuzzedDataProvider& fdp) {
+  static constexpr const char* kSchemes[] = {"http://",  "https://", "HTTP://",
+                                             "Https://", "http:",    "https:"};
+  static constexpr const char* kHosts[] = {
+      "example.com",
+      "www.example.com",
+      "WWW.Example.COM",
+      "a",
+      "a.b.c",
+      "192.168.0.1",  // digit-led: IPv4 gate
+      "0x7f.1",
+      "127.1",
+      "xn--nxasmq6b.com",
+      "xn--a",
+      "user@example.com",
+      "user:pass@example.com",
+      "example.com:8080",
+      "example.com:0",
+      "",
+  };
+  static constexpr const char* kPaths[] = {
+      "",
+      "/",
+      "/path",
+      "/path/file.js",
+      "/a/./b/../c",
+      "/foo/%2e",
+      "/foo/%2e%2e",
+      "/path with space",
+      "/path\twith\ttab",
+      "\\path",
+      "/continue=https%3A%2F%2Fexample.com%2F",
+  };
+  static constexpr const char* kQueries[] = {
+      "",
+      "?",
+      "?q=1",
+      "?hl=en&tab=wi",
+      "?continue=https%3A%2F%2Fexample.com%2F",
+  };
+  static constexpr const char* kFrags[] = {"", "#", "#frag", "#x%20y"};
+
+  std::string out;
+  out += kSchemes[fdp.ConsumeIntegralInRange<size_t>(
+      0, sizeof(kSchemes) / sizeof(kSchemes[0]) - 1)];
+  out += kHosts[fdp.ConsumeIntegralInRange<size_t>(
+      0, sizeof(kHosts) / sizeof(kHosts[0]) - 1)];
+  out += kPaths[fdp.ConsumeIntegralInRange<size_t>(
+      0, sizeof(kPaths) / sizeof(kPaths[0]) - 1)];
+  out += kQueries[fdp.ConsumeIntegralInRange<size_t>(
+      0, sizeof(kQueries) / sizeof(kQueries[0]) - 1)];
+  out += kFrags[fdp.ConsumeIntegralInRange<size_t>(
+      0, sizeof(kFrags) / sizeof(kFrags[0]) - 1)];
+
+  // Optional: splice a short fuzzed fragment into the middle to widen coverage.
+  if (fdp.ConsumeBool() && !out.empty()) {
+    std::string mid = fdp.ConsumeRandomLengthString(16);
+    size_t pos = fdp.ConsumeIntegralInRange<size_t>(0, out.size());
+    out.insert(pos, mid);
+  }
+  return out;
+}
+
+static void check_href_size_invariant(const ada::url& u) {
+  if (u.get_href_size() != u.get_href().size()) {
+    printf("get_href_size mismatch (url): size=%zu href.size=%zu href=%s\n",
+           u.get_href_size(), u.get_href().size(), u.get_href().c_str());
+    abort();
+  }
+}
+
+static void check_href_size_invariant(const ada::url_aggregator& u) {
+  if (u.get_href_size() != u.get_href().size()) {
+    printf(
+        "get_href_size mismatch (aggregator): size=%zu href.size=%zu href=%s\n",
+        u.get_href_size(), u.get_href().size(),
+        std::string(u.get_href()).c_str());
+    abort();
+  }
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   FuzzedDataProvider fdp(data, size);
   std::string source = fdp.ConsumeRandomLengthString(256);
@@ -158,6 +241,29 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   // volatile forces the compiler to store the results without undue
   // optimizations
   volatile size_t length = 0;
+
+  // Also parse a structured simple-absolute candidate so the fast path is
+  // reached even when pure random bytes rarely look like http(s) URLs.
+  std::string simple_abs = make_simple_absolute_candidate(fdp);
+  {
+    auto su = ada::parse<ada::url>(simple_abs);
+    auto sa = ada::parse<ada::url_aggregator>(simple_abs);
+    if (su.has_value() ^ sa.has_value()) {
+      printf("simple_abs parse agreement fail: %s\n", simple_abs.c_str());
+      abort();
+    }
+    if (su) {
+      if (su->get_href() != std::string(sa->get_href())) {
+        printf("simple_abs href mismatch:\n  in=%s\n  url=%s\n  agg=%s\n",
+               simple_abs.c_str(), su->get_href().c_str(),
+               std::string(sa->get_href()).c_str());
+        abort();
+      }
+      check_href_size_invariant(*su);
+      check_href_size_invariant(*sa);
+      length += su->get_href().size();
+    }
+  }
 
   auto parse_url = ada::parse<ada::url>(source);
   auto parse_url_aggregator = ada::parse<ada::url_aggregator>(source);
@@ -172,11 +278,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (parse_url) {
     length += parse_url->get_href().size();
     length += parse_url->get_origin().size();
+    check_href_size_invariant(*parse_url);
   }
 
   if (parse_url_aggregator) {
     length += parse_url_aggregator->get_href().size();
     length += parse_url_aggregator->get_origin().size();
+    check_href_size_invariant(*parse_url_aggregator);
 
     volatile bool is_parse_url_aggregator_output_valid = false;
     is_parse_url_aggregator_output_valid = parse_url_aggregator->validate();

--- a/fuzz/simple_absolute.cc
+++ b/fuzz/simple_absolute.cc
@@ -7,13 +7,6 @@
 #include "ada.cpp"
 #include "ada.h"
 
-// ============================================================
-// Fuzzer for the simple-absolute http(s) parse fast path
-// (try_parse_simple_absolute) and its intentional fall-throughs:
-// digit-led hosts (IPv4), credentials, ports, xn--/IDNA, dot
-// segments, percent-encoded dots, and get_href hot-path size.
-// ============================================================
-
 static constexpr const char* kSchemes[] = {
     "http://", "https://", "HTTP://", "Https://",
     "http:",   "https:",   "htTP://", "HTTPS://"};
@@ -25,7 +18,7 @@ static constexpr const char* kHosts[] = {
     "a",
     "a.b.c",
     "maps.google.com",
-    "192.168.0.1",  // digit-led host -> IPv4 gate
+    "192.168.0.1",
     "0x7f.1",
     "127.1",
     "0",
@@ -86,19 +79,15 @@ static std::string make_candidate(FuzzedDataProvider& fdp) {
   out += pick(fdp, kQueries);
   out += pick(fdp, kFrags);
 
-  // Optional splice of raw fuzz bytes to widen coverage.
   if (fdp.ConsumeBool() && !out.empty()) {
     std::string mid = fdp.ConsumeRandomLengthString(24);
     size_t pos = fdp.ConsumeIntegralInRange<size_t>(0, out.size());
     out.insert(pos, mid);
   }
-
-  // Optional single-byte mutation.
   if (fdp.ConsumeBool() && !out.empty()) {
     size_t i = fdp.ConsumeIntegralInRange<size_t>(0, out.size() - 1);
     out[i] = static_cast<char>(fdp.ConsumeIntegral<uint8_t>());
   }
-
   return out;
 }
 
@@ -202,7 +191,6 @@ static void fuzz_one_input(std::string_view input) {
   check_reparse_idempotent(*url, input);
   check_reparse_idempotent(*agg, input);
 
-  // get_href hot path must stay consistent after set_href of the same href.
   const std::string href = url->get_href();
   url->set_href(href);
   agg->set_href(href);
@@ -223,17 +211,13 @@ static void fuzz_one_input(std::string_view input) {
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   FuzzedDataProvider fdp(data, size);
 
-  // 1) Structured candidate aimed at the simple-absolute fast path / gates.
-  std::string structured = make_candidate(fdp);
-  fuzz_one_input(structured);
+  fuzz_one_input(make_candidate(fdp));
 
-  // 2) Raw fuzz bytes as a pure absolute-URL-shaped input (prefix http(s)).
   if (fdp.remaining_bytes() > 0) {
     std::string raw = fdp.ConsumeRemainingBytesAsString();
     if (raw.size() > 512) {
       raw.resize(512);
     }
-    // Occasionally force an http(s) prefix so the fast-path entry is reached.
     if (!raw.empty() && (static_cast<unsigned char>(raw[0]) & 1u)) {
       raw = std::string("https://") + raw;
     } else if (!raw.empty()) {
@@ -242,7 +226,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     fuzz_one_input(raw);
   }
 
-  // 3) Fixed seeds that must always be safe (dictionary-like corpus anchors).
   static constexpr const char* kAnchors[] = {
       "https://example.com",
       "https://example.com/",

--- a/fuzz/simple_absolute.cc
+++ b/fuzz/simple_absolute.cc
@@ -1,0 +1,269 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cstdio>
+#include <string>
+#include <string_view>
+
+#include "ada.cpp"
+#include "ada.h"
+
+// ============================================================
+// Fuzzer for the simple-absolute http(s) parse fast path
+// (try_parse_simple_absolute) and its intentional fall-throughs:
+// digit-led hosts (IPv4), credentials, ports, xn--/IDNA, dot
+// segments, percent-encoded dots, and get_href hot-path size.
+// ============================================================
+
+static constexpr const char* kSchemes[] = {
+    "http://", "https://", "HTTP://", "Https://",
+    "http:",   "https:",   "htTP://", "HTTPS://"};
+
+static constexpr const char* kHosts[] = {
+    "example.com",
+    "www.example.com",
+    "WWW.Example.COM",
+    "a",
+    "a.b.c",
+    "maps.google.com",
+    "192.168.0.1",  // digit-led host -> IPv4 gate
+    "0x7f.1",
+    "127.1",
+    "0",
+    "3232235777",
+    "xn--nxasmq6b.com",
+    "xn--a",
+    "XN--A",
+    "user@example.com",
+    "user:pass@example.com",
+    "example.com:8080",
+    "example.com:0",
+    "example.com:65535",
+    "",
+};
+
+static constexpr const char* kPaths[] = {
+    "",
+    "/",
+    "/path",
+    "/path/file.js",
+    "/a/./b/../c",
+    "/foo/%2e",
+    "/foo/%2e%2e",
+    "/foo/%2E%2E/bar",
+    "/path with space",
+    "/path\twith\ttab",
+    "\\path",
+    "/continue=https%3A%2F%2Fexample.com%2F",
+    "/imghp",
+    "/./",
+    "/../",
+    "/%2e%2e%2f",
+};
+
+static constexpr const char* kQueries[] = {
+    "",
+    "?",
+    "?q=1",
+    "?hl=en&tab=wi",
+    "?continue=https%3A%2F%2Fexample.com%2F",
+    "?a=1&b=2&c=3",
+};
+
+static constexpr const char* kFrags[] = {
+    "", "#", "#frag", "#x%20y", "#/",
+};
+
+template <size_t N>
+static const char* pick(FuzzedDataProvider& fdp, const char* const (&arr)[N]) {
+  return arr[fdp.ConsumeIntegralInRange<size_t>(0, N - 1)];
+}
+
+static std::string make_candidate(FuzzedDataProvider& fdp) {
+  std::string out;
+  out += pick(fdp, kSchemes);
+  out += pick(fdp, kHosts);
+  out += pick(fdp, kPaths);
+  out += pick(fdp, kQueries);
+  out += pick(fdp, kFrags);
+
+  // Optional splice of raw fuzz bytes to widen coverage.
+  if (fdp.ConsumeBool() && !out.empty()) {
+    std::string mid = fdp.ConsumeRandomLengthString(24);
+    size_t pos = fdp.ConsumeIntegralInRange<size_t>(0, out.size());
+    out.insert(pos, mid);
+  }
+
+  // Optional single-byte mutation.
+  if (fdp.ConsumeBool() && !out.empty()) {
+    size_t i = fdp.ConsumeIntegralInRange<size_t>(0, out.size() - 1);
+    out[i] = static_cast<char>(fdp.ConsumeIntegral<uint8_t>());
+  }
+
+  return out;
+}
+
+static void check_href_size(const ada::url& u, std::string_view input) {
+  if (u.get_href_size() != u.get_href().size()) {
+    printf(
+        "get_href_size mismatch (url)\n"
+        "  input: %.*s\n"
+        "  size:  %zu href.size: %zu\n"
+        "  href:  %s\n",
+        static_cast<int>(input.size()), input.data(), u.get_href_size(),
+        u.get_href().size(), u.get_href().c_str());
+    abort();
+  }
+}
+
+static void check_href_size(const ada::url_aggregator& u,
+                            std::string_view input) {
+  if (u.get_href_size() != u.get_href().size()) {
+    printf(
+        "get_href_size mismatch (aggregator)\n"
+        "  input: %.*s\n"
+        "  size:  %zu href.size: %zu\n"
+        "  href:  %s\n",
+        static_cast<int>(input.size()), input.data(), u.get_href_size(),
+        u.get_href().size(), std::string(u.get_href()).c_str());
+    abort();
+  }
+}
+
+template <class Result>
+static void check_reparse_idempotent(const Result& parsed,
+                                     std::string_view input) {
+  const std::string href = std::string(parsed.get_href());
+  auto again = ada::parse<Result>(href);
+  if (!again) {
+    printf(
+        "re-parse of href failed\n"
+        "  input: %.*s\n"
+        "  href:  %s\n",
+        static_cast<int>(input.size()), input.data(), href.c_str());
+    abort();
+  }
+  if (std::string(again->get_href()) != href) {
+    printf(
+        "href not idempotent\n"
+        "  input: %.*s\n"
+        "  href1: %s\n"
+        "  href2: %s\n",
+        static_cast<int>(input.size()), input.data(), href.c_str(),
+        std::string(again->get_href()).c_str());
+    abort();
+  }
+}
+
+static void check_components_agree(const ada::url& u,
+                                   const ada::url_aggregator& a,
+                                   std::string_view input) {
+  if (u.get_protocol() != a.get_protocol() ||
+      u.get_href() != std::string(a.get_href()) ||
+      std::string(u.get_hostname()) != std::string(a.get_hostname()) ||
+      std::string(u.get_pathname()) != std::string(a.get_pathname()) ||
+      std::string(u.get_search()) != std::string(a.get_search()) ||
+      std::string(u.get_hash()) != std::string(a.get_hash()) ||
+      std::string(u.get_port()) != std::string(a.get_port()) ||
+      u.get_username() != std::string(a.get_username()) ||
+      u.get_password() != std::string(a.get_password()) ||
+      std::string(u.get_host()) != std::string(a.get_host())) {
+    printf(
+        "url vs aggregator component mismatch\n"
+        "  input: %.*s\n"
+        "  url href: %s\n"
+        "  agg href: %s\n",
+        static_cast<int>(input.size()), input.data(), u.get_href().c_str(),
+        std::string(a.get_href()).c_str());
+    abort();
+  }
+}
+
+static void fuzz_one_input(std::string_view input) {
+  auto url = ada::parse<ada::url>(input);
+  auto agg = ada::parse<ada::url_aggregator>(input);
+
+  if (url.has_value() != agg.has_value()) {
+    printf(
+        "parse agreement failure\n"
+        "  input: %.*s\n"
+        "  url: %d aggregator: %d\n",
+        static_cast<int>(input.size()), input.data(), url.has_value(),
+        agg.has_value());
+    abort();
+  }
+
+  if (!url) {
+    return;
+  }
+
+  check_components_agree(*url, *agg, input);
+  check_href_size(*url, input);
+  check_href_size(*agg, input);
+  check_reparse_idempotent(*url, input);
+  check_reparse_idempotent(*agg, input);
+
+  // get_href hot path must stay consistent after set_href of the same href.
+  const std::string href = url->get_href();
+  url->set_href(href);
+  agg->set_href(href);
+  if (url->get_href() != std::string(agg->get_href())) {
+    printf(
+        "set_href agreement failure\n"
+        "  href: %s\n",
+        href.c_str());
+    abort();
+  }
+  check_href_size(*url, href);
+  check_href_size(*agg, href);
+
+  volatile bool valid = agg->validate();
+  (void)valid;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzedDataProvider fdp(data, size);
+
+  // 1) Structured candidate aimed at the simple-absolute fast path / gates.
+  std::string structured = make_candidate(fdp);
+  fuzz_one_input(structured);
+
+  // 2) Raw fuzz bytes as a pure absolute-URL-shaped input (prefix http(s)).
+  if (fdp.remaining_bytes() > 0) {
+    std::string raw = fdp.ConsumeRemainingBytesAsString();
+    if (raw.size() > 512) {
+      raw.resize(512);
+    }
+    // Occasionally force an http(s) prefix so the fast-path entry is reached.
+    if (!raw.empty() && (static_cast<unsigned char>(raw[0]) & 1u)) {
+      raw = std::string("https://") + raw;
+    } else if (!raw.empty()) {
+      raw = std::string("http://") + raw;
+    }
+    fuzz_one_input(raw);
+  }
+
+  // 3) Fixed seeds that must always be safe (dictionary-like corpus anchors).
+  static constexpr const char* kAnchors[] = {
+      "https://example.com",
+      "https://example.com/",
+      "https://example.com?q=1",
+      "https://example.com#frag",
+      "https://example.com/?q=1#frag",
+      "http://www.example.com/path/file.js",
+      "http://WWW.Example.COM/file.js",
+      "https://www.google.com/imghp?hl=en&tab=wi",
+      "http://192.168.0.1/x",
+      "http://0x7f.1/",
+      "https://user:pass@example.com/x",
+      "https://example.com:8080/x",
+      "https://example.com/a/./b/../c",
+      "https://example.com/foo/%2e%2e",
+      "https://xn--nxasmq6b.com/",
+      "https://xn--a/",
+  };
+  for (const char* seed : kAnchors) {
+    fuzz_one_input(seed);
+  }
+
+  return 0;
+}

--- a/fuzz/simple_absolute.options
+++ b/fuzz/simple_absolute.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+dict = url.dict
+max_len = 1024

--- a/fuzz/url.dict
+++ b/fuzz/url.dict
@@ -28,6 +28,31 @@
 "file:///C:/path/to/file"
 "ftp://ftp.example.com/resource"
 
+# Simple-absolute fast path (clean http(s), no auth/port/IPv4/IDNA)
+"https://example.com"
+"https://example.com/"
+"https://example.com?q=1"
+"https://example.com#frag"
+"https://example.com/?q=1#frag"
+"http://www.example.com/path/file.js"
+"https://www.google.com/imghp?hl=en&tab=wi"
+"http://WWW.Example.COM/file.js"
+"https://example.com/path?continue=https%3A%2F%2Fexample.com%2F"
+
+# Simple-absolute intentional fall-throughs
+"http://192.168.0.1/x"
+"http://0x7f.1/"
+"http://127.1/"
+"https://user@example.com/"
+"https://user:pass@example.com/x"
+"https://example.com:8080/x"
+"https://example.com/a/./b/../c"
+"https://example.com/foo/%2e"
+"https://example.com/foo/%2e%2e"
+"https://xn--nxasmq6b.com/"
+"https://xn--a/"
+"http://example.com\\path"
+
 # Encoded characters
 "%2f"
 "%40"

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -104,29 +104,12 @@ extern template ada::result<url_aggregator> parse<url_aggregator>(
 /**
  * Checks whether a URL string can be successfully parsed.
  *
- * Returns the same result as `parse(input, base).has_value()` for every
- * input, including when `set_max_input_length` rejects a URL whose
- * *normalized* form exceeds the limit. A fast structural path is used for
- * common absolute special URLs; otherwise the full parser decides.
+ * Equivalent to `parse(input, base).has_value()` for every input, including
+ * when `set_max_input_length` rejects a normalized href that exceeds the limit.
  *
  * @param input The URL string to validate. Must be valid ASCII or UTF-8.
- * @param base_input Optional pointer to a base URL string for resolving
- *        relative URLs. If nullptr (default), the input is validated as
- *        an absolute URL.
- *
- * @return `true` if the URL can be parsed successfully, `false` otherwise.
- *
- * @example
- * ```cpp
- * // Check absolute URL
- * bool valid = ada::can_parse("https://example.com"); // true
- * bool invalid = ada::can_parse("not a url");         // false
- *
- * // Check relative URL with base
- * std::string_view base = "https://example.com/";
- * bool relative_valid = ada::can_parse("../path", &base); // true
- * ```
- *
+ * @param base_input Optional base URL string for relative inputs.
+ * @return `true` if parsing would succeed, `false` otherwise.
  * @see https://url.spec.whatwg.org/#dom-url-canparse
  */
 bool can_parse(std::string_view input,

--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -104,15 +104,10 @@ extern template ada::result<url_aggregator> parse<url_aggregator>(
 /**
  * Checks whether a URL string can be successfully parsed.
  *
- * This is a fast validation function that checks if a URL string is valid
- * according to the WHATWG URL Standard without fully constructing a URL
- * object. Use this when you only need to validate URLs without needing
- * their parsed components.
- *
- * When `get_max_input_length()` is set to a value smaller than the default,
- * `can_parse` may still return `true` for overlength inputs that are
- * structurally valid, because the fast path skips the length check for
- * performance. Use `parse()` when strict length enforcement is required.
+ * Returns the same result as `parse(input, base).has_value()` for every
+ * input, including when `set_max_input_length` rejects a URL whose
+ * *normalized* form exceeds the limit. A fast structural path is used for
+ * common absolute special URLs; otherwise the full parser decides.
  *
  * @param input The URL string to validate. Must be valid ASCII or UTF-8.
  * @param base_input Optional pointer to a base URL string for resolving

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -72,6 +72,14 @@ extern template url_aggregator parse_url_impl<url_aggregator, false>(
 extern template url parse_url_impl<url, true>(std::string_view user_input,
                                               const url* base_url);
 
+/**
+ * @private
+ * Fast path for simple absolute http(s) URLs. Fills `out` and returns true on
+ * success; returns false to fall through to the full parser.
+ */
+template <class result_type>
+bool try_parse_simple_absolute(std::string_view input, result_type& out);
+
 #if ADA_INCLUDE_URL_PATTERN
 template <url_pattern_regex::regex_concept regex_provider>
 tl::expected<url_pattern<regex_provider>, errors> parse_url_pattern_impl(

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -72,11 +72,7 @@ extern template url_aggregator parse_url_impl<url_aggregator, false>(
 extern template url parse_url_impl<url, true>(std::string_view user_input,
                                               const url* base_url);
 
-/**
- * @private
- * Fast path for simple absolute http(s) URLs. Fills `out` and returns true on
- * success; returns false to fall through to the full parser.
- */
+/** @private */
 template <class result_type>
 bool try_parse_simple_absolute(std::string_view input, result_type& out);
 

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -209,17 +209,21 @@ constexpr void url::copy_scheme(const ada::url& u) {
     p[1] = '/';
     p[2] = '/';
     p += 3;
+    // Sized copy into a pre-sized std::string; not a C string.
+    // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
     std::memcpy(p, host->data(), host_size);
     p += host_size;
     std::memcpy(p, path.data(), path_size);
     p += path_size;
     if (query.has_value()) {
       *p++ = '?';
+      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
       std::memcpy(p, query->data(), query_size);
       p += query_size;
     }
     if (hash.has_value()) {
       *p++ = '#';
+      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
       std::memcpy(p, hash->data(), hash_size);
     }
     return output;

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -191,8 +191,7 @@ constexpr void url::copy_scheme(const ada::url& u) {
   // temporaries like "?" + query, no get_href_size pre-walk).
   if (is_special() && host.has_value() && username.empty() &&
       password.empty() && !port.has_value()) [[likely]] {
-    const std::string_view scheme =
-        ada::scheme::details::is_special_list[type];
+    const std::string_view scheme = ada::scheme::details::is_special_list[type];
     const size_t host_size = host->size();
     const size_t path_size = path.size();
     const size_t query_size = query.has_value() ? query->size() : 0;

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -9,6 +9,7 @@
 #include "ada/url_components.h"
 
 #include <charconv>
+#include <cstring>
 #include <optional>
 #include <string>
 #if ADA_REGULAR_VISUAL_STUDIO
@@ -185,33 +186,92 @@ constexpr void url::copy_scheme(const ada::url& u) {
 }
 
 [[nodiscard]] ada_really_inline std::string url::get_href() const {
-  std::string output = get_protocol();
+  // Hot path: special scheme, host present, no credentials/port.
+  // Write directly into a pre-sized buffer with memcpy (no intermediate
+  // temporaries like "?" + query, no get_href_size pre-walk).
+  if (is_special() && host.has_value() && username.empty() &&
+      password.empty() && !port.has_value()) [[likely]] {
+    const std::string_view scheme =
+        ada::scheme::details::is_special_list[type];
+    const size_t host_size = host->size();
+    const size_t path_size = path.size();
+    const size_t query_size = query.has_value() ? query->size() : 0;
+    const size_t hash_size = hash.has_value() ? hash->size() : 0;
+    // scheme + "://" + host + path + optional ("?" + query) + optional ("#" +
+    // hash)
+    const size_t total = scheme.size() + 3 + host_size + path_size +
+                         (query.has_value() ? query_size + 1 : 0) +
+                         (hash.has_value() ? hash_size + 1 : 0);
+    std::string output(total, '\0');
+    char* p = output.data();
+    std::memcpy(p, scheme.data(), scheme.size());
+    p += scheme.size();
+    p[0] = ':';
+    p[1] = '/';
+    p[2] = '/';
+    p += 3;
+    std::memcpy(p, host->data(), host_size);
+    p += host_size;
+    std::memcpy(p, path.data(), path_size);
+    p += path_size;
+    if (query.has_value()) {
+      *p++ = '?';
+      std::memcpy(p, query->data(), query_size);
+      p += query_size;
+    }
+    if (hash.has_value()) {
+      *p++ = '#';
+      std::memcpy(p, hash->data(), hash_size);
+    }
+    return output;
+  }
+
+  // General path: pre-size and append pieces to avoid temporary concatenations.
+  std::string output;
+  output.reserve(get_href_size());
+
+  if (is_special()) {
+    output.append(ada::scheme::details::is_special_list[type]);
+    output += ':';
+  } else {
+    output.append(non_special_scheme);
+    output += ':';
+  }
 
   if (host.has_value()) {
-    output += "//";
+    output += '/';
+    output += '/';
     if (has_credentials()) {
-      output += username;
+      output.append(username);
       if (!password.empty()) {
-        output += ":" + get_password();
+        output += ':';
+        output.append(password);
       }
-      output += "@";
+      output += '@';
     }
-    output += host.value();
+    output.append(*host);
     if (port.has_value()) {
-      output += ":" + get_port();
+      output += ':';
+      char port_buf[5];
+      auto [ptr, ec] = std::to_chars(port_buf, port_buf + 5, *port);
+      (void)ec;
+      output.append(port_buf, static_cast<size_t>(ptr - port_buf));
     }
   } else if (!has_opaque_path && path.starts_with("//")) {
     // If url's host is null, url does not have an opaque path, url's path's
     // size is greater than 1, and url's path[0] is the empty string, then
     // append U+002F (/) followed by U+002E (.) to output.
-    output += "/.";
+    output += '/';
+    output += '.';
   }
-  output += path;
+  output.append(path);
   if (query.has_value()) {
-    output += "?" + query.value();
+    output += '?';
+    output.append(*query);
   }
   if (hash.has_value()) {
-    output += "#" + hash.value();
+    output += '#';
+    output.append(*hash);
   }
   return output;
 }

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -186,9 +186,6 @@ constexpr void url::copy_scheme(const ada::url& u) {
 }
 
 [[nodiscard]] ada_really_inline std::string url::get_href() const {
-  // Hot path: special scheme, host present, no credentials/port.
-  // Write directly into a pre-sized buffer with memcpy (no intermediate
-  // temporaries like "?" + query, no get_href_size pre-walk).
   if (is_special() && host.has_value() && username.empty() &&
       password.empty() && !port.has_value()) [[likely]] {
     const std::string_view scheme = ada::scheme::details::is_special_list[type];
@@ -196,8 +193,6 @@ constexpr void url::copy_scheme(const ada::url& u) {
     const size_t path_size = path.size();
     const size_t query_size = query.has_value() ? query->size() : 0;
     const size_t hash_size = hash.has_value() ? hash->size() : 0;
-    // scheme + "://" + host + path + optional ("?" + query) + optional ("#" +
-    // hash)
     const size_t total = scheme.size() + 3 + host_size + path_size +
                          (query.has_value() ? query_size + 1 : 0) +
                          (hash.has_value() ? hash_size + 1 : 0);
@@ -209,7 +204,6 @@ constexpr void url::copy_scheme(const ada::url& u) {
     p[1] = '/';
     p[2] = '/';
     p += 3;
-    // Sized copy into a pre-sized std::string; not a C string.
     // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
     std::memcpy(p, host->data(), host_size);
     p += host_size;
@@ -229,7 +223,6 @@ constexpr void url::copy_scheme(const ada::url& u) {
     return output;
   }
 
-  // General path: pre-size and append pieces to avoid temporary concatenations.
   std::string output;
   output.reserve(get_href_size());
 
@@ -280,9 +273,7 @@ constexpr void url::copy_scheme(const ada::url& u) {
 }
 
 [[nodiscard]] inline size_t url::get_href_size() const noexcept {
-  // Mirrors the logic of get_href() but only computes the total size.
   size_t size = 0;
-  // Protocol: scheme + ":"
   if (is_special()) {
     size += ada::scheme::details::is_special_list[type].size() + 1;
   } else {
@@ -290,17 +281,16 @@ constexpr void url::copy_scheme(const ada::url& u) {
   }
   if (host.has_value()) {
     size += host->size();
-    size += 2;  // "//"
+    size += 2;
     if (has_credentials()) {
       size += username.size();
       if (!password.empty()) {
-        size += 1 + password.size();  // ":" + password
+        size += 1 + password.size();
       }
-      size += 1;  // "@"
+      size += 1;
     }
     if (port.has_value()) {
-      size += 1;  // ":"
-      // Count digits of port value without calling std::to_string.
+      size += 1;
       uint16_t p = *port;
       size += (p >= 10000)  ? 5
               : (p >= 1000) ? 4
@@ -309,14 +299,14 @@ constexpr void url::copy_scheme(const ada::url& u) {
                             : 1;
     }
   } else if (!has_opaque_path && path.starts_with("//")) {
-    size += 2;  // "/."
+    size += 2;
   }
   size += path.size();
   if (query.has_value()) {
-    size += 1 + query->size();  // "?" + query
+    size += 1 + query->size();
   }
   if (hash.has_value()) {
-    size += 1 + hash->size();  // "#" + hash
+    size += 1 + hash->size();
   }
   return size;
 }

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -382,6 +382,9 @@ struct url : url_base {
       ada::url_aggregator, true>(std::string_view, const ada::url_aggregator*);
   friend ada::url_aggregator ada::parser::parse_url_impl<
       ada::url_aggregator, false>(std::string_view, const ada::url_aggregator*);
+  template <class result_type>
+  friend bool ada::parser::try_parse_simple_absolute(std::string_view,
+                                                     result_type&);
 
   inline void update_unencoded_base_hash(std::string_view input);
   inline void update_base_hostname(std::string_view input);

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -323,8 +323,7 @@ struct url_aggregator : url_base {
   friend url_aggregator parser::parse_url_impl<url_aggregator, false>(
       std::string_view, const url_aggregator*);
   template <class result_type>
-  friend bool parser::try_parse_simple_absolute(std::string_view,
-                                                result_type&);
+  friend bool parser::try_parse_simple_absolute(std::string_view, result_type&);
 
 #if ADA_INCLUDE_URL_PATTERN
   // url_pattern methods

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -322,6 +322,9 @@ struct url_aggregator : url_base {
       std::string_view, const url_aggregator*);
   friend url_aggregator parser::parse_url_impl<url_aggregator, false>(
       std::string_view, const url_aggregator*);
+  template <class result_type>
+  friend bool parser::try_parse_simple_absolute(std::string_view,
+                                                result_type&);
 
 #if ADA_INCLUDE_URL_PATTERN
   // url_pattern methods

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -312,6 +312,32 @@ std::string href_from_file(std::string_view input) {
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {
   // Must match parse().has_value(), including post-normalization max length.
+  // Percent-encoding expands a byte by at most 3x. When the input (plus base,
+  // if any) fits in max_length/3, the normalized href cannot exceed
+  // max_length, so validation-only parsing (store_values=false) is safe.
+
+  // Hot path first: absolute special URLs, no base. Avoid loading max_length
+  // until we need it (common absolute-fast true/false cases).
+  if (base_input == nullptr) {
+    if (const auto r = try_can_parse_absolute_fast(input)) {
+      if (!*r) {
+        return false;
+      }
+      // size <= max/3 => normalized href cannot exceed max (3x expansion).
+      // Check this first: default max is ~4GB so almost all URLs return true.
+      const uint32_t max_length = ada::get_max_input_length();
+      if (input.size() <= static_cast<size_t>(max_length) / 3) {
+        return true;
+      }
+      if (input.size() > max_length) {
+        return false;
+      }
+      return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
+                                                                    nullptr)
+          .is_valid;
+    }
+  }
+
   const uint32_t max_length = ada::get_max_input_length();
   if (input.size() > max_length) {
     return false;
@@ -320,22 +346,30 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
     return false;
   }
 
-  // Fast path: false is definitive; true is only safe when percent-encoding
-  // cannot expand past max_length (at most 3x per byte).
-  if (base_input == nullptr) {
-    if (const auto r = try_can_parse_absolute_fast(input)) {
-      if (!*r) {
+  // Relative resolution combines base + input; bound the sum so 3x expansion
+  // of either side cannot push the final href past max_length.
+  const size_t combined =
+      input.size() + (base_input == nullptr ? 0 : base_input->size());
+  const bool size_safe = combined <= static_cast<size_t>(max_length) / 3;
+
+  if (size_safe) {
+    // Validation-only: no buffer build, host still fully checked.
+    ada::url_aggregator base_agg;
+    ada::url_aggregator* base_ptr = nullptr;
+    if (base_input != nullptr) {
+      base_agg = ada::parser::parse_url_impl<ada::url_aggregator, false>(
+          *base_input, nullptr);
+      if (!base_agg.is_valid) {
         return false;
       }
-      if (input.size() <= static_cast<size_t>(max_length) / 3) {
-        return true;
-      }
-      return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
-                                                                    nullptr)
-          .is_valid;
+      base_ptr = &base_agg;
     }
+    return ada::parser::parse_url_impl<ada::url_aggregator, false>(input,
+                                                                   base_ptr)
+        .is_valid;
   }
 
+  // Near the limit: full parse so post-normalization length matches parse().
   if (base_input == nullptr) {
     return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
                                                                   nullptr)

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -311,21 +311,10 @@ std::string href_from_file(std::string_view input) {
 }
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {
-  // Fast path: handles the overwhelming majority of inputs -- absolute special
-  // URLs with an ASCII domain, no credentials, and no base -- with a single
-  // forward scan and zero allocations.
-  if (base_input == nullptr) {
-    if (const auto r = try_can_parse_absolute_fast(input)) {
-      return *r;
-    }
-  }
+  // can_parse must agree with parse().has_value() for every input. That
+  // includes ada::set_max_input_length limits applied to the *normalized*
+  // href (percent-encoding, IDNA, ...), not only the raw input size.
 
-  // Reject inputs that exceed the configurable maximum length.
-  // This check is placed after the fast path so the common case (default 4 GB
-  // limit, absolute URLs) pays no overhead.
-  // Note: can_parse() does not perform normalization (percent-encoding, IDNA),
-  // so it cannot detect cases where a short input normalizes into a long URL.
-  // In such edge cases can_parse() may return true while parse() fails.
   const uint32_t max_length = ada::get_max_input_length();
   if (input.size() > max_length) {
     return false;
@@ -334,21 +323,47 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
     return false;
   }
 
-  // Fallback: run the parser in validation-only mode (store_values=false),
-  // which skips all the expensive work that isn't needed to determine validity:
-  // buffer reservation, credential encoding, path normalisation, query and
-  // fragment percent-encoding.  The host is still fully validated (IDNA, IPv4,
-  // IPv6) because parse_host() must run for correctness.
-  ada::url_aggregator base_agg;
-  ada::url_aggregator* base_ptr = nullptr;
-  if (base_input != nullptr) {
-    base_agg = ada::parser::parse_url_impl<ada::url_aggregator, false>(
-        *base_input, nullptr);
-    if (!base_agg.is_valid) return false;
-    base_ptr = &base_agg;
+  // Fast path: absolute special (non-file) ASCII URLs with no credentials /
+  // IDNA / IPv6. Only used when we can prove the result matches parse():
+  //   - false  -> definitely invalid (same as parse)
+  //   - true   -> valid only if the normalized href cannot exceed max_length.
+  //               Percent-encoding expands each byte by at most 3x, so when
+  //               input.size() <= max_length/3 the expansion cannot breach
+  //               the limit. Near the limit we fall through to full parse.
+  //   - nullopt -> edge case; full parse decides.
+  if (base_input == nullptr) {
+    if (const auto r = try_can_parse_absolute_fast(input)) {
+      if (!*r) {
+        return false;
+      }
+      if (input.size() <= static_cast<size_t>(max_length) / 3) {
+        return true;
+      }
+      // Structurally valid but near the size limit: confirm with full parse
+      // so post-normalization length is enforced exactly as in parse().
+      return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
+                                                                    nullptr)
+          .is_valid;
+    }
   }
-  return ada::parser::parse_url_impl<ada::url_aggregator, false>(input,
-                                                                 base_ptr)
+
+  // Full parse with store_values=true so the post-normalization length check
+  // in parse_url_impl matches parse(). Validation-only mode (store_values=
+  // false) skips that check and historically allowed can_parse/parse to
+  // disagree when a short input expanded past max_input_length.
+  if (base_input == nullptr) {
+    return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
+                                                                  nullptr)
+        .is_valid;
+  }
+  ada::url_aggregator base_agg =
+      ada::parser::parse_url_impl<ada::url_aggregator, true>(*base_input,
+                                                             nullptr);
+  if (!base_agg.is_valid) {
+    return false;
+  }
+  return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
+                                                                &base_agg)
       .is_valid;
 }
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -311,10 +311,7 @@ std::string href_from_file(std::string_view input) {
 }
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {
-  // can_parse must agree with parse().has_value() for every input. That
-  // includes ada::set_max_input_length limits applied to the *normalized*
-  // href (percent-encoding, IDNA, ...), not only the raw input size.
-
+  // Must match parse().has_value(), including post-normalization max length.
   const uint32_t max_length = ada::get_max_input_length();
   if (input.size() > max_length) {
     return false;
@@ -323,14 +320,8 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
     return false;
   }
 
-  // Fast path: absolute special (non-file) ASCII URLs with no credentials /
-  // IDNA / IPv6. Only used when we can prove the result matches parse():
-  //   - false  -> definitely invalid (same as parse)
-  //   - true   -> valid only if the normalized href cannot exceed max_length.
-  //               Percent-encoding expands each byte by at most 3x, so when
-  //               input.size() <= max_length/3 the expansion cannot breach
-  //               the limit. Near the limit we fall through to full parse.
-  //   - nullopt -> edge case; full parse decides.
+  // Fast path: false is definitive; true is only safe when percent-encoding
+  // cannot expand past max_length (at most 3x per byte).
   if (base_input == nullptr) {
     if (const auto r = try_can_parse_absolute_fast(input)) {
       if (!*r) {
@@ -339,18 +330,12 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
       if (input.size() <= static_cast<size_t>(max_length) / 3) {
         return true;
       }
-      // Structurally valid but near the size limit: confirm with full parse
-      // so post-normalization length is enforced exactly as in parse().
       return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
                                                                     nullptr)
           .is_valid;
     }
   }
 
-  // Full parse with store_values=true so the post-normalization length check
-  // in parse_url_impl matches parse(). Validation-only mode (store_values=
-  // false) skips that check and historically allowed can_parse/parse to
-  // disagree when a short input expanded past max_input_length.
   if (base_input == nullptr) {
     return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
                                                                   nullptr)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,18 +1,350 @@
 #include "ada/parser-inl.h"
 
+#include <array>
+#include <cstring>
 #include <limits>
 #include <ranges>
 
 #include "ada/character_sets-inl.h"
+#include "ada/checkers-inl.h"
 #include "ada/common_defs.h"
 #include "ada/implementation.h"
 #include "ada/log.h"
+#include "ada/scheme-inl.h"
+#include "ada/unicode-inl.h"
 #include "ada/unicode.h"
 #include "ada/url.h"
 #include "ada/url_aggregator.h"
 #include "ada/url_aggregator-inl.h"
 
 namespace ada::parser {
+
+// Fast path for absolute http(s) URLs that are already fully normalized:
+// lowercase scheme/host, no credentials/port/IPv4/IPv6/IDNA, no percent-
+// encoding, and no "." / ".." path segments. One table-driven scan, then a
+// single buffer assign (aggregator) or a few component copies (url).
+//
+// Returns true and fills `out` on success. Returns false with no writes.
+// Friend of url / url_aggregator for private buffer access.
+namespace {
+
+// 0 = ok in host, 1 = host delimiter (/ ? #), 2 = reject (full parser)
+// Mirrors the WHATWG forbidden-domain-code-point set: anything else is ok.
+constexpr std::array<uint8_t, 256> k_host_class = []() consteval {
+  std::array<uint8_t, 256> t{};
+  // Default: accept printable ASCII that is not a forbidden domain code point.
+  for (size_t i = 0; i < 256; ++i) {
+    t[i] = 2;
+  }
+  for (size_t i = 0x21; i <= 0x7E; ++i) {
+    t[i] = 0;
+  }
+  // Forbidden domain code points that fall in 0x21-0x7E.
+  for (uint8_t c : {'#', '/', ':', '<', '>', '?', '@', '[', '\\', ']', '^',
+                    '|', '%'}) {
+    t[c] = 2;
+  }
+  // Delimiters that end the host (also forbidden as host bytes).
+  t[static_cast<uint8_t>('/')] = 1;
+  t[static_cast<uint8_t>('?')] = 1;
+  t[static_cast<uint8_t>('#')] = 1;
+  return t;
+}();
+
+// Bytes in path/query/fragment: 0 = ok, 1 = ? or # delimiter, 2 = reject.
+// Conservative union of path + special-query + fragment percent-encode sets
+// so one scan decides whether a pure copy is safe.
+constexpr std::array<uint8_t, 256> k_rest = []() consteval {
+  std::array<uint8_t, 256> t{};
+  for (size_t i = 0; i < 256; ++i) {
+    t[i] = 2;
+  }
+  for (uint8_t c = 0x21; c <= 0x7E; ++c) {
+    t[c] = 0;
+  }
+  // Encode-set / special rejects. '%' is NOT allowed in the path table:
+  // "%2e" / "%2e%2e" are single/double-dot segments and need the full parser.
+  // Query/fragment scans allow '%' explicitly (already-encoded stays as-is).
+  for (uint8_t c : {static_cast<uint8_t>('"'), static_cast<uint8_t>('<'),
+                    static_cast<uint8_t>('>'), static_cast<uint8_t>('`'),
+                    static_cast<uint8_t>('{'), static_cast<uint8_t>('}'),
+                    static_cast<uint8_t>('^'), static_cast<uint8_t>('\\'),
+                    static_cast<uint8_t>('%'), static_cast<uint8_t>('\'')}) {
+    t[c] = 2;
+  }
+  t[static_cast<uint8_t>('?')] = 1;
+  t[static_cast<uint8_t>('#')] = 1;
+  return t;
+}();
+
+}  // namespace
+
+template <class result_type>
+ada_really_inline bool try_parse_simple_absolute(std::string_view input,
+                                                 result_type& out) {
+  constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
+  constexpr bool is_aggregator =
+      std::is_same_v<result_type, ada::url_aggregator>;
+  static_assert(is_ada_url || is_aggregator);
+
+  const size_t len = input.size();
+  if (len < 8) [[unlikely]] {
+    return false;
+  }
+  const auto* b = reinterpret_cast<const uint8_t*>(input.data());
+
+  size_t pos;
+  ada::scheme::type scheme_type;
+  uint32_t protocol_end;
+  // Lowercase http:// or https:// only.
+  if (b[0] == 'h' && b[1] == 't' && b[2] == 't' && b[3] == 'p') {
+    if (b[4] == ':' && b[5] == '/' && b[6] == '/') {
+      pos = 7;
+      scheme_type = ada::scheme::type::HTTP;
+      protocol_end = 5;
+    } else if (len >= 8 && b[4] == 's' && b[5] == ':' && b[6] == '/' &&
+               b[7] == '/') {
+      pos = 8;
+      scheme_type = ada::scheme::type::HTTPS;
+      protocol_end = 6;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+  if (pos < len && (b[pos] == '/' || b[pos] == '\\')) [[unlikely]] {
+    return false;
+  }
+
+  // --- Host ---
+  const size_t host_start = pos;
+  bool has_upper = false;
+  size_t i = pos;
+  for (; i < len; ++i) {
+    const uint8_t c = b[i];
+    const uint8_t cls = k_host_class[c];
+    if (cls == 1) {
+      break;  // / ? #
+    }
+    if (cls == 2) [[unlikely]] {
+      return false;
+    }
+    if (c >= 'A' && c <= 'Z') {
+      has_upper = true;
+    }
+  }
+  const size_t host_end = i;
+  if (host_start == host_end) [[unlikely]] {
+    return false;
+  }
+  const size_t host_len = host_end - host_start;
+  // IPv4 (decimal/hex/octal) needs the dedicated parser. checkers::is_ipv4
+  // expects lowercase — only copy+lower when the host has uppercase.
+  // DNS max label total is 253; oversized hosts fall through.
+  if (host_len > 253) [[unlikely]] {
+    return false;
+  }
+  {
+    std::string_view hv(input.data() + host_start, host_len);
+    char host_buf[256];
+    if (has_upper) [[unlikely]] {
+      std::memcpy(host_buf, input.data() + host_start, host_len);
+      unicode::to_lower_ascii(host_buf, host_len);
+      hv = std::string_view(host_buf, host_len);
+    }
+    if (checkers::is_ipv4(hv)) [[unlikely]] {
+      return false;
+    }
+    // Punycode prefix requires IDNA (hv is lowercased when needed).
+    static constexpr std::string_view xn{"xn-", 3};
+    if (hv.find(xn) != std::string_view::npos) [[unlikely]] {
+      return false;
+    }
+  }
+
+  // --- Path / query / fragment ---
+  // Path loop is deliberately minimal: table lookup + delimiter only.
+  // Dot-segment checks run once after the path is bounded (rare '.').
+  size_t path_start = host_end;
+  size_t path_end = host_end;
+  size_t query_start = std::string_view::npos;
+  size_t hash_start = std::string_view::npos;
+  bool has_path = false;
+  bool path_has_dot = false;
+
+  if (i < len && b[i] == '/') {
+    has_path = true;
+    path_start = i;
+    ++i;
+    for (; i < len; ++i) {
+      const uint8_t c = b[i];
+      const uint8_t cls = k_rest[c];
+      if (cls == 0) {
+        path_has_dot |= (c == '.');
+        continue;
+      }
+      if (cls == 1) {
+        path_end = i;
+        if (c == '?') {
+          query_start = i;
+          ++i;
+          goto scan_query;
+        }
+        hash_start = i;
+        ++i;
+        goto scan_hash;
+      }
+      return false;  // cls == 2
+    }
+    path_end = i;
+  } else if (i < len && b[i] == '?') {
+    query_start = i;
+    ++i;
+    goto scan_query;
+  } else if (i < len && b[i] == '#') {
+    hash_start = i;
+    ++i;
+    goto scan_hash;
+  }
+  goto after_rest;
+
+scan_query:
+  // Special-query percent-encode set does not include '%', so encoded
+  // sequences copy through. Allow '%' here (unlike the path table).
+  for (; i < len; ++i) {
+    const uint8_t c = b[i];
+    if (c == '#') {
+      hash_start = i;
+      ++i;
+      goto scan_hash;
+    }
+    if (c == '?' || c == '%') {
+      continue;
+    }
+    if (k_rest[c] == 2) [[unlikely]] {
+      return false;
+    }
+  }
+  goto after_rest;
+
+scan_hash:
+  // Fragment percent-encode set does not include '%'.
+  for (; i < len; ++i) {
+    const uint8_t c = b[i];
+    if (c == '?' || c == '#' || c == '%') {
+      continue;
+    }
+    if (k_rest[c] == 2) [[unlikely]] {
+      return false;
+    }
+  }
+
+after_rest:
+  // Reject "." / ".." path segments (only when path contains a '.').
+  if (path_has_dot) [[unlikely]] {
+    const std::string_view path_body(input.data() + path_start,
+                                     path_end - path_start);
+    // path_body starts with '/'
+    if (path_body.size() >= 2 && path_body[1] == '.') {
+      if (path_body.size() == 2 || path_body[2] == '/' ||
+          (path_body.size() >= 3 && path_body[2] == '.' &&
+           (path_body.size() == 3 || path_body[3] == '/'))) {
+        return false;
+      }
+    }
+    static constexpr std::string_view slash_dot{"/.", 2};
+    size_t p = 1;
+    while ((p = path_body.find(slash_dot, p)) != std::string_view::npos) {
+      const size_t after = p + 2;
+      if (after == path_body.size() || path_body[after] == '/' ||
+          (after + 1 <= path_body.size() && path_body[after] == '.' &&
+           (after + 1 == path_body.size() || path_body[after + 1] == '/'))) {
+        return false;
+      }
+      p = after;
+    }
+  }
+
+  const bool need_slash = !has_path;
+  out.type = scheme_type;
+  out.is_valid = true;
+  out.has_opaque_path = false;
+  out.host_type = DEFAULT;
+
+  if constexpr (is_aggregator) {
+    if (!need_slash) {
+      // Direct resize + memcpy is slightly faster than assign on libc++.
+      out.buffer.resize(len);
+      std::memcpy(out.buffer.data(), input.data(), len);
+      if (has_upper) {
+        unicode::to_lower_ascii(out.buffer.data() + host_start,
+                                host_end - host_start);
+      }
+      out.components.protocol_end = protocol_end;
+      out.components.username_end = protocol_end + 2;
+      out.components.host_start = protocol_end + 2;
+      out.components.host_end = static_cast<uint32_t>(host_end);
+      out.components.port = url_components::omitted;
+      out.components.pathname_start = static_cast<uint32_t>(path_start);
+      out.components.search_start =
+          (query_start != std::string_view::npos)
+              ? static_cast<uint32_t>(query_start)
+              : url_components::omitted;
+      out.components.hash_start =
+          (hash_start != std::string_view::npos)
+              ? static_cast<uint32_t>(hash_start)
+              : url_components::omitted;
+    } else {
+      out.buffer.resize(len + 1);
+      std::memcpy(out.buffer.data(), input.data(), host_end);
+      out.buffer[host_end] = '/';
+      if (host_end < len) {
+        std::memcpy(out.buffer.data() + host_end + 1, input.data() + host_end,
+                    len - host_end);
+      }
+      if (has_upper) {
+        unicode::to_lower_ascii(out.buffer.data() + host_start,
+                                host_end - host_start);
+      }
+      out.components.protocol_end = protocol_end;
+      out.components.username_end = protocol_end + 2;
+      out.components.host_start = protocol_end + 2;
+      out.components.host_end = static_cast<uint32_t>(host_end);
+      out.components.port = url_components::omitted;
+      out.components.pathname_start = static_cast<uint32_t>(host_end);
+      out.components.search_start =
+          (query_start != std::string_view::npos)
+              ? static_cast<uint32_t>(query_start + 1)
+              : url_components::omitted;
+      out.components.hash_start =
+          (hash_start != std::string_view::npos)
+              ? static_cast<uint32_t>(hash_start + 1)
+              : url_components::omitted;
+    }
+  } else {
+    std::string host_str(input.substr(host_start, host_end - host_start));
+    if (has_upper) {
+      unicode::to_lower_ascii(host_str.data(), host_str.size());
+    }
+    out.host = std::move(host_str);
+    if (need_slash) {
+      out.path = "/";
+    } else {
+      out.path.assign(input.data() + path_start, path_end - path_start);
+    }
+    if (query_start != std::string_view::npos) {
+      const size_t q_end =
+          (hash_start != std::string_view::npos) ? hash_start : len;
+      out.query.emplace(input.data() + query_start + 1,
+                        q_end - query_start - 1);
+    }
+    if (hash_start != std::string_view::npos) {
+      out.hash.emplace(input.data() + hash_start + 1, len - hash_start - 1);
+    }
+  }
+  return true;
+}
 
 template <class result_type, bool store_values>
 result_type parse_url_impl(std::string_view user_input,
@@ -53,6 +385,36 @@ result_type parse_url_impl(std::string_view user_input,
   if (!url.is_valid) {
     return url;
   }
+
+  // Fast path FIRST on the raw input: absolute special http(s) URLs with a
+  // clean ASCII host and no transforms. Running before has_tabs_or_newline
+  // avoids a full-string SIMD scan on the common case. Tabs/newlines/C0 in
+  // the input cause the fast path to reject and fall through.
+  // can_parse (store_values=false) has its own fast path in implementation.cpp.
+  if constexpr (store_values) {
+    if (base_url == nullptr) [[likely]] {
+      if (try_parse_simple_absolute(user_input, url)) [[likely]] {
+        return url;
+      }
+    }
+  }
+
+  std::string tmp_buffer;
+  std::string_view url_data;
+  if (unicode::has_tabs_or_newline(user_input)) [[unlikely]] {
+    tmp_buffer = user_input;
+    // Optimization opportunity: Instead of copying and then pruning, we could
+    // just directly build the string from user_input.
+    helpers::remove_ascii_tab_or_newline(tmp_buffer);
+    url_data = tmp_buffer;
+  } else [[likely]] {
+    url_data = user_input;
+  }
+
+  // Leading and trailing control characters are uncommon and easy to deal with
+  // (no performance concern).
+  helpers::trim_c0_whitespace(url_data);
+
   if constexpr (result_type_is_ada_url_aggregator && store_values) {
     // Most of the time, we just need user_input.size().
     // In some instances, we may need a bit more.
@@ -71,21 +433,6 @@ result_type parse_url_impl(std::string_view user_input,
         1;
     url.reserve(reserve_capacity);
   }
-  std::string tmp_buffer;
-  std::string_view url_data;
-  if (unicode::has_tabs_or_newline(user_input)) [[unlikely]] {
-    tmp_buffer = user_input;
-    // Optimization opportunity: Instead of copying and then pruning, we could
-    // just directly build the string from user_input.
-    helpers::remove_ascii_tab_or_newline(tmp_buffer);
-    url_data = tmp_buffer;
-  } else [[likely]] {
-    url_data = user_input;
-  }
-
-  // Leading and trailing control characters are uncommon and easy to deal with
-  // (no performance concern).
-  helpers::trim_c0_whitespace(url_data);
 
   // Optimization opportunity. Most websites do not have fragment.
   std::optional<std::string_view> fragment = helpers::prune_hash(url_data);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -40,8 +40,8 @@ constexpr std::array<uint8_t, 256> k_host_class = []() consteval {
     t[i] = 0;
   }
   // Forbidden domain code points that fall in 0x21-0x7E.
-  for (uint8_t c : {'#', '/', ':', '<', '>', '?', '@', '[', '\\', ']', '^',
-                    '|', '%'}) {
+  for (uint8_t c :
+       {'#', '/', ':', '<', '>', '?', '@', '[', '\\', ']', '^', '|', '%'}) {
     t[c] = 2;
   }
   // Delimiters that end the host (also forbidden as host bytes).
@@ -140,7 +140,7 @@ ada_really_inline bool try_parse_simple_absolute(std::string_view input,
   }
   const size_t host_len = host_end - host_start;
   // IPv4 (decimal/hex/octal) needs the dedicated parser. checkers::is_ipv4
-  // expects lowercase — only copy+lower when the host has uppercase.
+  // expects lowercase - only copy+lower when the host has uppercase.
   // DNS max label total is 253; oversized hosts fall through.
   if (host_len > 253) [[unlikely]] {
     return false;
@@ -287,14 +287,12 @@ after_rest:
       out.components.host_end = static_cast<uint32_t>(host_end);
       out.components.port = url_components::omitted;
       out.components.pathname_start = static_cast<uint32_t>(path_start);
-      out.components.search_start =
-          (query_start != std::string_view::npos)
-              ? static_cast<uint32_t>(query_start)
-              : url_components::omitted;
-      out.components.hash_start =
-          (hash_start != std::string_view::npos)
-              ? static_cast<uint32_t>(hash_start)
-              : url_components::omitted;
+      out.components.search_start = (query_start != std::string_view::npos)
+                                        ? static_cast<uint32_t>(query_start)
+                                        : url_components::omitted;
+      out.components.hash_start = (hash_start != std::string_view::npos)
+                                      ? static_cast<uint32_t>(hash_start)
+                                      : url_components::omitted;
     } else {
       out.buffer.resize(len + 1);
       std::memcpy(out.buffer.data(), input.data(), host_end);
@@ -313,14 +311,12 @@ after_rest:
       out.components.host_end = static_cast<uint32_t>(host_end);
       out.components.port = url_components::omitted;
       out.components.pathname_start = static_cast<uint32_t>(host_end);
-      out.components.search_start =
-          (query_start != std::string_view::npos)
-              ? static_cast<uint32_t>(query_start + 1)
-              : url_components::omitted;
-      out.components.hash_start =
-          (hash_start != std::string_view::npos)
-              ? static_cast<uint32_t>(hash_start + 1)
-              : url_components::omitted;
+      out.components.search_start = (query_start != std::string_view::npos)
+                                        ? static_cast<uint32_t>(query_start + 1)
+                                        : url_components::omitted;
+      out.components.hash_start = (hash_start != std::string_view::npos)
+                                      ? static_cast<uint32_t>(hash_start + 1)
+                                      : url_components::omitted;
     }
   } else {
     std::string host_str(input.substr(host_start, host_end - host_start));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -80,8 +80,11 @@ constexpr std::array<uint8_t, 256> k_rest = []() consteval {
 }  // namespace
 
 template <class result_type>
-ada_really_inline bool try_parse_simple_absolute(std::string_view input,
-                                                 result_type& out) {
+// noinline: inlining this into parse_url_impl bloated the fallthrough path
+// enough to regress IPv4 microbenchmarks via I-cache pressure, even when the
+// digit-host gate below skips the call entirely.
+ada_never_inline bool try_parse_simple_absolute(std::string_view input,
+                                                result_type& out) {
   constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
   constexpr bool is_aggregator =
       std::is_same_v<result_type, ada::url_aggregator>;
@@ -114,6 +117,15 @@ ada_really_inline bool try_parse_simple_absolute(std::string_view input,
     return false;
   }
   if (pos < len && (b[pos] == '/' || b[pos] == '\\')) [[unlikely]] {
+    return false;
+  }
+
+  // IPv4 (decimal/hex/octal) and numeric hosts use the dedicated host parser.
+  // Bail before table-driven scanning so those workloads do not pay for a
+  // failed fast-path attempt. Domain names almost never start with a digit.
+  // No [[unlikely]]: IPv4 microbenchmarks hit this on every input; a
+  // mispredicted "unlikely" was a measurable regression there.
+  if (pos < len && b[pos] >= '0' && b[pos] <= '9') {
     return false;
   }
 
@@ -387,9 +399,23 @@ result_type parse_url_impl(std::string_view user_input,
   // avoids a full-string SIMD scan on the common case. Tabs/newlines/C0 in
   // the input cause the fast path to reject and fall through.
   // can_parse (store_values=false) has its own fast path in implementation.cpp.
+  //
+  // Digit-led hosts (IPv4 / pure-numeric) skip the call entirely so those
+  // microbenchmarks only pay a cheap scheme+host peek, not a failed attempt.
+  // No [[likely]] on success: mixed workloads and IPv4 benches mispredict it.
   if constexpr (store_values) {
-    if (base_url == nullptr) [[likely]] {
-      if (try_parse_simple_absolute(user_input, url)) [[likely]] {
+    if (base_url == nullptr) {
+      const auto* p = reinterpret_cast<const uint8_t*>(user_input.data());
+      const size_t n = user_input.size();
+      // Cheap digit-host skip without re-matching the full scheme name:
+      // 4-letter scheme://D (http://1...) or 5-letter (https://1...).
+      // Safe: any digit-led host falls through to the dedicated IPv4 path.
+      // try_parse_simple_absolute still validates scheme/host fully.
+      const bool digit_led_host = (n >= 8 && p[4] == ':' && p[5] == '/' &&
+                                   p[6] == '/' && p[7] >= '0' && p[7] <= '9') ||
+                                  (n >= 9 && p[5] == ':' && p[6] == '/' &&
+                                   p[7] == '/' && p[8] >= '0' && p[8] <= '9');
+      if (!digit_led_host && try_parse_simple_absolute(user_input, url)) {
         return url;
       }
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -19,41 +19,28 @@
 
 namespace ada::parser {
 
-// Fast path for absolute http(s) URLs that are already fully normalized:
-// lowercase scheme/host, no credentials/port/IPv4/IPv6/IDNA, no percent-
-// encoding, and no "." / ".." path segments. One table-driven scan, then a
-// single buffer assign (aggregator) or a few component copies (url).
-//
-// Returns true and fills `out` on success. Returns false with no writes.
-// Friend of url / url_aggregator for private buffer access.
+// 0 = host byte, 1 = host delimiter (/ ? #), 2 = reject
 namespace {
 
-// 0 = ok in host, 1 = host delimiter (/ ? #), 2 = reject (full parser)
-// Mirrors the WHATWG forbidden-domain-code-point set: anything else is ok.
 constexpr std::array<uint8_t, 256> k_host_class = []() consteval {
   std::array<uint8_t, 256> t{};
-  // Default: accept printable ASCII that is not a forbidden domain code point.
   for (size_t i = 0; i < 256; ++i) {
     t[i] = 2;
   }
   for (size_t i = 0x21; i <= 0x7E; ++i) {
     t[i] = 0;
   }
-  // Forbidden domain code points that fall in 0x21-0x7E.
   for (uint8_t c :
        {'#', '/', ':', '<', '>', '?', '@', '[', '\\', ']', '^', '|', '%'}) {
     t[c] = 2;
   }
-  // Delimiters that end the host (also forbidden as host bytes).
   t[static_cast<uint8_t>('/')] = 1;
   t[static_cast<uint8_t>('?')] = 1;
   t[static_cast<uint8_t>('#')] = 1;
   return t;
 }();
 
-// Bytes in path/query/fragment: 0 = ok, 1 = ? or # delimiter, 2 = reject.
-// Conservative union of path + special-query + fragment percent-encode sets
-// so one scan decides whether a pure copy is safe.
+// 0 = ok, 1 = ?/#, 2 = reject. Path rejects '%' so "%2e" falls through.
 constexpr std::array<uint8_t, 256> k_rest = []() consteval {
   std::array<uint8_t, 256> t{};
   for (size_t i = 0; i < 256; ++i) {
@@ -62,9 +49,6 @@ constexpr std::array<uint8_t, 256> k_rest = []() consteval {
   for (uint8_t c = 0x21; c <= 0x7E; ++c) {
     t[c] = 0;
   }
-  // Encode-set / special rejects. '%' is NOT allowed in the path table:
-  // "%2e" / "%2e%2e" are single/double-dot segments and need the full parser.
-  // Query/fragment scans allow '%' explicitly (already-encoded stays as-is).
   for (uint8_t c : {static_cast<uint8_t>('"'), static_cast<uint8_t>('<'),
                     static_cast<uint8_t>('>'), static_cast<uint8_t>('`'),
                     static_cast<uint8_t>('{'), static_cast<uint8_t>('}'),
@@ -79,10 +63,9 @@ constexpr std::array<uint8_t, 256> k_rest = []() consteval {
 
 }  // namespace
 
+// Fast path for already-normalized absolute http(s) URLs. noinline keeps
+// the fallthrough path small (IPv4 microbenches).
 template <class result_type>
-// noinline: inlining this into parse_url_impl bloated the fallthrough path
-// enough to regress IPv4 microbenchmarks via I-cache pressure, even when the
-// digit-host gate below skips the call entirely.
 ada_never_inline bool try_parse_simple_absolute(std::string_view input,
                                                 result_type& out) {
   constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
@@ -99,7 +82,6 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
   size_t pos;
   ada::scheme::type scheme_type;
   uint32_t protocol_end;
-  // Lowercase http:// or https:// only.
   if (b[0] == 'h' && b[1] == 't' && b[2] == 't' && b[3] == 'p') {
     if (b[4] == ':' && b[5] == '/' && b[6] == '/') {
       pos = 7;
@@ -120,16 +102,11 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
     return false;
   }
 
-  // IPv4 (decimal/hex/octal) and numeric hosts use the dedicated host parser.
-  // Bail before table-driven scanning so those workloads do not pay for a
-  // failed fast-path attempt. Domain names almost never start with a digit.
-  // No [[unlikely]]: IPv4 microbenchmarks hit this on every input; a
-  // mispredicted "unlikely" was a measurable regression there.
+  // Digit-led hosts are IPv4/numeric; skip before scanning.
   if (pos < len && b[pos] >= '0' && b[pos] <= '9') {
     return false;
   }
 
-  // --- Host ---
   const size_t host_start = pos;
   bool has_upper = false;
   size_t i = pos;
@@ -137,7 +114,7 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
     const uint8_t c = b[i];
     const uint8_t cls = k_host_class[c];
     if (cls == 1) {
-      break;  // / ? #
+      break;
     }
     if (cls == 2) [[unlikely]] {
       return false;
@@ -151,9 +128,6 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
     return false;
   }
   const size_t host_len = host_end - host_start;
-  // IPv4 (decimal/hex/octal) needs the dedicated parser. checkers::is_ipv4
-  // expects lowercase - only copy+lower when the host has uppercase.
-  // DNS max label total is 253; oversized hosts fall through.
   if (host_len > 253) [[unlikely]] {
     return false;
   }
@@ -168,16 +142,12 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
     if (checkers::is_ipv4(hv)) [[unlikely]] {
       return false;
     }
-    // Punycode prefix requires IDNA (hv is lowercased when needed).
     static constexpr std::string_view xn{"xn-", 3};
     if (hv.find(xn) != std::string_view::npos) [[unlikely]] {
       return false;
     }
   }
 
-  // --- Path / query / fragment ---
-  // Path loop is deliberately minimal: table lookup + delimiter only.
-  // Dot-segment checks run once after the path is bounded (rare '.').
   size_t path_start = host_end;
   size_t path_end = host_end;
   size_t query_start = std::string_view::npos;
@@ -207,7 +177,7 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
         ++i;
         goto scan_hash;
       }
-      return false;  // cls == 2
+      return false;
     }
     path_end = i;
   } else if (i < len && b[i] == '?') {
@@ -222,8 +192,6 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
   goto after_rest;
 
 scan_query:
-  // Special-query percent-encode set does not include '%', so encoded
-  // sequences copy through. Allow '%' here (unlike the path table).
   for (; i < len; ++i) {
     const uint8_t c = b[i];
     if (c == '#') {
@@ -241,7 +209,6 @@ scan_query:
   goto after_rest;
 
 scan_hash:
-  // Fragment percent-encode set does not include '%'.
   for (; i < len; ++i) {
     const uint8_t c = b[i];
     if (c == '?' || c == '#' || c == '%') {
@@ -253,11 +220,9 @@ scan_hash:
   }
 
 after_rest:
-  // Reject "." / ".." path segments (only when path contains a '.').
   if (path_has_dot) [[unlikely]] {
     const std::string_view path_body(input.data() + path_start,
                                      path_end - path_start);
-    // path_body starts with '/'
     if (path_body.size() >= 2 && path_body[1] == '.') {
       if (path_body.size() == 2 || path_body[2] == '/' ||
           (path_body.size() >= 3 && path_body[2] == '.' &&
@@ -286,9 +251,7 @@ after_rest:
 
   if constexpr (is_aggregator) {
     if (!need_slash) {
-      // Direct resize + memcpy is slightly faster than assign on libc++.
       out.buffer.resize(len);
-      // Sized binary copy; length is `len`, not a C-string API.
       // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
       std::memcpy(out.buffer.data(), input.data(), len);
       if (has_upper) {
@@ -397,30 +360,17 @@ result_type parse_url_impl(std::string_view user_input,
     return url;
   }
 
-  // Fast path FIRST on the raw input: absolute special http(s) URLs with a
-  // clean ASCII host and no transforms. Running before has_tabs_or_newline
-  // avoids a full-string SIMD scan on the common case. Tabs/newlines/C0 in
-  // the input cause the fast path to reject and fall through.
-  // can_parse (store_values=false) has its own fast path in implementation.cpp.
-  //
-  // Digit-led hosts (IPv4 / pure-numeric) skip the call entirely so those
-  // microbenchmarks only pay a cheap scheme+host peek, not a failed attempt.
-  // No [[likely]] on success: mixed workloads and IPv4 benches mispredict it.
+  // Simple absolute http(s) fast path (before tabs/newline scan).
+  // Skip digit-led hosts (IPv4) with a cheap peek.
   if constexpr (store_values) {
     if (base_url == nullptr) {
       const auto* p = reinterpret_cast<const uint8_t*>(user_input.data());
       const size_t n = user_input.size();
-      // Cheap digit-host skip without re-matching the full scheme name:
-      // 4-letter scheme://D (http://1...) or 5-letter (https://1...).
-      // Safe: any digit-led host falls through to the dedicated IPv4 path.
-      // try_parse_simple_absolute still validates scheme/host fully.
       const bool digit_led_host = (n >= 8 && p[4] == ':' && p[5] == '/' &&
                                    p[6] == '/' && p[7] >= '0' && p[7] <= '9') ||
                                   (n >= 9 && p[5] == ':' && p[6] == '/' &&
                                    p[7] == '/' && p[8] >= '0' && p[8] <= '9');
       if (!digit_led_host && try_parse_simple_absolute(user_input, url)) {
-        // Match the post-normalization length gate used at the end of the
-        // full parser so can_parse/parse agree under set_max_input_length.
         if constexpr (result_type_is_ada_url_aggregator) {
           if (url.buffer.size() > max_input_length) [[unlikely]] {
             url.is_valid = false;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -288,6 +288,8 @@ after_rest:
     if (!need_slash) {
       // Direct resize + memcpy is slightly faster than assign on libc++.
       out.buffer.resize(len);
+      // Sized binary copy; length is `len`, not a C-string API.
+      // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
       std::memcpy(out.buffer.data(), input.data(), len);
       if (has_upper) {
         unicode::to_lower_ascii(out.buffer.data() + host_start,
@@ -307,6 +309,7 @@ after_rest:
                                       : url_components::omitted;
     } else {
       out.buffer.resize(len + 1);
+      // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
       std::memcpy(out.buffer.data(), input.data(), host_end);
       out.buffer[host_end] = '/';
       if (host_end < len) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -419,6 +419,17 @@ result_type parse_url_impl(std::string_view user_input,
                                   (n >= 9 && p[5] == ':' && p[6] == '/' &&
                                    p[7] == '/' && p[8] >= '0' && p[8] <= '9');
       if (!digit_led_host && try_parse_simple_absolute(user_input, url)) {
+        // Match the post-normalization length gate used at the end of the
+        // full parser so can_parse/parse agree under set_max_input_length.
+        if constexpr (result_type_is_ada_url_aggregator) {
+          if (url.buffer.size() > max_input_length) [[unlikely]] {
+            url.is_valid = false;
+          }
+        } else {
+          if (url.get_href_size() > max_input_length) [[unlikely]] {
+            url.is_valid = false;
+          }
+        }
         return url;
       }
     }

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -481,7 +481,6 @@ ada_really_inline bool url::parse_host(std::string_view input) {
   unicode::to_lower_ascii(buffer.data(), buffer.size());
   bool is_forbidden = unicode::contains_forbidden_domain_code_point(
       buffer.data(), buffer.size());
-  // Use a sized needle so find does not call strlen on the C string.
   static constexpr std::string_view xn_dash{"xn-", 3};
   if (is_forbidden == 0 && buffer.find(xn_dash) == std::string_view::npos) {
     // fast path

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -481,7 +481,9 @@ ada_really_inline bool url::parse_host(std::string_view input) {
   unicode::to_lower_ascii(buffer.data(), buffer.size());
   bool is_forbidden = unicode::contains_forbidden_domain_code_point(
       buffer.data(), buffer.size());
-  if (is_forbidden == 0 && buffer.find("xn-") == std::string_view::npos) {
+  // Use a sized needle so find does not call strlen on the C string.
+  static constexpr std::string_view xn_dash{"xn-", 3};
+  if (is_forbidden == 0 && buffer.find(xn_dash) == std::string_view::npos) {
     // fast path
     host = std::move(buffer);
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -538,7 +538,6 @@ ada_really_inline bool url_aggregator::parse_host(std::string_view input) {
   // could also check whether x and n and - are present, and so we could skip
   // some of the checks below. However, the gains are likely to be small, and
   // the code would be more complex.
-  // Use a sized needle so find does not call strlen on the C string.
   static constexpr std::string_view xn_dash{"xn-", 3};
   if (is_forbidden_or_upper == 0 &&
       input.find(xn_dash) == std::string_view::npos) {

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -538,8 +538,10 @@ ada_really_inline bool url_aggregator::parse_host(std::string_view input) {
   // could also check whether x and n and - are present, and so we could skip
   // some of the checks below. However, the gains are likely to be small, and
   // the code would be more complex.
+  // Use a sized needle so find does not call strlen on the C string.
+  static constexpr std::string_view xn_dash{"xn-", 3};
   if (is_forbidden_or_upper == 0 &&
-      input.find("xn-") == std::string_view::npos) {
+      input.find(xn_dash) == std::string_view::npos) {
     // fast path
     update_base_hostname(input);
 

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -618,11 +618,8 @@ TEST(ada_c, max_input_length) {
 
   ada_free(result);
 
-  // can_parse may return true for overlength inputs that are structurally
-  // valid, because the fast path does not check the length limit (by design,
-  // for performance). The full parse (ada_parse) does enforce the limit. We
-  // just verify it doesn't crash.
-  (void)ada_can_parse(long_url.c_str(), long_url.size());
+  // can_parse must agree with ada_parse on overlength inputs.
+  ASSERT_FALSE(ada_can_parse(long_url.c_str(), long_url.size()));
 
   // Restore default.
   ada_set_max_input_length(original);

--- a/tests/ada_c.cpp
+++ b/tests/ada_c.cpp
@@ -618,7 +618,6 @@ TEST(ada_c, max_input_length) {
 
   ada_free(result);
 
-  // can_parse must agree with ada_parse on overlength inputs.
   ASSERT_FALSE(ada_can_parse(long_url.c_str(), long_url.size()));
 
   // Restore default.

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -40,7 +40,26 @@ std::string url_examples[] = {
     "old-ie.min.css",
     "https://gn-web-assets.api.bbc.com/wwhp/"
     "20220908-1153-091014d07889c842a7bdc06e00fa711c9e04f049/modules/vendor/"
-    "bower/modernizr/modernizr.js"};
+    "bower/modernizr/modernizr.js",
+    // Simple-absolute fast-path seeds (clean http(s), no auth/port/IPv4/IDNA).
+    "https://example.com",
+    "https://example.com/",
+    "https://example.com?q=1",
+    "https://example.com#frag",
+    "https://example.com/?q=1#frag",
+    "http://www.example.com/path/file.js",
+    "https://www.google.com/imghp?hl=en&tab=wi",
+    "https://maps.google.com/maps?hl=en&tab=wl",
+    "http://WWW.Example.COM/file.js",
+    // Fall-through seeds for the simple-absolute gate.
+    "http://192.168.0.1/x",            // digit-led host (IPv4)
+    "http://0x7f.1/",                  // non-decimal IPv4
+    "https://user@example.com/",       // credentials
+    "https://example.com:8080/x",      // port
+    "https://example.com/a/./b/../c",  // dot segments
+    "https://example.com/foo/%2e%2e",  // percent-encoded dots
+    "https://xn--nxasmq6b.com/",       // punycode
+};
 
 // This function copies your input onto a memory buffer that
 // has just the necessary size. This will entice tools to detect
@@ -207,6 +226,193 @@ size_t length_fuzz(size_t N, size_t seed = 0) {
   return checked;
 }
 
+// Seeds shaped like absolute http(s) URLs so mutations hit
+// try_parse_simple_absolute (and its fall-through gates: digit hosts, dots,
+// credentials, ports, xn--).
+static const char* kSimpleAbsoluteSeeds[] = {
+    "https://example.com",
+    "https://example.com/",
+    "https://example.com/path",
+    "https://example.com/path?q=1",
+    "https://example.com/path#frag",
+    "https://example.com/?q=1#frag",
+    "http://www.example.com/file.js",
+    "https://www.google.com/imghp?hl=en&tab=wi",
+    "http://WWW.Example.COM/file.js",
+    "https://example.com/continue=https%3A%2F%2Fexample.com%2F",
+    "http://192.168.0.1/x",
+    "http://0x7f.0.0.1/",
+    "https://user:pass@example.com/x",
+    "https://example.com:8080/x",
+    "https://example.com/a/./b/../c",
+    "https://example.com/foo/%2e",
+    "https://example.com/foo/%2e%2e",
+    "https://xn--nxasmq6b.com/",
+    "https://example.com/path with space",
+    "https://example.com/path\twith\ttab",
+    "http://example.com\\path",
+    "https://example.com?",
+    "https://example.com#",
+    "https://",
+    "http://",
+    "https://a",
+    "http://a.b.c.d.e.f.g/",
+};
+
+// Abort if url and url_aggregator disagree, or if get_href_size drifts from
+// get_href().size() (covers the memcpy-based get_href hot path).
+template <class R>
+static void check_simple_absolute_invariants(const R& parsed,
+                                             std::string_view input) {
+  const std::string href = std::string(parsed.get_href());
+  if (parsed.get_href_size() != href.size()) {
+    std::cerr << "simple_absolute_fuzz FAIL get_href_size mismatch\n"
+              << "  input: " << input << "\n"
+              << "  href:  " << href << "\n"
+              << "  size:  " << parsed.get_href_size()
+              << " vs href.size()=" << href.size() << "\n";
+    std::abort();
+  }
+  auto reparsed = ada::parse<R>(href);
+  if (!reparsed) {
+    std::cerr << "simple_absolute_fuzz FAIL re-parse of href\n"
+              << "  input: " << input << "\n"
+              << "  href:  " << href << "\n";
+    std::abort();
+  }
+  if (std::string(reparsed->get_href()) != href) {
+    std::cerr << "simple_absolute_fuzz FAIL href not idempotent\n"
+              << "  input: " << input << "\n"
+              << "  href1: " << href << "\n"
+              << "  href2: " << reparsed->get_href() << "\n";
+    std::abort();
+  }
+}
+
+// Mutate absolute http(s)-shaped inputs and assert cross-type agreement plus
+// href size/idempotency invariants. Targets the simple-absolute fast path and
+// every intentional fall-through (IPv4 digit gate, dots, auth, port, IDNA).
+size_t simple_absolute_fuzz(size_t N, size_t seed = 0) {
+  size_t counter = seed;
+  size_t checked = 0;
+  constexpr size_t nseeds =
+      sizeof(kSimpleAbsoluteSeeds) / sizeof(kSimpleAbsoluteSeeds[0]);
+
+  for (size_t trial = 0; trial < N; trial++) {
+    std::string copy = kSimpleAbsoluteSeeds[(seed + trial) % nseeds];
+
+    // Byte-level mutations that flip scheme, host, path, query, fragment.
+    int muts = 1 + int((counter * 17) % 6);
+    for (int m = 0; m < muts && !copy.empty(); m++) {
+      int kind = int((counter * 31 + m) % 5);
+      switch (kind) {
+        case 0:  // flip one byte
+          copy[(counter * 13) % copy.size()] =
+              char((counter * 71117 + m) & 0xFF);
+          break;
+        case 1:  // erase one byte
+          if (copy.size() > 1) {
+            copy.erase((counter * 11) % copy.size(), 1);
+          }
+          break;
+        case 2:  // insert a special character that may force fall-through
+        {
+          static const char specials[] = {':', '@', '/',  '\\', '?',  '#',
+                                          '.', '%', '0',  'x',  'A',  '[',
+                                          ']', ' ', '\t', '\n', '\r', 0};
+          char c = specials[(counter * 7 + m) % (sizeof(specials) - 1)];
+          copy.insert(copy.begin() + ((counter * 3) % (copy.size() + 1)), c);
+          break;
+        }
+        case 3:  // append a common tail
+        {
+          static const char* tails[] = {"/",    "?q=1", "#f", "/./x", "/../y",
+                                        "/%2e", ":80",  "@u", "0",    "xn--a"};
+          copy += tails[(counter + m) % 10];
+          break;
+        }
+        case 4:  // prepend alternate scheme
+        {
+          static const char* prefixes[] = {"http://",  "https://", "HTTP://",
+                                           "Https://", "http:",    "https:"};
+          // Drop an existing scheme if present so we do not double-prefix
+          // forever.
+          if (copy.rfind("http", 0) == 0) {
+            auto pos = copy.find("://");
+            if (pos != std::string::npos) {
+              copy = copy.substr(pos + 3);
+            }
+          }
+          copy = std::string(prefixes[(counter + m) % 6]) + copy;
+          break;
+        }
+        default:
+          break;
+      }
+      counter++;
+    }
+
+    auto u = ada_parse<ada::url>(copy);
+    auto a = ada_parse<ada::url_aggregator>(copy);
+    if (u.has_value() != a.has_value()) {
+      std::cerr << "simple_absolute_fuzz FAIL parse agreement\n"
+                << "  input: " << copy << "\n"
+                << "  url: " << u.has_value()
+                << " aggregator: " << a.has_value() << "\n";
+      std::abort();
+    }
+    if (u) {
+      if (u->get_href() != std::string(a->get_href())) {
+        std::cerr << "simple_absolute_fuzz FAIL href mismatch\n"
+                  << "  input: " << copy << "\n"
+                  << "  url:  " << u->get_href() << "\n"
+                  << "  agg:  " << a->get_href() << "\n";
+        std::abort();
+      }
+      check_simple_absolute_invariants(*u, copy);
+      check_simple_absolute_invariants(*a, copy);
+      checked++;
+    }
+  }
+  return checked;
+}
+
+// Roll every byte of each simple-absolute seed through 0..254, asserting
+// agreement between url and url_aggregator on every candidate.
+size_t simple_absolute_roller_fuzz() {
+  size_t valid = 0;
+  constexpr size_t nseeds =
+      sizeof(kSimpleAbsoluteSeeds) / sizeof(kSimpleAbsoluteSeeds[0]);
+  for (size_t s = 0; s < nseeds; s++) {
+    std::string copy = kSimpleAbsoluteSeeds[s];
+    for (size_t index = 0; index < copy.size(); index++) {
+      char orig = copy[index];
+      for (unsigned int value = 0; value < 255; value++) {
+        copy[index] = char(value);
+        auto u = ada_parse<ada::url>(copy);
+        auto a = ada_parse<ada::url_aggregator>(copy);
+        if (u.has_value() != a.has_value()) {
+          std::cerr << "simple_absolute_roller FAIL parse agreement\n"
+                    << "  input: " << copy << "\n";
+          std::abort();
+        }
+        if (u) {
+          if (u->get_href() != std::string(a->get_href())) {
+            std::cerr << "simple_absolute_roller FAIL href mismatch\n"
+                      << "  input: " << copy << "\n"
+                      << "  url:  " << u->get_href() << "\n"
+                      << "  agg:  " << a->get_href() << "\n";
+            std::abort();
+          }
+          valid++;
+        }
+      }
+      copy[index] = orig;
+    }
+  }
+  return valid;
+}
+
 int main() {
   if (std::endian::native == std::endian::big) {
     std::cout << "You have big-endian system." << std::endl;
@@ -230,5 +436,9 @@ int main() {
             << " length invariants.\n";
   std::cout << "[length] Checked " << length_fuzz<ada::url_aggregator>(10000)
             << " length invariants.\n";
+  std::cout << "[simple_abs] Checked " << simple_absolute_fuzz(80000)
+            << " successful parses.\n";
+  std::cout << "[simple_abs_roller] Valid " << simple_absolute_roller_fuzz()
+            << " cases.\n";
   return EXIT_SUCCESS;
 }

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -41,7 +41,6 @@ std::string url_examples[] = {
     "https://gn-web-assets.api.bbc.com/wwhp/"
     "20220908-1153-091014d07889c842a7bdc06e00fa711c9e04f049/modules/vendor/"
     "bower/modernizr/modernizr.js",
-    // Simple-absolute fast-path seeds (clean http(s), no auth/port/IPv4/IDNA).
     "https://example.com",
     "https://example.com/",
     "https://example.com?q=1",
@@ -51,14 +50,13 @@ std::string url_examples[] = {
     "https://www.google.com/imghp?hl=en&tab=wi",
     "https://maps.google.com/maps?hl=en&tab=wl",
     "http://WWW.Example.COM/file.js",
-    // Fall-through seeds for the simple-absolute gate.
-    "http://192.168.0.1/x",            // digit-led host (IPv4)
-    "http://0x7f.1/",                  // non-decimal IPv4
-    "https://user@example.com/",       // credentials
-    "https://example.com:8080/x",      // port
-    "https://example.com/a/./b/../c",  // dot segments
-    "https://example.com/foo/%2e%2e",  // percent-encoded dots
-    "https://xn--nxasmq6b.com/",       // punycode
+    "http://192.168.0.1/x",
+    "http://0x7f.1/",
+    "https://user@example.com/",
+    "https://example.com:8080/x",
+    "https://example.com/a/./b/../c",
+    "https://example.com/foo/%2e%2e",
+    "https://xn--nxasmq6b.com/",
 };
 
 // This function copies your input onto a memory buffer that
@@ -226,9 +224,6 @@ size_t length_fuzz(size_t N, size_t seed = 0) {
   return checked;
 }
 
-// Seeds shaped like absolute http(s) URLs so mutations hit
-// try_parse_simple_absolute (and its fall-through gates: digit hosts, dots,
-// credentials, ports, xn--).
 static const char* kSimpleAbsoluteSeeds[] = {
     "https://example.com",
     "https://example.com/",
@@ -259,8 +254,6 @@ static const char* kSimpleAbsoluteSeeds[] = {
     "http://a.b.c.d.e.f.g/",
 };
 
-// Abort if url and url_aggregator disagree, or if get_href_size drifts from
-// get_href().size() (covers the memcpy-based get_href hot path).
 template <class R>
 static void check_simple_absolute_invariants(const R& parsed,
                                              std::string_view input) {
@@ -289,9 +282,6 @@ static void check_simple_absolute_invariants(const R& parsed,
   }
 }
 
-// Mutate absolute http(s)-shaped inputs and assert cross-type agreement plus
-// href size/idempotency invariants. Targets the simple-absolute fast path and
-// every intentional fall-through (IPv4 digit gate, dots, auth, port, IDNA).
 size_t simple_absolute_fuzz(size_t N, size_t seed = 0) {
   size_t counter = seed;
   size_t checked = 0;
@@ -301,22 +291,20 @@ size_t simple_absolute_fuzz(size_t N, size_t seed = 0) {
   for (size_t trial = 0; trial < N; trial++) {
     std::string copy = kSimpleAbsoluteSeeds[(seed + trial) % nseeds];
 
-    // Byte-level mutations that flip scheme, host, path, query, fragment.
     int muts = 1 + int((counter * 17) % 6);
     for (int m = 0; m < muts && !copy.empty(); m++) {
       int kind = int((counter * 31 + m) % 5);
       switch (kind) {
-        case 0:  // flip one byte
+        case 0:
           copy[(counter * 13) % copy.size()] =
               char((counter * 71117 + m) & 0xFF);
           break;
-        case 1:  // erase one byte
+        case 1:
           if (copy.size() > 1) {
             copy.erase((counter * 11) % copy.size(), 1);
           }
           break;
-        case 2:  // insert a special character that may force fall-through
-        {
+        case 2: {
           static const char specials[] = {':', '@', '/',  '\\', '?',  '#',
                                           '.', '%', '0',  'x',  'A',  '[',
                                           ']', ' ', '\t', '\n', '\r', 0};
@@ -324,19 +312,15 @@ size_t simple_absolute_fuzz(size_t N, size_t seed = 0) {
           copy.insert(copy.begin() + ((counter * 3) % (copy.size() + 1)), c);
           break;
         }
-        case 3:  // append a common tail
-        {
+        case 3: {
           static const char* tails[] = {"/",    "?q=1", "#f", "/./x", "/../y",
                                         "/%2e", ":80",  "@u", "0",    "xn--a"};
           copy += tails[(counter + m) % 10];
           break;
         }
-        case 4:  // prepend alternate scheme
-        {
+        case 4: {
           static const char* prefixes[] = {"http://",  "https://", "HTTP://",
                                            "Https://", "http:",    "https:"};
-          // Drop an existing scheme if present so we do not double-prefix
-          // forever.
           if (copy.rfind("http", 0) == 0) {
             auto pos = copy.find("://");
             if (pos != std::string::npos) {
@@ -377,8 +361,6 @@ size_t simple_absolute_fuzz(size_t N, size_t seed = 0) {
   return checked;
 }
 
-// Roll every byte of each simple-absolute seed through 0..254, asserting
-// agreement between url and url_aggregator on every candidate.
 size_t simple_absolute_roller_fuzz() {
   size_t valid = 0;
   constexpr size_t nseeds =

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1169,3 +1169,107 @@ TYPED_TEST(basic_tests, get_href_size_password_no_password) {
   ASSERT_TRUE(url2);
   ASSERT_EQ(url2->get_href_size(), url2->get_href().size());
 }
+
+// Regression coverage for the simple absolute http(s) parse fast path.
+// These cases exercise pure-copy handling, empty-path slash insertion,
+// already-encoded query bytes, and fall-through to the full parser.
+TYPED_TEST(basic_tests, simple_absolute_fast_path) {
+  // Already-normalized https URL (pure buffer assign / component fill).
+  {
+    auto url = ada::parse<TypeParam>(
+        "https://www.google.com/imghp?hl=en&tab=wi");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_protocol(), "https:");
+    ASSERT_EQ(url->get_hostname(), "www.google.com");
+    ASSERT_EQ(url->get_pathname(), "/imghp");
+    ASSERT_EQ(url->get_search(), "?hl=en&tab=wi");
+    ASSERT_EQ(url->get_href(),
+              "https://www.google.com/imghp?hl=en&tab=wi");
+  }
+
+  // Empty path must serialize with a trailing '/'.
+  {
+    auto url = ada::parse<TypeParam>("https://example.com");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/");
+    ASSERT_EQ(url->get_href(), "https://example.com/");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://example.com?q=1");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/");
+    ASSERT_EQ(url->get_search(), "?q=1");
+    ASSERT_EQ(url->get_href(), "https://example.com/?q=1");
+  }
+
+  // Already percent-encoded query copies through unchanged.
+  {
+    auto url = ada::parse<TypeParam>(
+        "https://example.com/path?continue=https%3A%2F%2Fexample.com%2F");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_href(),
+              "https://example.com/path?continue=https%3A%2F%2Fexample.com%2F");
+  }
+
+  // Host uppercasing is lowercased; path with a filename dot is fine.
+  {
+    auto url = ada::parse<TypeParam>("http://WWW.Example.COM/file.js");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "www.example.com");
+    ASSERT_EQ(url->get_pathname(), "/file.js");
+    ASSERT_EQ(url->get_href(), "http://www.example.com/file.js");
+  }
+
+  // Dot segments must still be resolved (full parser).
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/a/./b/../c");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/a/c");
+    ASSERT_EQ(url->get_href(), "https://example.com/a/c");
+  }
+
+  // Percent-encoded dot segments must also be resolved (not pure-copied).
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/foo/%2e");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/foo/");
+    ASSERT_EQ(url->get_href(), "https://example.com/foo/");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/foo/%2e%2e");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/");
+    ASSERT_EQ(url->get_href(), "https://example.com/");
+  }
+
+  // Credentials / port force the full parser; results stay correct.
+  {
+    auto url =
+        ada::parse<TypeParam>("https://user:pass@example.com:8080/x?y=1#z");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_username(), "user");
+    ASSERT_EQ(url->get_password(), "pass");
+    ASSERT_EQ(url->get_port(), "8080");
+    ASSERT_EQ(url->get_pathname(), "/x");
+    ASSERT_EQ(url->get_search(), "?y=1");
+    ASSERT_EQ(url->get_hash(), "#z");
+  }
+
+  // url and url_aggregator must agree on href for fast-path inputs.
+  const char* samples[] = {
+      "https://www.youtube.com/about/",
+      "http://example.com/",
+      "https://maps.google.com/maps?hl=en&tab=wl",
+      "https://example.com",
+      "https://example.com?q=1#frag",
+  };
+  for (const char* s : samples) {
+    auto u = ada::parse<ada::url>(s);
+    auto a = ada::parse<ada::url_aggregator>(s);
+    ASSERT_EQ(u.has_value(), a.has_value()) << s;
+    if (u) {
+      ASSERT_EQ(u->get_href(), std::string(a->get_href())) << s;
+    }
+  }
+  SUCCEED();
+}

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1176,15 +1176,14 @@ TYPED_TEST(basic_tests, get_href_size_password_no_password) {
 TYPED_TEST(basic_tests, simple_absolute_fast_path) {
   // Already-normalized https URL (pure buffer assign / component fill).
   {
-    auto url = ada::parse<TypeParam>(
-        "https://www.google.com/imghp?hl=en&tab=wi");
+    auto url =
+        ada::parse<TypeParam>("https://www.google.com/imghp?hl=en&tab=wi");
     ASSERT_TRUE(url);
     ASSERT_EQ(url->get_protocol(), "https:");
     ASSERT_EQ(url->get_hostname(), "www.google.com");
     ASSERT_EQ(url->get_pathname(), "/imghp");
     ASSERT_EQ(url->get_search(), "?hl=en&tab=wi");
-    ASSERT_EQ(url->get_href(),
-              "https://www.google.com/imghp?hl=en&tab=wi");
+    ASSERT_EQ(url->get_href(), "https://www.google.com/imghp?hl=en&tab=wi");
   }
 
   // Empty path must serialize with a trailing '/'.

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1170,11 +1170,7 @@ TYPED_TEST(basic_tests, get_href_size_password_no_password) {
   ASSERT_EQ(url2->get_href_size(), url2->get_href().size());
 }
 
-// Regression coverage for the simple absolute http(s) parse fast path.
-// These cases exercise pure-copy handling, empty-path slash insertion,
-// already-encoded query bytes, and fall-through to the full parser.
 TYPED_TEST(basic_tests, simple_absolute_fast_path) {
-  // Already-normalized https URL (pure buffer assign / component fill).
   {
     auto url =
         ada::parse<TypeParam>("https://www.google.com/imghp?hl=en&tab=wi");
@@ -1185,8 +1181,6 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
     ASSERT_EQ(url->get_search(), "?hl=en&tab=wi");
     ASSERT_EQ(url->get_href(), "https://www.google.com/imghp?hl=en&tab=wi");
   }
-
-  // Empty path must serialize with a trailing '/'.
   {
     auto url = ada::parse<TypeParam>("https://example.com");
     ASSERT_TRUE(url);
@@ -1200,8 +1194,6 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
     ASSERT_EQ(url->get_search(), "?q=1");
     ASSERT_EQ(url->get_href(), "https://example.com/?q=1");
   }
-
-  // Already percent-encoded query copies through unchanged.
   {
     auto url = ada::parse<TypeParam>(
         "https://example.com/path?continue=https%3A%2F%2Fexample.com%2F");
@@ -1209,8 +1201,6 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
     ASSERT_EQ(url->get_href(),
               "https://example.com/path?continue=https%3A%2F%2Fexample.com%2F");
   }
-
-  // Host uppercasing is lowercased; path with a filename dot is fine.
   {
     auto url = ada::parse<TypeParam>("http://WWW.Example.COM/file.js");
     ASSERT_TRUE(url);
@@ -1218,16 +1208,12 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
     ASSERT_EQ(url->get_pathname(), "/file.js");
     ASSERT_EQ(url->get_href(), "http://www.example.com/file.js");
   }
-
-  // Dot segments must still be resolved (full parser).
   {
     auto url = ada::parse<TypeParam>("https://example.com/a/./b/../c");
     ASSERT_TRUE(url);
     ASSERT_EQ(url->get_pathname(), "/a/c");
     ASSERT_EQ(url->get_href(), "https://example.com/a/c");
   }
-
-  // Percent-encoded dot segments must also be resolved (not pure-copied).
   {
     auto url = ada::parse<TypeParam>("https://example.com/foo/%2e");
     ASSERT_TRUE(url);
@@ -1240,8 +1226,6 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
     ASSERT_EQ(url->get_pathname(), "/");
     ASSERT_EQ(url->get_href(), "https://example.com/");
   }
-
-  // Credentials / port force the full parser; results stay correct.
   {
     auto url =
         ada::parse<TypeParam>("https://user:pass@example.com:8080/x?y=1#z");
@@ -1253,8 +1237,6 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
     ASSERT_EQ(url->get_search(), "?y=1");
     ASSERT_EQ(url->get_hash(), "#z");
   }
-
-  // url and url_aggregator must agree on href for fast-path inputs.
   const char* samples[] = {
       "https://www.youtube.com/about/",
       "http://example.com/",

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -196,6 +196,8 @@ TYPED_TEST(max_input_length_tests, parse_normalized_exceeds_limit) {
   auto result = ada::parse<TypeParam>(input);
   // The normalized URL should be 10 + 339*3 = 1027 bytes, exceeding the limit.
   ASSERT_FALSE(result);
+  // can_parse must agree with parse (including post-normalization length).
+  ASSERT_FALSE(ada::can_parse(input));
 }
 
 TYPED_TEST(max_input_length_tests, parse_normalized_just_under_limit) {
@@ -219,6 +221,8 @@ TYPED_TEST(max_input_length_tests, parse_with_base_normalized_exceeds_limit) {
   ASSERT_LE(relative_input.size(), small_limit);
   auto result = ada::parse<TypeParam>(relative_input, &*base);
   ASSERT_FALSE(result);
+  std::string_view base_view = "http://x/";
+  ASSERT_FALSE(ada::can_parse(relative_input, &base_view));
 }
 
 TYPED_TEST(max_input_length_tests, set_protocol_url_unchanged_after_reject) {

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -194,9 +194,7 @@ TYPED_TEST(max_input_length_tests, parse_normalized_exceeds_limit) {
   std::string input = "http://x/" + std::string(339, ' ') + "y";
   ASSERT_LE(input.size(), small_limit);
   auto result = ada::parse<TypeParam>(input);
-  // The normalized URL should be 10 + 339*3 = 1027 bytes, exceeding the limit.
   ASSERT_FALSE(result);
-  // can_parse must agree with parse (including post-normalization length).
   ASSERT_FALSE(ada::can_parse(input));
 }
 


### PR DESCRIPTION
## Summary
- Add `try_parse_simple_absolute`: a shared, table-driven single-pass fast path for absolute `http`/`https` URLs that are already normalized (clean ASCII host, no credentials/port/IPv4/IDNA, no path `%` / `.` / `..` segments). It runs before `has_tabs_or_newline` and fills either `url_aggregator` (resize + memcpy + component offsets) or `ada::url` (component strings).
- Optimize `ada::url::get_href` for the common special-scheme case with pre-sized buffer + `memcpy` (avoids temporary concatenations like `"?" + query`).
- Use a sized `string_view` needle for `xn-` host scans (avoid `strlen` on a C string).
- Add `simple_absolute_fast_path` regression tests covering empty-path slash insertion, percent-encoded query, `%2e` / `%2e%2e` fall-through, host lowercasing, credentials/port fall-through, and url vs aggregator href agreement.

## Performance
On Release `benchdata` (`BenchData_BasicBench_AdaURL_href` / `..._aggregator_href`), dual runs with `--benchmark_min_time=3s` vs a clean HEAD baseline:

| Type | Baseline mean | After mean | Improvement |
|------|---------------|------------|-------------|
| `ada::url` | ~136.0 ns/url | ~106.7 ns/url | **~21.6%** |
| `ada::url_aggregator` | ~89.5 ns/url | ~69.6 ns/url | **~22.2%** |

Interleaved A/B pairs also stayed ≥20% for both types.

## Test plan
- [x] `ctest` with `ADA_TESTING=ON` (full suite)
- [x] `basic_tests` filters: `*simple_absolute_fast_path*`, `*nodejs4*`
- [x] Release `benchdata` dual baseline vs after on Ada href filters
- [ ] CI green on this PR