### PR TITLE
delete dash-dot in set_host colon path when host has a port

### DIFF
--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -639,6 +639,11 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
       if (!succeeded) {
         *this = std::move(saved_url);
         return false;
+      } else if (has_dash_dot()) {
+        // The url now has a non-null host, so the "/." that guarded a
+        // leading "//" path is no longer needed. Drop it before the port is
+        // inserted at host_end, otherwise it stays wedged in the path.
+        delete_dash_dot();
       }
 
       // Set url's host to host, buffer to the empty string, and state to port

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1047,6 +1047,22 @@ TYPED_TEST(basic_tests, failed_set_host_does_not_poison_set_port) {
             "https://user:pass@example.com:1/path?query=1#hash");
 }
 
+TYPED_TEST(basic_tests, set_host_with_port_strips_dash_dot) {
+  // A non-special URL with a null host and a path starting with "//" carries a
+  // "/." guard in its serialization. Setting a host that contains a port (so
+  // the ":" host/port split is taken) must drop that guard, exactly like the
+  // no-port path already does. url_aggregator used to leave the "/." wedged in
+  // the path, diverging from ada::url.
+  auto url = ada::parse<TypeParam>("non-spec:/.//p");
+  ASSERT_TRUE(url);
+  ASSERT_EQ(url->get_href(), "non-spec:/.//p");
+
+  ASSERT_TRUE(url->set_host("host:99"));
+  ASSERT_EQ(url->get_host(), "host:99");
+  ASSERT_EQ(url->get_pathname(), "//p");
+  ASSERT_EQ(url->get_href(), "non-spec://host:99//p");
+}
+
 TYPED_TEST(basic_tests, get_href_size_matches_get_href) {
   // Verify that get_href_size() returns the same value as get_href().size()
   // across a variety of URLs.


### PR DESCRIPTION
set_host with a value that carries a port takes the colon branch of set_host_or_hostname, which parses the host but never drops the `/.` path guard that a null-host URL with a `//` path keeps in its serialization. On a non-special URL like `non-spec:/.//p` that leaves the result as `non-spec://host:99/.//p` where ada::url gives `non-spec://host:99//p`. The no-port branch already runs delete_dash_dot after a successful parse_host, so do the same in the colon branch, before the port is inserted at host_end.