### PR TITLE
fix: avoid out-of-bounds read on empty input in is_ipv4

### DIFF
--- a/fuzz/serializers.cc
+++ b/fuzz/serializers.cc
@@ -184,20 +184,23 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     volatile bool has_tn = ada::unicode::has_tabs_or_newline(util_input);
     (void)has_tn;
 
-    // is_ipv4: must not crash on arbitrary input. Cross-check against URL
-    // parsing: if is_ipv4 reports true, embedding the string as a hostname
-    // in an http:// URL must succeed (it must be a parseable IPv4 address).
-    volatile bool is_v4 = ada::checkers::is_ipv4(util_input);
-    (void)is_v4;
-    if (is_v4) {
-      std::string ipv4_url = "http://" + util_input + "/";
-      auto parsed = ada::parse<ada::url_aggregator>(ipv4_url);
-      // is_ipv4 reports true only for strings that look like IPv4 addresses;
-      // the full parser may still reject them (e.g. out-of-range octets), but
-      // if it accepts them the host type must be IPv4.
-      if (parsed) {
-        volatile bool v = parsed->validate();
-        (void)v;
+    // is_ipv4 assumes a non-empty, lower-cased input, so honor that
+    // precondition here. Cross-check against URL parsing: if is_ipv4 reports
+    // true, embedding the string as a hostname in an http:// URL must succeed
+    // (it must be a parseable IPv4 address).
+    if (!util_input.empty()) {
+      volatile bool is_v4 = ada::checkers::is_ipv4(util_input);
+      (void)is_v4;
+      if (is_v4) {
+        std::string ipv4_url = "http://" + util_input + "/";
+        auto parsed = ada::parse<ada::url_aggregator>(ipv4_url);
+        // is_ipv4 reports true only for strings that look like IPv4 addresses;
+        // the full parser may still reject them (e.g. out-of-range octets), but
+        // if it accepts them the host type must be IPv4.
+        if (parsed) {
+          volatile bool v = parsed->validate();
+          (void)v;
+        }
       }
     }
 


### PR DESCRIPTION
checkers::is_ipv4 calls view.back() before checking for an empty view, so an empty string_view reads one byte out of bounds (UBSAN reports an offset of SIZE_MAX applied to a null pointer). is_ipv4 is a public helper in checkers.h and fuzz/serializers.cc reaches it with fuzzer-controlled input. verify_dns_length in the same file already guards the empty case, so add the same check to is_ipv4.