### PR TITLE
bound hex ipv4 number by value not digit count in parse_ipv4_number

### DIFF
--- a/include/ada/url_ip-inl.h
+++ b/include/ada/url_ip-inl.h
@@ -53,7 +53,10 @@ inline bool parse_ipv4_number(const char*& p, const char* end, uint64_t& value,
     int digits = 0;
     while (p < end && *p != '.') {
       const uint8_t nib = hex_nibble[static_cast<unsigned char>(*p)];
-      if (nib == 0xff || digits >= 8) [[unlikely]] {
+      if (nib == 0xff) [[unlikely]] {
+        return false;
+      }
+      if (v > (0xFFFFFFFFULL >> 4)) [[unlikely]] {
         return false;
       }
       v = (v << 4) | nib;

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -699,6 +699,21 @@ TYPED_TEST(basic_tests, nodejs_51619) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, ipv4_hex_leading_zeros) {
+  // Leading zeros are permitted in a hex IPv4 number, so digit runs longer
+  // than eight still map to a <= 32-bit value.
+  auto a = ada::parse<TypeParam>("http://0x0000000ff/");
+  ASSERT_TRUE(a);
+  ASSERT_EQ(a->get_hostname(), "0.0.0.255");
+  auto b = ada::parse<TypeParam>("http://0x00000000ff/");
+  ASSERT_TRUE(b);
+  ASSERT_EQ(b->get_hostname(), "0.0.0.255");
+  // A value that genuinely exceeds 32 bits is still rejected.
+  auto c = ada::parse<TypeParam>("http://0x100000000/");
+  ASSERT_FALSE(c);
+  SUCCEED();
+}
+
 // https://github.com/nodejs/undici/pull/2971
 TYPED_TEST(basic_tests, nodejs_undici_2971) {
   std::string_view base =


### PR DESCRIPTION
parse_ipv4_number caps a hex segment at eight digits, but leading zeros are allowed in a hex IPv4 number so a value that still fits in 32 bits can use more digits than that. Because of the cap, http://0x0000000ff/ (value 255) is now rejected even though the std::from_chars(radix 16) path it replaced in #1179 accepted it and returned host 0.0.0.255. This swaps the digit-count cap for the same value-range guard the octal branch already uses, so leading-zero hex numbers parse again while numbers above 0xFFFFFFFF stay rejected.