### PR TITLE
fix no scheme state accepting any input containing a fragment

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -526,10 +526,14 @@ result_type parse_url_impl(std::string_view user_input,
       }
       case state::NO_SCHEME: {
         ada_log("NO_SCHEME ", helpers::substring(url_data, input_position));
+        // The fragment was pruned from url_data before the state machine ran,
+        // so 'c is U+0023 (#)' holds exactly when a fragment was found and
+        // nothing else remains in front of it.
+        const bool c_is_hash =
+            fragment.has_value() && input_position == input_size;
         // If base is null, or base has an opaque path and c is not U+0023 (#),
         // validation error, return failure.
-        if (base_url == nullptr ||
-            (base_url->has_opaque_path && !fragment.has_value())) {
+        if (base_url == nullptr || (base_url->has_opaque_path && !c_is_hash)) {
           ada_log("NO_SCHEME validation error");
           url.is_valid = false;
           return url;
@@ -537,8 +541,7 @@ result_type parse_url_impl(std::string_view user_input,
         // Otherwise, if base has an opaque path and c is U+0023 (#),
         // set url's scheme to base's scheme, url's path to base's path, url's
         // query to base's query, and set state to fragment state.
-        else if (base_url->has_opaque_path && fragment.has_value() &&
-                 input_position == input_size) {
+        else if (base_url->has_opaque_path) {
           ada_log("NO_SCHEME opaque base with fragment");
           url.copy_scheme(*base_url);
           url.has_opaque_path = base_url->has_opaque_path;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -541,7 +541,7 @@ result_type parse_url_impl(std::string_view user_input,
         // Otherwise, if base has an opaque path and c is U+0023 (#),
         // set url's scheme to base's scheme, url's path to base's path, url's
         // query to base's query, and set state to fragment state.
-        else if (base_url->has_opaque_path) {
+        else if (base_url->has_opaque_path && c_is_hash) {
           ada_log("NO_SCHEME opaque base with fragment");
           url.copy_scheme(*base_url);
           url.has_opaque_path = base_url->has_opaque_path;

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -452,11 +452,29 @@ TYPED_TEST(basic_tests, node_issue_47889) {
   ASSERT_TRUE(expected_url->has_opaque_path);
   ASSERT_EQ(expected_url->get_href(), "a:b#");
   ASSERT_EQ(expected_url->get_pathname(), "b");
-  auto url = ada::parse<TypeParam>("..#", &*urlbase);
+  // The base has an opaque path and the input does not begin with '#', so
+  // "no scheme state" returns failure. It must report that instead of
+  // crashing, which is what the node issue asked for.
+  ASSERT_FALSE(ada::parse<TypeParam>("..#", &*urlbase));
+  ASSERT_FALSE(ada::parse<TypeParam>("x#f", &*urlbase));
+  // A fragment-only input is the one relative form such a base accepts.
+  auto url = ada::parse<TypeParam>("#f", &*urlbase);
   ASSERT_TRUE(url);
   ASSERT_TRUE(url->has_opaque_path);
-  ASSERT_EQ(url->get_href(), "a:b/#");
-  ASSERT_EQ(url->get_pathname(), "b/");
+  ASSERT_EQ(url->get_href(), "a:b#f");
+  ASSERT_EQ(url->get_pathname(), "b");
+  SUCCEED();
+}
+
+// A '#' anywhere in the input must not turn an opaque-path base into a
+// hierarchical one: the authority here is never parsed.
+TYPED_TEST(basic_tests, opaque_base_relative_hash_no_authority) {
+  auto base = ada::parse<TypeParam>("about:blank");
+  ASSERT_TRUE(base);
+  ASSERT_TRUE(base->has_opaque_path);
+  ASSERT_FALSE(ada::parse<TypeParam>("//evil.com/p", &*base));
+  ASSERT_FALSE(ada::parse<TypeParam>("//evil.com/p#", &*base));
+  ASSERT_FALSE(ada::parse<TypeParam>("/etc/passwd#", &*base));
   SUCCEED();
 }
 

--- a/tests/wpt/ada_extra_urltestdata.json
+++ b/tests/wpt/ada_extra_urltestdata.json
@@ -274,7 +274,22 @@
   {
     "input": "..#",
     "base": "a:b",
-    "href": "a:b/#",
+    "failure": true
+  },
+  {
+    "input": "//evil.com/p#",
+    "base": "about:blank",
+    "failure": true
+  },
+  {
+    "input": "x#f",
+    "base": "a:b",
+    "failure": true
+  },
+  {
+    "input": "#f",
+    "base": "a:b",
+    "href": "a:b#f",
     "origin": null,
     "protocol": "a:",
     "username": "",
@@ -282,8 +297,8 @@
     "host": "",
     "hostname": "",
     "port": "",
-    "pathname": "b/",
+    "pathname": "b",
     "search": "",
-    "hash": ""
+    "hash": "#f"
   }
 ]


### PR DESCRIPTION
no scheme state decides whether a relative input may resolve against a base with an opaque path by testing `!fragment.has_value()`, but `prune_hash` strips the fragment from `url_data` before the state machine runs, so that only asks whether the input contains a '#' anywhere rather than whether c is '#'. Anything carrying a fragment therefore skips the failure branch and falls through to relative state, so `parse("//evil.com/p#", base="about:blank")` gives `about://evil.com/p#` with host `evil.com` and `parse("..#", base="a:b")` gives `a:b/#`, where Chrome, whatwg-url and the standard all return failure; the same inputs without the trailing '#' are already rejected, so one '#' is enough to grow an authority on an opaque-path base. Comparing `input_position` against `input_size` is what the fragment branch just below already does, and it is the only condition under which c can be '#' once the fragment has been pruned.

The `..#` expectation in `ada_extra_urltestdata.json` and in `node_issue_47889` came from #368, which fixed the abort in nodejs/node#47889 but settled on `a:b/#` where that issue asked for `ERR_INVALID_URL`; both now expect failure, and the test keeps its original point that the parser reports rather than crashes. Full suite is green and the fix moves every case I could find onto Chrome's answer.