### PR TITLE
reject unterminated group in url pattern constructor string parser

### DIFF
--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -954,6 +954,8 @@ constructor_string_parser<regex_provider>::parse(std::string_view input) {
       parser.group_depth += 1;
       // Increment parser's token index by parser's token increment.
       parser.token_index += parser.token_increment;
+      // Continue.
+      continue;
     }
 
     // If parser's group depth is greater than 0:

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -591,6 +591,30 @@ TEST(wpt_urlpattern_tests, pathname_encodes_query_and_fragment_delimiters) {
   }
 }
 
+// A constructor string ending with an unterminated "{" must be rejected. The
+// end token has to reach the state machine so the trailing component is
+// captured and compiled; if it is consumed as group content instead, the
+// component is never set and silently falls back to the "*" wildcard.
+TEST(wpt_urlpattern_tests, constructor_string_unterminated_group) {
+  for (const auto& input : std::vector<std::string>{
+           "https://example.com/a{",
+           "https://example.com/{",
+           "https://example.com{",
+           "https://example.com:80/a{",
+           "https://example.com/a?q{",
+           "https://example.com/a#f{",
+       }) {
+    auto url = ada::parse_url_pattern<regex_provider>(std::string_view(input));
+    EXPECT_FALSE(url) << "pattern \"" << input << "\" should be rejected";
+  }
+  // A balanced group is unaffected.
+  auto url = ada::parse_url_pattern<regex_provider>(
+      std::string_view("https://example.com/a{b}"));
+  ASSERT_TRUE(url);
+  EXPECT_EQ(url->get_hostname(), "example.com");
+  EXPECT_EQ(url->get_pathname(), "/ab");
+}
+
 // Tests are taken from WPT
 // https://github.com/web-platform-tests/wpt/blob/0c1d19546fd4873bb9f4147f0bbf868e7b4f91b7/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 TEST(wpt_urlpattern_tests, has_regexp_groups) {


### PR DESCRIPTION
constructor_string_parser::parse increments the group depth on an open token and then falls through into the group-depth branch instead of continuing, so when "{" is the final token the end token gets consumed as group content and the loop walks off the token list without ever reaching the end handling that changes state to DONE. The component under construction is never assigned and quietly keeps its "*" default, so ada::parse_url_pattern("https://example.com{") returns a pattern whose hostname is "*" and matches any host, and "https://example.com/a{" returns pathname "*", where the string should instead fail to compile. Step 3 of parse a constructor string ends with "Continue."; this restores it, and the trailing component is then captured and compiled like any other.