### PR TITLE
report capture groups for empty input in regex_search

### DIFF
--- a/src/url_pattern_regex.cpp
+++ b/src/url_pattern_regex.cpp
@@ -38,8 +38,11 @@ std_regex_provider::regex_search(std::string_view input,
     return std::nullopt;
   }
   std::vector<std::optional<std::string>> matches;
-  // If input is empty, let's assume the result will be empty as well.
-  if (input.empty() || match_result.empty()) {
+  // An empty input can still match with capture groups (e.g. "(x*)" or an
+  // optional ":a?" against ""), so the group values must be extracted here
+  // just like for a non-empty input. A successful regex_search always leaves
+  // the full match at index 0, so match_result is never empty at this point.
+  if (match_result.empty()) {
     return matches;
   }
   matches.reserve(match_result.size());

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -179,6 +179,46 @@ TEST(wpt_urlpattern_tests, unmatched_optional_group_keeps_alignment) {
   EXPECT_EQ(pathname_groups.at("1").value_or(""), "b");
 }
 
+// A capture group in a non-wildcard component can match an empty input value:
+// "(x*)" captures the empty string and ":a?" leaves an optional group
+// undefined. These go through the compiled-regex path (not the FULL_WILDCARD
+// fast path), so the group values must still be reported for an empty input.
+TEST(wpt_urlpattern_tests, empty_input_capture_group_reported) {
+  {
+    auto init = ada::url_pattern_init{};
+    init.search = "(x*)";
+    auto pattern = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(pattern);
+
+    auto input = ada::url_pattern_init{};
+    input.search = "";
+    auto result = pattern->exec(input, nullptr);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result->has_value());
+
+    auto& groups = result->value().search.groups;
+    ASSERT_EQ(groups.size(), 1u);
+    EXPECT_EQ(groups.at("0").value_or("<undef>"), "");
+  }
+  {
+    auto init = ada::url_pattern_init{};
+    init.search = ":a?";
+    auto pattern = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(pattern);
+
+    auto input = ada::url_pattern_init{};
+    input.search = "";
+    auto result = pattern->exec(input, nullptr);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result->has_value());
+
+    auto& groups = result->value().search.groups;
+    ASSERT_EQ(groups.size(), 1u);
+    EXPECT_FALSE(groups.at("a").has_value())
+        << "unmatched optional group must be undefined, not absent";
+  }
+}
+
 // Verify that patterns with parentheses in regex values don't parse
 // (URLPattern spec doesn't allow unescaped parentheses in custom regex).
 // This documents the expected behavior and ensures we don't crash.


### PR DESCRIPTION
std_regex_provider::regex_search returns an empty groups vector whenever the component input is the empty string, skipping group extraction before it starts. A URLPattern component whose regexp has a capture group that matches an empty value then loses that group from exec(): {search: "(x*)"} against an empty search reports {} instead of {"0": ""}, and the optional {search: ":a?"} reports {} instead of leaving the group undefined, while Chrome and the create-a-component-match-result algorithm keep the key. Dropping the input.empty() term runs the same 1..n extraction for an empty match; a successful regex_search always leaves the full match at index 0 so match_result is never empty here, and the FULL_WILDCARD fast path is untouched.