### PR TITLE
account for idna expansion in can_parse size shortcut

### DIFF
--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -312,9 +312,11 @@ std::string href_from_file(std::string_view input) {
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {
   // Must match parse().has_value(), including post-normalization max length.
-  // Percent-encoding expands a byte by at most 3x. When the input (plus base,
-  // if any) fits in max_length/3, the normalized href cannot exceed
-  // max_length, so validation-only parsing (store_values=false) is safe.
+  // Percent-encoding expands a byte by at most 3x, but IDNA expands more: a
+  // 3-byte UTF-8 label such as U+337F becomes the 17-byte "xn--6oqv20b1zgzxr",
+  // so a dotted host sustains 4.5x. When the input (plus base, if any) fits in
+  // max_length/5, the normalized href cannot exceed max_length, so
+  // validation-only parsing (store_values=false) is safe.
 
   // Hot path first: absolute special URLs, no base. Avoid loading max_length
   // until we need it (common absolute-fast true/false cases).
@@ -323,10 +325,10 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
       if (!*r) {
         return false;
       }
-      // size <= max/3 => normalized href cannot exceed max (3x expansion).
+      // size <= max/5 => normalized href cannot exceed max (4.5x expansion).
       // Check this first: default max is ~4GB so almost all URLs return true.
       const uint32_t max_length = ada::get_max_input_length();
-      if (input.size() <= static_cast<size_t>(max_length) / 3) {
+      if (input.size() <= static_cast<size_t>(max_length) / 5) {
         return true;
       }
       if (input.size() > max_length) {
@@ -346,11 +348,11 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
     return false;
   }
 
-  // Relative resolution combines base + input; bound the sum so 3x expansion
+  // Relative resolution combines base + input; bound the sum so 4.5x expansion
   // of either side cannot push the final href past max_length.
   const size_t combined =
       input.size() + (base_input == nullptr ? 0 : base_input->size());
-  const bool size_safe = combined <= static_cast<size_t>(max_length) / 3;
+  const bool size_safe = combined <= static_cast<size_t>(max_length) / 5;
 
   if (size_safe) {
     // Validation-only: no buffer build, host still fully checked.

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -208,6 +208,25 @@ TYPED_TEST(max_input_length_tests, parse_normalized_just_under_limit) {
   ASSERT_LE(result->get_href().size(), small_limit);
 }
 
+TYPED_TEST(max_input_length_tests, can_parse_matches_parse_for_idna_expansion) {
+  // IDNA expands a host by more than the 3x that percent-encoding produces:
+  // U+337F is 3 UTF-8 bytes and becomes the 17-byte "xn--6oqv20b1zgzxr", so a
+  // dotted host sustains 4.5x once the label separator is amortized.
+  //
+  // 60 labels: input = 5 + 60*3 + 59 + 1 = 245 bytes, well under the limit.
+  // Normalized = 5 + 60*17 + 59 + 1 = 1085 bytes > 1024.
+  std::string host;
+  for (int i = 0; i < 60; i++) {
+    if (i) host += ".";
+    host += "\xe3\x8d\xbf";
+  }
+  std::string input = "ws://" + host + "/";
+  ASSERT_LE(input.size(), small_limit);
+  auto result = ada::parse<TypeParam>(input);
+  ASSERT_FALSE(result);
+  ASSERT_FALSE(ada::can_parse(input));
+}
+
 TYPED_TEST(max_input_length_tests, parse_with_base_normalized_exceeds_limit) {
   // Relative URL resolution can also produce long normalized URLs.
   auto base = ada::parse<TypeParam>("http://x/");


### PR DESCRIPTION
can_parse skips the full parse when the input fits in max_input_length/3, on the assumption that normalization grows a byte by at most 3x. that holds for percent-encoding but not for idna: u+337f is three utf-8 bytes and becomes the seventeen-byte xn--6oqv20b1zgzxr, so a dotted host sustains 4.5x once the label separator is amortized. can_parse then answers true for inputs whose normalized href exceeds max_input_length and which parse() rejects, contradicting the contract in its own comment and the existing parse_normalized_exceeds_limit test, which only covers the percent-encoding case. with max_input_length at 40, can_parse("ws://\xe3\x8d\xbf.\xe3\x8d\xbf/") is true on a 13-byte input whose href would be 41 bytes, while parse rejects it. raised the divisor to 5 at both shortcut sites; 4.5x is the worst amortized label expansion over all code points, so 5 is the smallest sound integer bound. the added regression fails on both backends before the change.