### PR TITLE
treat file as a special scheme in url pattern protocol check

### DIFF
--- a/include/ada/url_pattern_helpers-inl.h
+++ b/include/ada/url_pattern_helpers-inl.h
@@ -846,7 +846,8 @@ bool protocol_component_matches_special_scheme(
              component.exact_match_value == "https" ||
              component.exact_match_value == "ws" ||
              component.exact_match_value == "wss" ||
-             component.exact_match_value == "ftp";
+             component.exact_match_value == "ftp" ||
+             component.exact_match_value == "file";
     case url_pattern_component_type::FULL_WILDCARD:
       // Full wildcard matches everything including special schemes
       return true;
@@ -857,7 +858,8 @@ bool protocol_component_matches_special_scheme(
              regex_provider::regex_match("https", regex) ||
              regex_provider::regex_match("ws", regex) ||
              regex_provider::regex_match("wss", regex) ||
-             regex_provider::regex_match("ftp", regex);
+             regex_provider::regex_match("ftp", regex) ||
+             regex_provider::regex_match("file", regex);
   }
   ada::unreachable();
 }

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -655,6 +655,29 @@ TEST(wpt_urlpattern_tests, constructor_string_unterminated_group) {
   EXPECT_EQ(url->get_pathname(), "/ab");
 }
 
+// "file" is one of the special schemes, so a protocol component that matches it
+// must compile the pathname with the pathname options (segment wildcards stop
+// at "/") and make an absent pathname default to "/".
+TEST(wpt_urlpattern_tests, file_protocol_matches_special_scheme) {
+  for (const auto& input : std::vector<std::string>{
+           "file://host/:x",
+           "{file}://host/:x",
+       }) {
+    auto url = ada::parse_url_pattern<regex_provider>(std::string_view(input));
+    ASSERT_TRUE(url) << "pattern \"" << input << "\"";
+    auto one_segment = url->test(std::string_view("file://host/a"), nullptr);
+    ASSERT_TRUE(one_segment) << "pattern \"" << input << "\"";
+    EXPECT_TRUE(*one_segment) << "pattern \"" << input << "\"";
+    auto two_segments = url->test(std::string_view("file://host/a/b"), nullptr);
+    ASSERT_TRUE(two_segments) << "pattern \"" << input << "\"";
+    EXPECT_FALSE(*two_segments) << "pattern \"" << input << "\"";
+  }
+  auto url =
+      ada::parse_url_pattern<regex_provider>(std::string_view("file://host?q"));
+  ASSERT_TRUE(url);
+  EXPECT_EQ(url->get_pathname(), "/");
+}
+
 // Tests are taken from WPT
 // https://github.com/web-platform-tests/wpt/blob/0c1d19546fd4873bb9f4147f0bbf868e7b4f91b7/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 TEST(wpt_urlpattern_tests, has_regexp_groups) {


### PR DESCRIPTION
protocol_component_matches_special_scheme lists the special schemes as http, https, ws, wss and ftp and leaves out file, which scheme::is_special and the URL standard both include. Because that predicate decides whether the pathname component gets the pathname options and canonicalize a pathname, a file pattern is compiled as an opaque path: ada::parse_url_pattern("file://host/:x") matches file://host/a/b as well as file://host/a, and "file://host?q" ends up with an empty pathname instead of "/". The regexp branch had the same gap, so {file}://host/:x behaved the same way; checking 8000 generated patterns against urlpattern-polyfill, 11 results change with this and all of them move onto the reference behaviour.