### PR TITLE
keep braces around a prefixed part in generate_pattern_string

### DIFF
--- a/src/url_pattern_helpers.cpp
+++ b/src/url_pattern_helpers.cpp
@@ -1119,8 +1119,8 @@ std::string generate_pattern_string(
     // point.
     bool needs_grouping =
         !part.suffix.empty() ||
-        (!part.prefix.empty() && !options.get_prefix().empty() &&
-         part.prefix[0] != options.get_prefix()[0]);
+        (!part.prefix.empty() && (options.get_prefix().empty() ||
+                                  part.prefix[0] != options.get_prefix()[0]));
 
     // If all of the following are true:
     // - needs grouping is false; and

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -631,6 +631,52 @@ TEST(wpt_urlpattern_tests, pathname_encodes_query_and_fragment_delimiters) {
   }
 }
 
+TEST(wpt_urlpattern_tests, grouped_part_keeps_braces_without_prefix_option) {
+  // "generate a pattern string" needs grouping when a part's prefix is not the
+  // options's prefix code point. Only the pathname options carry a prefix
+  // ('/'), so a prefixed part in any other component always keeps its braces.
+  {
+    auto init = ada::url_pattern_init{};
+    init.hostname = "{-:e}?.example.com";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_hostname(), "{-:e}?.example.com");
+    // The optional modifier applies to the whole group, so a bare "-" label
+    // does not match while an absent label does.
+    auto with_dash =
+        url->test(std::string_view("https://-.example.com/"), nullptr);
+    ASSERT_TRUE(with_dash);
+    EXPECT_FALSE(*with_dash);
+    auto without =
+        url->test(std::string_view("https://.example.com/"), nullptr);
+    ASSERT_TRUE(without);
+    EXPECT_TRUE(*without);
+  }
+  {
+    // Recompiling a component from its own serialization has to give back the
+    // same component.
+    auto init = ada::url_pattern_init{};
+    init.search = "{a:x}?";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_search(), "{a:x}?");
+    auto round = ada::url_pattern_init{};
+    round.search = std::string(url->get_search());
+    auto again = ada::parse_url_pattern<regex_provider>(round);
+    ASSERT_TRUE(again);
+    EXPECT_EQ(again->get_search(), url->get_search());
+  }
+  {
+    // The pathname options do carry '/' as prefix code point, so a '/'-prefixed
+    // part stays ungrouped there.
+    auto init = ada::url_pattern_init{};
+    init.pathname = "/a{/:b}?";
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url);
+    EXPECT_EQ(url->get_pathname(), "/a/:b?");
+  }
+}
+
 // A constructor string ending with an unterminated "{" must be rejected. The
 // end token has to reach the state machine so the trailing component is
 // captured and compiled; if it is consumed as group content instead, the


### PR DESCRIPTION
generate_pattern_string adds an extra "options's prefix code point is not empty" term to its needs-grouping check, but only the pathname options carry a prefix code point, so in every other component a part that has a prefix loses its braces and the getter stops round-tripping: a pattern with hostname `{-:e}?.example.com` serializes as `-:e?.example.com`, which recompiles with the optional modifier on the named group rather than on the whole group and therefore matches `https://-.example.com/` where the original does not, and no longer matches `https://.example.com/` where the original does. The spec condition is only that the prefix is not the empty string and is not options's prefix code point, so an absent prefix code point has to count as different. Checked against urlpattern-polyfill over 20000 generated patterns: 303 component strings change, all of them from wrong to the reference output and none regressing.