### PR TITLE
fix: enforce max input length on href_from_file and search params

### DIFF
--- a/include/ada/implementation.h
+++ b/include/ada/implementation.h
@@ -149,9 +149,13 @@ parse_url_pattern(std::variant<std::string_view, url_pattern_init>&& input,
  * Creates a properly formatted file URL from a local file system path.
  * Handles platform-specific path separators and percent-encoding.
  *
+ * Respects `get_max_input_length()`: if the input path or the resulting
+ * `file://` href would exceed the limit, returns an empty string.
+ *
  * @param path The file system path to convert. Must be valid ASCII or UTF-8.
  *
- * @return A file:// URL string representing the given path.
+ * @return A file:// URL string representing the given path, or empty on
+ *         length-limit rejection.
  */
 std::string href_from_file(std::string_view path);
 
@@ -160,7 +164,9 @@ std::string href_from_file(std::string_view path);
  *
  * Both the raw input and the resulting normalized URL (the href) are checked
  * against this limit. Parsing or setter calls that would produce a URL
- * exceeding this length are rejected. The value must fit in a uint32_t.
+ * exceeding this length are rejected. The same limit also applies to
+ * `href_from_file` and to query strings passed to `url_search_params`
+ * construction / `reset`. The value must fit in a uint32_t.
  * The default is std::numeric_limits<uint32_t>::max() (approximately 4 GB).
  *
  * @param length The new maximum URL length in bytes.

--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -10,6 +10,7 @@
 #include "ada/url_search_params.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -17,6 +18,10 @@
 #include <vector>
 
 namespace ada {
+
+// Declared in implementation.h; used here as a DoS bound on untrusted query
+// strings (ada.h includes both headers).
+uint32_t get_max_input_length();
 
 // A default, empty url_search_params for use with empty iterators.
 template <typename T, ada::url_search_params_iter_type Type>
@@ -32,6 +37,10 @@ inline void url_search_params::initialize(std::string_view input) {
     input.remove_prefix(1);
   }
   if (input.empty()) {
+    return;
+  }
+  // Refuse overlong query strings (same process-wide cap as URL parsing).
+  if (input.size() > get_max_input_length()) {
     return;
   }
 

--- a/include/ada/url_search_params.h
+++ b/include/ada/url_search_params.h
@@ -55,6 +55,10 @@ using url_search_params_entries_iter =
  * All string inputs must be valid UTF-8. The caller is responsible for
  * ensuring UTF-8 validity.
  *
+ * Construction and `reset` refuse query strings longer than
+ * `get_max_input_length()` (the object is left empty). Individual `append` /
+ * `set` calls are not length-capped.
+ *
  * @see https://url.spec.whatwg.org/#interface-urlsearchparams
  */
 struct url_search_params {
@@ -63,6 +67,7 @@ struct url_search_params {
   /**
    * Constructs url_search_params by parsing a query string.
    * @param input A query string (with or without leading '?'). Must be UTF-8.
+   *        If longer than `get_max_input_length()`, the object stays empty.
    */
   explicit url_search_params(const std::string_view input) {
     initialize(input);

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -288,6 +288,14 @@ template ada::result<url_aggregator> parse<url_aggregator>(
     std::string_view input, const url_aggregator* base_url = nullptr);
 
 std::string href_from_file(std::string_view input) {
+  // Match ada::parse / setters: refuse inputs that already exceed the limit.
+  // Path percent-encoding can still expand the result, so we also check the
+  // final href below.
+  const uint32_t max_length = ada::get_max_input_length();
+  if (input.size() > max_length) {
+    return {};
+  }
+
   // This is going to be much faster than constructing a URL.
   std::string tmp_buffer;
   std::string_view internal_input;
@@ -307,7 +315,11 @@ std::string href_from_file(std::string_view input) {
   } else {
     helpers::parse_prepared_path(internal_input, ada::scheme::type::FILE, path);
   }
-  return "file://" + path;
+  std::string result = "file://" + path;
+  if (result.size() > max_length) {
+    return {};
+  }
+  return result;
 }
 
 bool can_parse(std::string_view input, const std::string_view* base_input) {

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -253,10 +253,15 @@ TYPED_TEST(max_input_length_tests, set_protocol_url_unchanged_after_reject) {
 }
 
 TEST(max_input_length_helpers, href_from_file_rejects_overlength_input) {
+  const uint32_t previous_limit = ada::get_max_input_length();
+  struct restore_t {
+    uint32_t v;
+    ~restore_t() { ada::set_max_input_length(v); }
+  } restore{previous_limit};
+
   ada::set_max_input_length(small_limit);
   std::string long_path(small_limit + 1, 'a');
   ASSERT_TRUE(ada::href_from_file(long_path).empty());
-  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
 }
 
 TEST(max_input_length_helpers, href_from_file_rejects_expanded_result) {

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -251,3 +251,71 @@ TYPED_TEST(max_input_length_tests, set_protocol_url_unchanged_after_reject) {
   ASSERT_FALSE(result->set_protocol(long_protocol));
   ASSERT_EQ(result->get_href(), original_href);
 }
+
+TEST(max_input_length_helpers, href_from_file_rejects_overlength_input) {
+  ada::set_max_input_length(small_limit);
+  std::string long_path(small_limit + 1, 'a');
+  ASSERT_TRUE(ada::href_from_file(long_path).empty());
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+}
+
+TEST(max_input_length_helpers, href_from_file_rejects_expanded_result) {
+  // Spaces in the path percent-encode to %20 (3x). With enough spaces the
+  // input stays under the limit while "file://" + encoded path exceeds it.
+  ada::set_max_input_length(small_limit);
+  // "file://" = 7, path starts with '/', spaces encode to "%20".
+  // Result length = 7 + 1 + 3*N. Need 8 + 3*N > 1024 => N > 338.6, use 339.
+  // Input length = 339 (no leading slash in input uses parse path as-is...
+  // For input of N spaces: internal path building may add leading '/'.
+  std::string path(339, ' ');
+  path += 'y';  // avoid trailing-space stripping edge cases on opaque paths
+  ASSERT_LE(path.size(), small_limit);
+  ASSERT_TRUE(ada::href_from_file(path).empty());
+  // Control: fewer spaces must succeed and stay under the limit.
+  std::string short_path(100, ' ');
+  short_path += 'y';
+  std::string ok = ada::href_from_file(short_path);
+  ASSERT_FALSE(ok.empty());
+  ASSERT_LE(ok.size(), small_limit);
+  ASSERT_TRUE(ok.starts_with("file://"));
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+}
+
+TEST(max_input_length_helpers, href_from_file_accepts_under_limit) {
+  ada::set_max_input_length(small_limit);
+  std::string ok = ada::href_from_file("/home/user/file.txt");
+  ASSERT_FALSE(ok.empty());
+  ASSERT_LE(ok.size(), small_limit);
+  ASSERT_EQ(ok, "file:///home/user/file.txt");
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+}
+
+TEST(max_input_length_helpers, url_search_params_rejects_overlength_input) {
+  ada::set_max_input_length(small_limit);
+  std::string long_query(small_limit + 1, 'a');
+  long_query += "=b";
+  ada::url_search_params params(long_query);
+  ASSERT_EQ(params.size(), 0);
+  ASSERT_TRUE(params.to_string().empty());
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+}
+
+TEST(max_input_length_helpers, url_search_params_reset_rejects_overlength) {
+  ada::set_max_input_length(small_limit);
+  ada::url_search_params params("a=b");
+  ASSERT_EQ(params.size(), 1);
+  std::string long_query(small_limit + 1, 'x');
+  long_query += "=y";
+  params.reset(long_query);
+  // reset clears first, then initialize rejects -> empty
+  ASSERT_EQ(params.size(), 0);
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+}
+
+TEST(max_input_length_helpers, url_search_params_accepts_under_limit) {
+  ada::set_max_input_length(small_limit);
+  ada::url_search_params params("foo=bar&baz=qux");
+  ASSERT_EQ(params.size(), 2);
+  ASSERT_EQ(params.get("foo"), "bar");
+  ada::set_max_input_length(std::numeric_limits<uint32_t>::max());
+}


### PR DESCRIPTION
## Summary
- Make `href_from_file` respect `get_max_input_length()` for both the input path and the final `file://` href (returns empty string when rejected).
- Make `url_search_params` construction / `reset` refuse query strings longer than the same limit (object stays empty).
- Add regression tests covering overlength input, percent-encoding expansion, and the under-limit success path.

## Test plan
- [x] `./build/tests/max_input_length`
- [x] `./build/tests/from_file_tests`
- [x] `./build/tests/url_search_params`
- [ ] CI on the PR


Made with [Cursor](https://cursor.com)