### PR TITLE
Speed up can_parse for canonical HTTP(S) URLs

### DIFF
--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,5 +1,6 @@
 #include "ada/implementation-inl.h"
 
+#include <array>
 #include <atomic>
 #include <limits>
 #include <optional>
@@ -28,6 +29,83 @@ uint32_t get_max_input_length() {
 }
 
 namespace {
+
+constexpr std::array<uint8_t, 256> clean_http_host_byte = []() consteval {
+  std::array<uint8_t, 256> result{};
+  for (size_t i = 0; i < result.size(); ++i) {
+    const auto c = static_cast<uint8_t>(i);
+    result[i] =
+        static_cast<uint8_t>((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                             c == '-' || c == '.' || c == '_' || c == '~');
+  }
+  return result;
+}();
+
+ada_really_inline bool eight_clean_http_host_bytes(
+    const uint8_t* input) noexcept {
+  return clean_http_host_byte[input[0]] & clean_http_host_byte[input[1]] &
+         clean_http_host_byte[input[2]] & clean_http_host_byte[input[3]] &
+         clean_http_host_byte[input[4]] & clean_http_host_byte[input[5]] &
+         clean_http_host_byte[input[6]] & clean_http_host_byte[input[7]];
+}
+
+// Minimal front end for the overwhelmingly common already-canonical HTTP(S)
+// case. It deliberately handles fewer inputs than
+// try_can_parse_absolute_fast: anything requiring normalization or detailed
+// host parsing falls through to that broader validator.
+std::optional<bool> try_can_parse_clean_http(std::string_view input) noexcept {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(input.data());
+  const size_t length = input.size();
+
+  size_t authority_start;
+  if (length >= 8 && input.starts_with("https://")) {
+    authority_start = 8;
+  } else if (length >= 7 && input.starts_with("http://")) {
+    authority_start = 7;
+  } else {
+    return std::nullopt;
+  }
+
+  if (authority_start >= length) {
+    return false;
+  }
+
+  size_t cursor = authority_start;
+  while (cursor + 8 <= length && eight_clean_http_host_bytes(bytes + cursor)) {
+    cursor += 8;
+  }
+  while (cursor < length) {
+    const uint8_t c = bytes[cursor];
+    if (c == '/' || c == '?' || c == '#') {
+      break;
+    }
+    if (!clean_http_host_byte[c]) {
+      return std::nullopt;
+    }
+    ++cursor;
+  }
+
+  const size_t host_length = cursor - authority_start;
+  if (host_length == 0) {
+    // Extra special-scheme slashes are normalization, not an empty host.
+    if (bytes[authority_start] == '/' || bytes[authority_start] == '\\') {
+      return std::nullopt;
+    }
+    return false;
+  }
+  if (host_length > 253 || bytes[cursor - 1] == '.') {
+    return std::nullopt;
+  }
+
+  const std::string_view host(input.data() + authority_start, host_length);
+  if (checkers::is_ipv4(host) || host.find("xn-") != std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  // Once a special URL has a valid host, path/query/fragment bytes cannot make
+  // it structurally invalid: the full parser percent-encodes them as needed.
+  return true;
+}
 
 // @private
 // Fast-path validator for can_parse.
@@ -333,7 +411,11 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
   // Hot path first: absolute special URLs, no base. Avoid loading max_length
   // until we need it (common absolute-fast true/false cases).
   if (base_input == nullptr) {
-    if (const auto r = try_can_parse_absolute_fast(input)) {
+    auto r = try_can_parse_clean_http(input);
+    if (!r.has_value()) {
+      r = try_can_parse_absolute_fast(input);
+    }
+    if (r.has_value()) {
       if (!*r) {
         return false;
       }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -514,6 +514,26 @@ static void assert_can_parse_consistent(const std::string& input) {
   }
 }
 
+TEST(basic_tests, can_parse_consistency_clean_http_frontend) {
+  for (const auto& input : std::vector<std::string>{
+           "https://example.com/",
+           "https://example.de/a/long/path?query=value#fragment",
+           "http://foo_bar.example/path with spaces",
+           "http://example.com",
+           "http://",
+           "http://?query",
+           "http:///path",
+           "http://Example.com/",
+           "http://example.com:65536/",
+           "http://1.2.3.999/",
+           "http://xn--/",
+           "http://example.com./",
+           "http://%65xample.com/",
+       }) {
+    assert_can_parse_consistent(input);
+  }
+}
+
 // Regression: extra slashes after "://" are consumed by
 // SPECIAL_AUTHORITY_IGNORE_SLASHES in the full parser, but
 // try_can_parse_absolute_fast stopped at the first extra '/' after "//",


### PR DESCRIPTION
## Summary

This ports the canonical HTTP(S) validation fast path from [Lucid URL](https://github.com/lucid-softworks/url), our URL library, into Ada's `can_parse` implementation.

It adds a narrow `can_parse` front end for already-canonical lowercase HTTP(S) URLs. The new path:

- recognizes exact lowercase `http://` and `https://` inputs
- scans clean host bytes eight at a time using a lookup table
- falls back to the existing validator for ports, credentials, IPv4, IDNA, uppercase hosts, normalization, and other complex cases
- preserves the existing normalized-output length checks

## Why

The existing validation fast path still performs broader scheme and authority processing for the overwhelmingly common canonical HTTP(S) case. Handling that conservative subset first avoids unnecessary work while retaining the current behavior for everything outside the subset.

On the shared 100,025-URL benchmark corpus used to compare Ada with the source implementation in Lucid URL, median `can_parse` performance changed from:

| | Median time | Throughput |
|---|---:|---:|
| Ada baseline | 36.77 ns/URL | 27.2M URLs/s |
| This PR | 12.75 ns/URL | 78.4M URLs/s |
| Lucid URL | 11.09 ns/URL | 90.2M URLs/s |

That is a 2.88x speedup for Ada, or a 65.3% reduction in median time per URL. Parsing and serialization paths are unchanged.

## Validation

- All 318 tests pass.
- Added focused `can_parse`/full-parser consistency coverage for fast-path and fallback inputs.
- The shared benchmark corpus reports zero validity or serialization disagreements.
- `bash tools/run-clangcldocker.sh` passes (clang-format and clang-tidy).
