### PR TITLE
perf: skip setter rollback snapshot when length limit is unreachable

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -81,6 +81,19 @@ if(MSVC AND BUILD_SHARED_LIBS)
         "$<TARGET_FILE_DIR:percent_decode>")                 # <--this is out-file path
 endif()
 
+# (most) Setters
+add_executable(bench_setters bench_setters.cpp)
+target_link_libraries(bench_setters PRIVATE ada counters::counters)
+target_include_directories(bench_setters PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(bench_setters PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/benchmarks>")
+if(MSVC AND BUILD_SHARED_LIBS)
+  # Copy the ada dll into the directory
+  add_custom_command(TARGET bench_setters POST_BUILD        # Adds a post-build event
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake -E copy_if_different..."
+        "$<TARGET_FILE:ada>"      # <--this is in-file
+        "$<TARGET_FILE_DIR:bench_setters>")                 # <--this is out-file path
+endif()
+
 add_executable(model_bench model_bench.cpp)
 target_link_libraries(model_bench PRIVATE ada counters::counters)
 target_compile_definitions(model_bench PRIVATE ADA_URL_FILE="${url-dataset_SOURCE_DIR}/out.txt")
@@ -92,10 +105,11 @@ target_link_libraries(bbc_bench PRIVATE benchmark::benchmark)
 target_link_libraries(bench_ipv4 PRIVATE benchmark::benchmark)
 target_link_libraries(percent_encode PRIVATE benchmark::benchmark)
 target_link_libraries(percent_decode PRIVATE benchmark::benchmark)
+target_link_libraries(bench_setters PRIVATE benchmark::benchmark)
 target_link_libraries(bench_search_params PRIVATE benchmark::benchmark)
 target_link_libraries(urlpattern PRIVATE benchmark::benchmark)
 
-set(BENCHMARKS wpt_bench bench benchdata bbc_bench bench_ipv4 percent_encode percent_decode bench_search_params urlpattern)
+set(BENCHMARKS wpt_bench bench benchdata bbc_bench bench_ipv4 percent_encode percent_decode bench_setters bench_search_params urlpattern)
 
 add_custom_target(run_all_benchmarks
         COMMAND ${CMAKE_COMMAND} -E echo "Running all benchmarks..."

--- a/benchmarks/bench_setters.cpp
+++ b/benchmarks/bench_setters.cpp
@@ -1,0 +1,126 @@
+#include <memory>
+#include <string>
+
+#include "ada.h"
+#include "counters/event_counter.h"
+counters::event_collector collector;
+size_t N = 1000;
+
+#include <benchmark/benchmark.h>
+
+// A representative absolute URL that every setter mutates in place. These
+// benchmarks measure that per-call cost so the guard can be optimized safely.
+static const std::string base_url =
+    "https://user:pass@www.example.com:8080/path/to/"
+    "resource?foo=bar&baz=qux#section";
+
+void init_data() {}
+
+// Runs `op` once per iteration and when hardware performance counters are
+// available, collects instruction/cycle stats
+template <typename F>
+static void run_setter(benchmark::State& state, F op) {
+  for (auto _ : state) {
+    op();
+  }
+  if (collector.has_events()) {
+    counters::event_aggregate aggregate{};
+    for (size_t i = 0; i < N; i++) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      collector.start();
+      op();
+      std::atomic_thread_fence(std::memory_order_release);
+      counters::event_count allocate_count = collector.end();
+      aggregate << allocate_count;
+    }
+    state.counters["instructions/op"] = aggregate.best.instructions();
+    state.counters["instructions/cycle"] =
+        aggregate.total.instructions() / aggregate.total.cycles();
+    state.counters["GHz"] =
+        aggregate.total.cycles() / aggregate.total.elapsed_ns();
+  }
+  state.counters["time/op"] =
+      benchmark::Counter(1, benchmark::Counter::kIsIterationInvariantRate |
+                                benchmark::Counter::kInvert);
+  state.counters["ops/s"] =
+      benchmark::Counter(1, benchmark::Counter::kIsIterationInvariantRate);
+}
+
+static void SetProtocol(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] { benchmark::DoNotOptimize(url.set_protocol("wss")); });
+}
+BENCHMARK(SetProtocol);
+
+static void SetUsername(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state,
+             [&] { benchmark::DoNotOptimize(url.set_username("newuser")); });
+}
+BENCHMARK(SetUsername);
+
+static void SetPassword(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state,
+             [&] { benchmark::DoNotOptimize(url.set_password("newpass")); });
+}
+BENCHMARK(SetPassword);
+
+static void SetPort(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] { benchmark::DoNotOptimize(url.set_port("9090")); });
+}
+BENCHMARK(SetPort);
+
+static void SetPathname(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] {
+    benchmark::DoNotOptimize(url.set_pathname("/some/other/path/here"));
+  });
+}
+BENCHMARK(SetPathname);
+
+static void SetSearch(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] { url.set_search("?a=1&b=2&c=3&d=4"); });
+}
+BENCHMARK(SetSearch);
+
+static void SetHash(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] { url.set_hash("#newfragment"); });
+}
+BENCHMARK(SetHash);
+
+static void SetHostname(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] {
+    benchmark::DoNotOptimize(url.set_hostname("www.newhost.example.org"));
+  });
+}
+BENCHMARK(SetHostname);
+
+static void SetHref(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  run_setter(state, [&] { benchmark::DoNotOptimize(url.set_href(base_url)); });
+}
+BENCHMARK(SetHref);
+
+int main(int argc, char** argv) {
+#if (__APPLE__ && __aarch64__) || defined(__linux__)
+  if (!collector.has_events()) {
+    benchmark::AddCustomContext("performance counters",
+                                "No privileged access (sudo may help).");
+  }
+#else
+  if (!collector.has_events()) {
+    benchmark::AddCustomContext("performance counters", "Unsupported system.");
+  }
+#endif
+  if (collector.has_events()) {
+    benchmark::AddCustomContext("performance counters", "Enabled");
+  }
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+}

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -390,6 +390,17 @@ struct url_aggregator : url_base {
    */
   [[nodiscard]] constexpr bool cannot_have_credentials_or_port() const;
 
+  /**
+   * @private
+   * Several setters restore a saved copy of the URL when the mutation pushes
+   * the buffer past get_max_input_length(). A setter grows the buffer by at
+   * most input_len * 3 (worst-case percent-encoding) plus a small constant for
+   * delimiters, so this returns false when that upper bound stays within the
+   * limit. It does not account for parse-failure rollbacks, which are
+   * unrelated to the length limit.
+   */
+  [[nodiscard]] bool needs_rollback_snapshot(size_t input_len) const noexcept;
+
   template <bool override_hostname = false>
   bool set_host_or_hostname(std::string_view input);
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -210,6 +210,13 @@ inline void url_aggregator::set_scheme(std::string_view new_scheme) {
   ADA_ASSERT_TRUE(validate());
 }
 
+bool url_aggregator::needs_rollback_snapshot(size_t input_len) const noexcept {
+  // 3x should cover worst-case percent-encoding of every input byte; the
+  // constant covers the handful of delimiter bytes a setter may add ("/.", "?",
+  // "#" and so on)
+  return buffer.size() + input_len * 3 + 16 > ada::get_max_input_length();
+}
+
 bool url_aggregator::set_protocol(const std::string_view input) {
   ada_log("url_aggregator::set_protocol ", input);
   ADA_ASSERT_TRUE(validate());
@@ -231,11 +238,14 @@ bool url_aggregator::set_protocol(const std::string_view input) {
       std::ranges::find_if_not(view, unicode::is_alnum_plus);
 
   if (pointer != view.end() && *pointer == ':') {
-    url_aggregator saved_url(*this);
+    std::optional<url_aggregator> saved_url;
+    if (needs_rollback_snapshot(view.size())) {
+      saved_url = *this;
+    }
     bool result = parse_scheme_with_colon<true>(
         view.substr(0, pointer - view.begin() + 1));
-    if (result && buffer.size() > ada::get_max_input_length()) {
-      *this = std::move(saved_url);
+    if (result && saved_url && buffer.size() > ada::get_max_input_length()) {
+      *this = std::move(*saved_url);
       return false;
     }
     return result;
@@ -250,7 +260,10 @@ bool url_aggregator::set_username(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
-  url_aggregator saved_url(*this);
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(input.size())) {
+    saved_url = *this;
+  }
   size_t idx = ada::unicode::percent_encode_index(
       input, character_sets::USERINFO_PERCENT_ENCODE);
   if (idx == input.size()) {
@@ -260,8 +273,8 @@ bool url_aggregator::set_username(const std::string_view input) {
     update_base_username(ada::unicode::percent_encode(
         input, character_sets::USERINFO_PERCENT_ENCODE, idx));
   }
-  if (buffer.size() > ada::get_max_input_length()) {
-    *this = std::move(saved_url);
+  if (saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
     return false;
   }
   ADA_ASSERT_TRUE(validate());
@@ -275,7 +288,10 @@ bool url_aggregator::set_password(const std::string_view input) {
   if (cannot_have_credentials_or_port()) {
     return false;
   }
-  url_aggregator saved_url(*this);
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(input.size())) {
+    saved_url = *this;
+  }
   size_t idx = ada::unicode::percent_encode_index(
       input, character_sets::USERINFO_PERCENT_ENCODE);
   if (idx == input.size()) {
@@ -285,8 +301,8 @@ bool url_aggregator::set_password(const std::string_view input) {
     update_base_password(ada::unicode::percent_encode(
         input, character_sets::USERINFO_PERCENT_ENCODE, idx));
   }
-  if (buffer.size() > ada::get_max_input_length()) {
-    *this = std::move(saved_url);
+  if (saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
     return false;
   }
   ADA_ASSERT_TRUE(validate());
@@ -347,7 +363,10 @@ bool url_aggregator::set_pathname(const std::string_view input) {
   if (has_opaque_path) {
     return false;
   }
-  url_aggregator saved_url(*this);
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(input.size())) {
+    saved_url = *this;
+  }
   clear_pathname();
   parse_path(input);
   if (get_pathname().starts_with("//") && !has_authority() && !has_dash_dot()) {
@@ -360,8 +379,8 @@ bool url_aggregator::set_pathname(const std::string_view input) {
       components.hash_start += 2;
     }
   }
-  if (buffer.size() > ada::get_max_input_length()) {
-    *this = std::move(saved_url);
+  if (saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
     return false;
   }
   ADA_ASSERT_TRUE(validate());
@@ -427,10 +446,13 @@ void url_aggregator::set_search(const std::string_view input) {
       is_special() ? ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE
                    : ada::character_sets::QUERY_PERCENT_ENCODE;
 
-  url_aggregator saved_url(*this);
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(new_value.size())) {
+    saved_url = *this;
+  }
   update_base_search(new_value, query_percent_encode_set);
-  if (buffer.size() > ada::get_max_input_length()) {
-    *this = std::move(saved_url);
+  if (saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
     return;
   }
   ADA_ASSERT_TRUE(validate());
@@ -452,10 +474,13 @@ void url_aggregator::set_hash(const std::string_view input) {
   std::string new_value;
   new_value = input[0] == '#' ? input.substr(1) : input;
   helpers::remove_ascii_tab_or_newline(new_value);
-  url_aggregator saved_url(*this);
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(new_value.size())) {
+    saved_url = *this;
+  }
   update_unencoded_base_hash(new_value);
-  if (buffer.size() > ada::get_max_input_length()) {
-    *this = std::move(saved_url);
+  if (saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
     return;
   }
   ADA_ASSERT_TRUE(validate());


### PR DESCRIPTION
Another quick win found while hiking through the codebase:

Most `url_aggregator` setters copy the entire buffer up front (`url_aggregator saved_url(*this)`) purely so they can restore it if the mutation pushes the URL past `get_max_input_length()`. That limit defaults to ~4 GB, so in practice the rollback never fires and the copy is dead weight on every `set_*` call.

These are obviously not in the hot path, but a win none the less.

## What changed

Introduce a new guard:

```cpp
[[nodiscard]] bool needs_rollback_snapshot(size_t input_len) const noexcept {
  return buffer.size() + input_len * 3 + 16 > ada::get_max_input_length();
}
```

A setter grows the buffer by at most `input_len * 3` (worst-case percent-encoding) plus a few bytes of delimiters, so when that upper bound still fits under the limit the length-guard rollback cannot fire and the snapshot is skipped. When it is needed, it's now taken lazily via `std::optional<url_aggregator>`.

Applied to the six setters whose rollback is limited by length: `set_protocol`, `set_username`, `set_password`, `set_pathname`, `set_search`, `set_hash`.

Intentionally skipped: `set_port` and `set_host_or_hostname`. Their rollbacks also handle `parse_port` / `parse_host` failures, which are not length-related, so the snapshot there is still required.

Finally, add `benchmarks/bench_setters.cpp`, which benchmarks every setter to make the case. I can fold these someplace else given their importance?

## Benchmarks

Measured with `bench_setters` with a Apple M5:

| Setter | Before | After | Speedup |
|--------|--------|-------|---------|
| `set_username` | 22.1 ns | 11.0 ns | **2.01×** |
| `set_protocol` | 29.1 ns | 18.3 ns | **1.59×** |
| `set_password` | 30.0 ns | 19.5 ns | **1.54×** |
| `set_hash` | 26.9 ns | 18.9 ns | **1.42×** |
| `set_search` | 36.6 ns | 26.3 ns | **1.39×** |
| `set_pathname` | 49.6 ns | 39.8 ns | **1.25×** |

`set_port`, `set_host_or_hostname`, and `set_href` are unchanged.

## Testing

- Full suite passes
- `clang-format`, `clang-tidy` are happy