### PR TITLE
chore: remove unused has_hex_prefix(_unsafe) helpers

### DIFF
--- a/fuzz/unicode.cc
+++ b/fuzz/unicode.cc
@@ -95,21 +95,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   volatile bool has_tn = ada::unicode::has_tabs_or_newline(sv);
   (void)has_tn;
 
-  // has_hex_prefix and has_hex_prefix_unsafe must agree when size >= 2.
-  {
-    bool safe = ada::checkers::has_hex_prefix(sv);
-    if (sv.size() >= 2) {
-      bool unsafe = ada::checkers::has_hex_prefix_unsafe(sv);
-      if (safe != unsafe) {
-        printf(
-            "has_hex_prefix vs has_hex_prefix_unsafe inconsistency for"
-            " input '%s'\n",
-            input.c_str());
-        abort();
-      }
-    }
-  }
-
   // is_double_dot and is_single_dot are mutually exclusive.
   {
     bool double_dot = ada::unicode::is_double_dot_path_segment(sv);

--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -18,25 +18,6 @@
 
 namespace ada::checkers {
 
-constexpr bool has_hex_prefix_unsafe(std::string_view input) {
-  // This is actually efficient code, see has_hex_prefix for the assembly.
-  constexpr bool is_little_endian = std::endian::native == std::endian::little;
-  constexpr uint16_t word0x = 0x7830;
-  uint16_t two_first_bytes =
-      static_cast<uint16_t>(input[0]) |
-      static_cast<uint16_t>((static_cast<uint16_t>(input[1]) << 8));
-  if constexpr (is_little_endian) {
-    two_first_bytes |= 0x2000;
-  } else {
-    two_first_bytes |= 0x020;
-  }
-  return two_first_bytes == word0x;
-}
-
-constexpr bool has_hex_prefix(std::string_view input) {
-  return input.size() >= 2 && has_hex_prefix_unsafe(input);
-}
-
 constexpr bool is_digit(char x) noexcept { return (x >= '0') & (x <= '9'); }
 
 constexpr char to_lower(char x) noexcept { return (x | 0x20); }

--- a/include/ada/checkers.h
+++ b/include/ada/checkers.h
@@ -38,20 +38,6 @@ constexpr bool is_alpha(char x) noexcept;
 
 /**
  * @private
- * Check whether a string starts with 0x or 0X. The function is only
- * safe if input.size() >=2.
- *
- * @see has_hex_prefix
- */
-constexpr bool has_hex_prefix_unsafe(std::string_view input);
-/**
- * @private
- * Check whether a string starts with 0x or 0X.
- */
-constexpr bool has_hex_prefix(std::string_view input);
-
-/**
- * @private
  * Check whether x is an ASCII digit. More likely to be inlined than
  * std::isdigit.
  */


### PR DESCRIPTION
`has_hex_prefix` and `has_hex_prefix_unsafe` are no longer in use after #1179 which replaced the usage with a shared implementation.

Tested with a shared library build to confirm that no symbols were exported.

Refs: https://github.com/ada-url/ada/pull/1179