### PR TITLE
perf: skip rollback snapshots for set_port and ada::url::set_protocol

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -5,19 +5,6 @@ CPMAddPackage(
   GIT_TAG v3.0.0
 )
 
-# Optional gperftools heap profiler (brew install gperftools), enable with
-# -DADA_MEMORY_PROFILE=ON. Linking this in lets any benchmark be run under
-# `HEAPPROFILE=/tmp/some.heap ./bench_setters` to capture allocation profiles.
-option(ADA_MEMORY_PROFILE "Link the gperftools heap profiler into benchmarks" OFF)
-if(ADA_MEMORY_PROFILE)
-  find_library(TCMALLOC_PROFILER_LIB tcmalloc_and_profiler
-    PATHS /opt/homebrew/lib /usr/local/lib)
-  if(NOT TCMALLOC_PROFILER_LIB)
-    message(FATAL_ERROR "ADA_MEMORY_PROFILE=ON but libtcmalloc_and_profiler was not found (brew install gperftools)")
-  endif()
-  message(STATUS "Heap profiler enabled, linking ${TCMALLOC_PROFILER_LIB}")
-endif()
-
 # bench_protocol
 add_executable(bench_protocol bench_protocol.cpp)
 target_link_libraries(bench_protocol PRIVATE ada counters::counters)
@@ -123,12 +110,6 @@ target_link_libraries(bench_search_params PRIVATE benchmark::benchmark)
 target_link_libraries(urlpattern PRIVATE benchmark::benchmark)
 
 set(BENCHMARKS wpt_bench bench benchdata bbc_bench bench_ipv4 percent_encode percent_decode bench_setters bench_search_params urlpattern)
-
-if(ADA_MEMORY_PROFILE)
-  foreach(benchmark IN LISTS BENCHMARKS)
-    target_link_libraries(${benchmark} PRIVATE ${TCMALLOC_PROFILER_LIB})
-  endforeach()
-endif()
 
 add_custom_target(run_all_benchmarks
         COMMAND ${CMAKE_COMMAND} -E echo "Running all benchmarks..."

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -5,6 +5,19 @@ CPMAddPackage(
   GIT_TAG v3.0.0
 )
 
+# Optional gperftools heap profiler (brew install gperftools), enable with
+# -DADA_MEMORY_PROFILE=ON. Linking this in lets any benchmark be run under
+# `HEAPPROFILE=/tmp/some.heap ./bench_setters` to capture allocation profiles.
+option(ADA_MEMORY_PROFILE "Link the gperftools heap profiler into benchmarks" OFF)
+if(ADA_MEMORY_PROFILE)
+  find_library(TCMALLOC_PROFILER_LIB tcmalloc_and_profiler
+    PATHS /opt/homebrew/lib /usr/local/lib)
+  if(NOT TCMALLOC_PROFILER_LIB)
+    message(FATAL_ERROR "ADA_MEMORY_PROFILE=ON but libtcmalloc_and_profiler was not found (brew install gperftools)")
+  endif()
+  message(STATUS "Heap profiler enabled, linking ${TCMALLOC_PROFILER_LIB}")
+endif()
+
 # bench_protocol
 add_executable(bench_protocol bench_protocol.cpp)
 target_link_libraries(bench_protocol PRIVATE ada counters::counters)
@@ -110,6 +123,12 @@ target_link_libraries(bench_search_params PRIVATE benchmark::benchmark)
 target_link_libraries(urlpattern PRIVATE benchmark::benchmark)
 
 set(BENCHMARKS wpt_bench bench benchdata bbc_bench bench_ipv4 percent_encode percent_decode bench_setters bench_search_params urlpattern)
+
+if(ADA_MEMORY_PROFILE)
+  foreach(benchmark IN LISTS BENCHMARKS)
+    target_link_libraries(${benchmark} PRIVATE ${TCMALLOC_PROFILER_LIB})
+  endforeach()
+endif()
 
 add_custom_target(run_all_benchmarks
         COMMAND ${CMAKE_COMMAND} -E echo "Running all benchmarks..."

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -397,6 +397,12 @@ struct url : url_base {
   inline void update_base_port(std::optional<uint16_t> input);
 
   /**
+   * Returns true if growing href by input_len (worst case) could exceed
+   * get_max_input_length(), meaning a rollback snapshot is actually needed.
+   */
+  [[nodiscard]] bool needs_rollback_snapshot(size_t input_len) const noexcept;
+
+  /**
    * Sets the host or hostname according to override condition.
    * Return true on success.
    * @see https://url.spec.whatwg.org/#hostname-state

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -588,6 +588,10 @@ ada_really_inline void url::parse_path(std::string_view input) {
   return (!hash.has_value() || (hash->empty())) ? "" : "#" + hash.value();
 }
 
+bool url::needs_rollback_snapshot(size_t input_len) const noexcept {
+  return get_href_size() + input_len + 16 > ada::get_max_input_length();
+}
+
 template <bool override_hostname>
 bool url::set_host_or_hostname(const std::string_view input) {
   if (has_opaque_path) {
@@ -857,11 +861,14 @@ bool url::set_protocol(const std::string_view input) {
       std::ranges::find_if_not(view, unicode::is_alnum_plus);
 
   if (pointer != view.end() && *pointer == ':') {
-    url saved_url(*this);
+    std::optional<url> saved_url;
+    if (needs_rollback_snapshot(view.size())) {
+      saved_url = *this;
+    }
     bool result = parse_scheme<true>(
         std::string_view(view.data(), pointer - view.begin()));
-    if (result && get_href_size() > ada::get_max_input_length()) {
-      *this = std::move(saved_url);
+    if (result && saved_url && get_href_size() > ada::get_max_input_length()) {
+      *this = std::move(*saved_url);
       return false;
     }
     return result;

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -340,20 +340,24 @@ bool url_aggregator::set_port(const std::string_view input) {
   std::string_view digits_to_parse =
       std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
 
-  // Revert changes if parse_port fails.
-  url_aggregator saved_url(*this);
-  parse_port(digits_to_parse);
-  if (is_valid) {
-    if (buffer.size() > ada::get_max_input_length()) {
-      *this = std::move(saved_url);
-      return false;
-    }
-    return true;
+  // parse_port only touches the buffer once the digits are already known to
+  // be in range, so an invalid port never mutates anything and needs no
+  // rollback; a valid one can only grow the buffer by a few bytes.
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(digits_to_parse.size())) {
+    saved_url = *this;
   }
-  *this = std::move(saved_url);
-  is_valid = true;
-  ADA_ASSERT_TRUE(validate());
-  return false;
+  parse_port(digits_to_parse);
+  if (!is_valid) {
+    is_valid = true;
+    ADA_ASSERT_TRUE(validate());
+    return false;
+  }
+  if (saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
+    return false;
+  }
+  return true;
 }
 
 bool url_aggregator::set_pathname(const std::string_view input) {


### PR DESCRIPTION
Followup to #1203, which skipped the rollback-snapshot copy on most setters when the length limit can't be hit, but left two functions unaddressed. This PR applies the same `needs_rollback_snapshot` pattern already established.

- `set_port`: The earlier PR skipped this setter because it can fail and roll back for reasons that have nothing to do with buffer length (e.g., an invalid port number). I mentioned this as a complex scenario and left it at that. But when the port *is* valid, the change it makes is a few bytes) it's still safe to check if it will get too big before bothering to make a backup copy
- `ada::url::set_protocol`: The earlier PR only fixed this for the `url_aggregator` class. There's a second, separate `url` class with its own `set_protocol` which I misssed. It was still always making a backup copy on every call, whether or not it was ever needed

## Benchmarks

Using `benchmarks/bench_setters.cpp` on Apple M5, 10 reps:

| Setter | Before | After | Speedup |
| --- | --- | --- | --- |
| `url_aggregator::set_port` | 44.3 ns | 31.5 ns | ~1.4x |
| `url::set_protocol` | 15.8 ns | 11.3 ns | ~1.4x |

## Test plan
- [x] Existing setter/parser test suite passes