### PR TITLE
validate ipv4 group structure in avx-512 fast path

### DIFF
--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -94,35 +94,6 @@ parse_ipv4_decimal_scalar(const char* p, const char* pend) noexcept {
 }
 
 #if defined(ADA_AVX512)
-// After SIMD validation: fewer rejection branches on convert.
-ada_really_inline uint64_t
-parse_ipv4_decimal_trusted(const char* p, const char* pend) noexcept {
-  uint32_t ipv4 = 0;
-  for (int i = 0; i < 4; ++i) {
-    uint32_t val = static_cast<uint32_t>(*p - '0');
-    ++p;
-    if (p < pend && static_cast<unsigned char>(*p - '0') <= 9) {
-      if (val == 0) [[unlikely]] {
-        return ipv4_fast_fail;
-      }
-      val = val * 10u + static_cast<uint32_t>(*p - '0');
-      ++p;
-      if (p < pend && static_cast<unsigned char>(*p - '0') <= 9) {
-        val = val * 10u + static_cast<uint32_t>(*p - '0');
-        ++p;
-        if (val > 255u) [[unlikely]] {
-          return ipv4_fast_fail;
-        }
-      }
-    }
-    ipv4 = (ipv4 << 8) | val;
-    if (i < 3) {
-      ++p;  // trusted '.'
-    }
-  }
-  return ipv4;  // trailing-dot already accounted for by caller via pend
-}
-
 // AVX-512 pure-decimal IPv4 (Lemire/Mula-style masked load + parallel checks).
 // No over-read of the source string. Wins when the binary is built with
 // -mavx512bw -mavx512vl (or -march that enables them).
@@ -149,10 +120,14 @@ ada_really_inline uint64_t try_parse_ipv4_avx512(const char* data,
   } else {
     return ipv4_fast_fail;
   }
-  // Convert from a tiny stack copy so trusted peeks stay in-bounds.
+  // Convert from a tiny stack copy so the scalar parser's peeks stay in-bounds.
+  // The SIMD stage only guarantees the byte set and dot count, not per-group
+  // digit count or non-emptiness, so the group structure must still be checked
+  // during the convert. Reuse the scalar parser rather than a "trusted" one so
+  // the AVX-512 path accepts exactly the same hosts as the portable path.
   alignas(16) char buf[16]{};
   std::memcpy(buf, data, effective_len);
-  return parse_ipv4_decimal_trusted(buf, buf + effective_len);
+  return parse_ipv4_decimal_scalar(buf, buf + effective_len);
 }
 #endif  // ADA_AVX512
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -772,6 +772,24 @@ TYPED_TEST(basic_tests, ipv4_hex_leading_zeros) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, ipv4_fast_path_malformed_groups) {
+  // A pure-decimal IPv4 group must hold 1-3 digits and be non-empty. These
+  // hosts satisfy the "all digits/dots, three dots" shape the AVX-512 fast
+  // path pre-checks but violate the group structure, so they are not valid
+  // IPv4 addresses and must be rejected on every build.
+  // Group longer than three digits:
+  ASSERT_FALSE(ada::parse<TypeParam>("http://1234.5.6.7/"));
+  ASSERT_FALSE(ada::parse<TypeParam>("http://1.2345.6.7/"));
+  // Empty group / consecutive dots:
+  ASSERT_FALSE(ada::parse<TypeParam>("http://1..2.34/"));
+  ASSERT_FALSE(ada::parse<TypeParam>("http://12.3..4/"));
+  // A well-formed address with the same length still parses:
+  auto ok = ada::parse<TypeParam>("http://12.34.56.78/");
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(ok->get_hostname(), "12.34.56.78");
+  SUCCEED();
+}
+
 // https://github.com/nodejs/undici/pull/2971
 TYPED_TEST(basic_tests, nodejs_undici_2971) {
   std::string_view base =


### PR DESCRIPTION
try_parse_ipv4_avx512 only checks that every host byte is a digit or dot and that the dot count is three, then hands the buffer to parse_ipv4_decimal_trusted, which assumes each group is one to three digits and non-empty. it isn't: a group longer than three digits like the host in http://1234.5.6.7/ has its fourth digit skipped as if it were the separator, and an empty group like http://1..2.34/ decodes the '.' as a digit, so both parse to a bogus in-range value and are accepted as ipv4 on avx-512 builds while the scalar parse_ipv4_decimal_scalar and the whatwg host parser reject them. the trusted convert also reads the first byte of each group with *p - '0' without a p<pend guard, unlike the scalar path. route the fast path through parse_ipv4_decimal_scalar on the stack copy so the avx-512 build accepts exactly the hosts the portable build does, and drop the now-unused trusted variant.