### PR TITLE
keep file url pattern port 0 in default-port step

### DIFF
--- a/include/ada/parser-inl.h
+++ b/include/ada/parser-inl.h
@@ -93,9 +93,12 @@ tl::expected<url_pattern<regex_provider>, errors> parse_url_pattern_impl(
   // using ASCII digits then set processedInit["port"] to the empty string.
   // TODO: Optimization opportunity.
   if (scheme::is_special(*processed_init->protocol)) {
-    std::string_view port = processed_init->port.value();
-    if (std::to_string(scheme::get_special_port(*processed_init->protocol)) ==
-        port) {
+    // file is the only special scheme with no default port; get_special_port
+    // returns 0 as its sentinel, so a literal "0" port must not be mistaken for
+    // a default and dropped.
+    uint16_t default_port = scheme::get_special_port(*processed_init->protocol);
+    if (default_port != 0 &&
+        std::to_string(default_port) == processed_init->port.value()) {
       processed_init->port->clear();
     }
   }

--- a/tests/wpt_urlpattern_tests.cpp
+++ b/tests/wpt_urlpattern_tests.cpp
@@ -551,6 +551,33 @@ TEST(wpt_urlpattern_tests, port_leading_zeros_canonicalization) {
   }
 }
 
+TEST(wpt_urlpattern_tests, file_zero_port_not_dropped_as_default) {
+  // Only file among the special schemes has no default port; the "default
+  // port" step must not treat a literal "0" as file's default and drop it.
+  // Other special schemes still drop their real default port.
+  for (const auto& [protocol, port, expected] :
+       std::vector<std::tuple<std::string, std::string, std::string>>{
+           {"file", "0", "0"},
+           {"file", "80", "80"},
+           {"http", "0", "0"},
+           {"http", "80", ""},
+           {"https", "443", ""},
+           {"ftp", "21", ""},
+       }) {
+    auto init = ada::url_pattern_init{};
+    init.protocol = protocol;
+    init.port = port;
+    auto url = ada::parse_url_pattern<regex_provider>(init);
+    ASSERT_TRUE(url) << protocol << ":" << port;
+    EXPECT_EQ(url->get_port(), expected) << protocol << ":" << port;
+  }
+  // Same through the constructor string form.
+  auto url = ada::parse_url_pattern<regex_provider>(
+      std::string_view("file://example.com:0/"));
+  ASSERT_TRUE(url);
+  EXPECT_EQ(url->get_port(), "0");
+}
+
 TEST(wpt_urlpattern_tests, search_and_hash_keep_leading_delimiter) {
   // "canonicalize a search" runs the URL parser in query state, and
   // "canonicalize a hash" in fragment state. Neither strips a leading


### PR DESCRIPTION
The URLPattern default-port step in parse_url_pattern_impl clears the port when it equals std::to_string(get_special_port(protocol)). file is the only special scheme with no default port and get_special_port returns 0 as its sentinel, so a literal port 0 on a file pattern stringifies to "0", matches, and gets dropped. new URLPattern("file://host:0") and url_pattern_init{protocol:"file", port:"0"} then report an empty port where the spec and urlpattern-polyfill keep "0". Guarding the comparison with default_port != 0, the same check canonicalize_port_with_protocol already uses, keeps file port 0 while http 80, https 443, ftp 21, ws 80 and wss 443 still drop as before.