### PR TITLE
perf: cut hot-path instructions with 8-byte scheme match and SWAR

### DIFF
--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -196,29 +196,21 @@ constexpr void url::copy_scheme(const ada::url& u) {
     const size_t total = scheme.size() + 3 + host_size + path_size +
                          (query.has_value() ? query_size + 1 : 0) +
                          (hash.has_value() ? hash_size + 1 : 0);
-    std::string output(total, '\0');
-    char* p = output.data();
-    std::memcpy(p, scheme.data(), scheme.size());
-    p += scheme.size();
-    p[0] = ':';
-    p[1] = '/';
-    p[2] = '/';
-    p += 3;
-    // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-    std::memcpy(p, host->data(), host_size);
-    p += host_size;
-    std::memcpy(p, path.data(), path_size);
-    p += path_size;
+    // reserve + append copies once. string(n, '\0') value-inits then
+    // overwrites, which is a wasted memset on this hot path.
+    std::string output;
+    output.reserve(total);
+    output.append(scheme);
+    output.append("://", 3);
+    output.append(*host);
+    output.append(path);
     if (query.has_value()) {
-      *p++ = '?';
-      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-      std::memcpy(p, query->data(), query_size);
-      p += query_size;
+      output.push_back('?');
+      output.append(*query);
     }
     if (hash.has_value()) {
-      *p++ = '#';
-      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-      std::memcpy(p, hash->data(), hash_size);
+      output.push_back('#');
+      output.append(*hash);
     }
     return output;
   }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -42,12 +42,37 @@ constexpr std::array<uint8_t, 256> clean_http_host_byte = []() consteval {
   return result;
 }();
 
+// SWAR: eight ASCII host bytes in [a-z0-9-._~] without 8 table lookups.
+// High bits must be clear first so the range subtracts cannot borrow
+// across bytes.
+ada_really_inline uint64_t swar_byte_eq(uint64_t w, uint8_t c) noexcept {
+  constexpr uint64_t k_ones = 0x0101010101010101ull;
+  constexpr uint64_t k_high = 0x8080808080808080ull;
+  const uint64_t x = w ^ (k_ones * c);
+  return (x - k_ones) & ~x & k_high;
+}
+
+ada_really_inline uint64_t swar_in_range(uint64_t w, uint8_t lo,
+                                         uint8_t hi) noexcept {
+  constexpr uint64_t k_ones = 0x0101010101010101ull;
+  constexpr uint64_t k_high = 0x8080808080808080ull;
+  const uint64_t ge_lo = (w | k_high) - (k_ones * lo);
+  const uint64_t le_hi = ((k_ones * hi) | k_high) - w;
+  return ge_lo & le_hi & k_high;
+}
+
 ada_really_inline bool eight_clean_http_host_bytes(
     const uint8_t* input) noexcept {
-  return clean_http_host_byte[input[0]] & clean_http_host_byte[input[1]] &
-         clean_http_host_byte[input[2]] & clean_http_host_byte[input[3]] &
-         clean_http_host_byte[input[4]] & clean_http_host_byte[input[5]] &
-         clean_http_host_byte[input[6]] & clean_http_host_byte[input[7]];
+  uint64_t w = 0;
+  std::memcpy(&w, input, 8);
+  constexpr uint64_t k_high = 0x8080808080808080ull;
+  if ((w & k_high) != 0) {
+    return false;
+  }
+  const uint64_t ok = swar_in_range(w, 'a', 'z') | swar_in_range(w, '0', '9') |
+                      swar_byte_eq(w, '-') | swar_byte_eq(w, '.') |
+                      swar_byte_eq(w, '_') | swar_byte_eq(w, '~');
+  return ok == k_high;
 }
 
 // Minimal front end for the overwhelmingly common already-canonical HTTP(S)
@@ -68,22 +93,40 @@ std::optional<bool> try_can_parse_clean_http(std::string_view input) noexcept {
     return std::nullopt;
   }
 
-  uint32_t first4{};
-  std::memcpy(&first4, bytes, 4);
-  const bool is_http =
-      first4 == (k_can_parse_little_endian ? 0x70747468u : 0x68747470u);
-  if (!is_http) {
-    return std::nullopt;
-  }
-
   size_t authority_start;
-  if (length >= 8 && bytes[4] == 's' && bytes[5] == ':' && bytes[6] == '/' &&
-      bytes[7] == '/') {
-    authority_start = 8;
-  } else if (bytes[4] == ':' && bytes[5] == '/' && bytes[6] == '/') {
-    authority_start = 7;
+  if constexpr (k_can_parse_little_endian) {
+    if (length >= 8) {
+      uint64_t first8 = 0;
+      std::memcpy(&first8, bytes, 8);
+      if (first8 == 0x2f2f3a7370747468ull) {  // "https://"
+        authority_start = 8;
+      } else if ((first8 & 0x00ffffffffffffffull) ==
+                 0x002f2f3a70747468ull) {  // "http://"
+        authority_start = 7;
+      } else {
+        return std::nullopt;
+      }
+    } else if (bytes[0] == 'h' && bytes[1] == 't' && bytes[2] == 't' &&
+               bytes[3] == 'p' && bytes[4] == ':' && bytes[5] == '/' &&
+               bytes[6] == '/') {
+      authority_start = 7;
+    } else {
+      return std::nullopt;
+    }
   } else {
-    return std::nullopt;
+    uint32_t first4{};
+    std::memcpy(&first4, bytes, 4);
+    if (first4 != 0x68747470u) {  // "http"
+      return std::nullopt;
+    }
+    if (length >= 8 && bytes[4] == 's' && bytes[5] == ':' && bytes[6] == '/' &&
+        bytes[7] == '/') {
+      authority_start = 8;
+    } else if (bytes[4] == ':' && bytes[5] == '/' && bytes[6] == '/') {
+      authority_start = 7;
+    } else {
+      return std::nullopt;
+    }
   }
 
   if (authority_start >= length) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -777,31 +777,6 @@ ADA_PARSER_SIMD void scan_hash_run(const uint8_t* b, size_t& i,
 
 #undef ADA_SCAN_STOP_RUN
 
-ada_really_inline bool last_label_may_be_a_number(
-    std::string_view view) noexcept {
-  if (view.empty()) {
-    return false;
-  }
-  if (view.back() == '.') {
-    view.remove_suffix(1);
-    if (view.empty()) {
-      return false;
-    }
-  }
-  auto is_ipv4_number_char = [](char c) noexcept {
-    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
-           (c >= 'A' && c <= 'F') || c == 'x' || c == 'X';
-  };
-  size_t i = view.size();
-  while (i > 0 && is_ipv4_number_char(view[i - 1])) {
-    --i;
-  }
-  if (i > 0 && view[i - 1] != '.') {
-    return false;
-  }
-  return i != view.size() && (view[i] >= '0' && view[i] <= '9');
-}
-
 bool path_has_dot_segment(std::string_view path) noexcept {
   if (path.empty()) {
     return false;
@@ -1114,30 +1089,68 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
   size_t pos = 0;
   ada::scheme::type scheme_type = ada::scheme::type::NOT_SPECIAL;
   uint32_t protocol_end = 0;
-  bool matched_scheme = false;
 #if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
     defined(_M_X64) || defined(_M_IX86) || defined(_M_AMD64)
-  uint32_t first4 = 0;
-  std::memcpy(&first4, b, 4);
-  if (first4 == 0x70747468u) {  // "http"
-    matched_scheme = true;
-    if (len >= 7 && b[4] == ':' && b[5] == '/' && b[6] == '/') {
-      pos = 7;
-      scheme_type = ada::scheme::type::HTTP;
-      protocol_end = 5;
-    } else if (len >= 8 && b[4] == 's' && b[5] == ':' && b[6] == '/' &&
-               b[7] == '/') {
+  // One 8-byte load + integer compare is a single cmp/jcc on x86-64.
+  // Masked compares cover the shorter special schemes without extra loads.
+  if (len >= 8) {
+    uint64_t first8 = 0;
+    std::memcpy(&first8, b, 8);
+    if (first8 == 0x2f2f3a7370747468ull) {  // "https://"
       pos = 8;
       scheme_type = ada::scheme::type::HTTPS;
       protocol_end = 6;
+    } else if ((first8 & 0x00ffffffffffffffull) ==
+               0x002f2f3a70747468ull) {  // "http://"
+      pos = 7;
+      scheme_type = ada::scheme::type::HTTP;
+      protocol_end = 5;
+    } else if ((first8 & 0x0000ffffffffffffull) ==
+               0x00002f2f3a737377ull) {  // "wss://"
+      pos = 6;
+      scheme_type = ada::scheme::type::WSS;
+      protocol_end = 4;
+    } else if ((first8 & 0x0000ffffffffffffull) ==
+               0x00002f2f3a707466ull) {  // "ftp://"
+      pos = 6;
+      scheme_type = ada::scheme::type::FTP;
+      protocol_end = 4;
+    } else if ((first8 & 0x000000ffffffffffull) ==
+               0x0000002f2f3a7377ull) {  // "ws://"
+      pos = 5;
+      scheme_type = ada::scheme::type::WS;
+      protocol_end = 3;
     } else {
       return false;
     }
+  } else if (b[0] == 'w' && b[1] == 's') {
+    if (b[2] == ':' && b[3] == '/' && b[4] == '/') {
+      pos = 5;
+      scheme_type = ada::scheme::type::WS;
+      protocol_end = 3;
+    } else if (b[2] == 's' && b[3] == ':' && b[4] == '/' && b[5] == '/') {
+      pos = 6;
+      scheme_type = ada::scheme::type::WSS;
+      protocol_end = 4;
+    } else {
+      return false;
+    }
+  } else if (b[0] == 'f' && b[1] == 't' && b[2] == 'p' && b[3] == ':' &&
+             b[4] == '/' && b[5] == '/') {
+    pos = 6;
+    scheme_type = ada::scheme::type::FTP;
+    protocol_end = 4;
+  } else if (len >= 7 && b[0] == 'h' && b[1] == 't' && b[2] == 't' &&
+             b[3] == 'p' && b[4] == ':' && b[5] == '/' && b[6] == '/') {
+    pos = 7;
+    scheme_type = ada::scheme::type::HTTP;
+    protocol_end = 5;
+  } else {
+    return false;
   }
 #else
-  // Big-endian / uncommon arches: byte-wise http(s) match (compiled out on LE).
+  // Big-endian / uncommon arches: byte-wise special-scheme match.
   if (len >= 7 && b[0] == 'h' && b[1] == 't' && b[2] == 't' && b[3] == 'p') {
-    matched_scheme = true;
     if (b[4] == ':' && b[5] == '/' && b[6] == '/') {
       pos = 7;
       scheme_type = ada::scheme::type::HTTP;
@@ -1150,31 +1163,28 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
     } else {
       return false;
     }
-  }
-#endif
-  if (!matched_scheme) {
-    if (b[0] == 'w' && b[1] == 's') {
-      if (b[2] == ':' && b[3] == '/' && b[4] == '/') {
-        pos = 5;
-        scheme_type = ada::scheme::type::WS;
-        protocol_end = 3;
-      } else if (len >= 6 && b[2] == 's' && b[3] == ':' && b[4] == '/' &&
-                 b[5] == '/') {
-        pos = 6;
-        scheme_type = ada::scheme::type::WSS;
-        protocol_end = 4;
-      } else {
-        return false;
-      }
-    } else if (b[0] == 'f' && b[1] == 't' && b[2] == 'p' && b[3] == ':' &&
-               b[4] == '/' && b[5] == '/') {
+  } else if (b[0] == 'w' && b[1] == 's') {
+    if (b[2] == ':' && b[3] == '/' && b[4] == '/') {
+      pos = 5;
+      scheme_type = ada::scheme::type::WS;
+      protocol_end = 3;
+    } else if (len >= 6 && b[2] == 's' && b[3] == ':' && b[4] == '/' &&
+               b[5] == '/') {
       pos = 6;
-      scheme_type = ada::scheme::type::FTP;
+      scheme_type = ada::scheme::type::WSS;
       protocol_end = 4;
     } else {
       return false;
     }
+  } else if (b[0] == 'f' && b[1] == 't' && b[2] == 'p' && b[3] == ':' &&
+             b[4] == '/' && b[5] == '/') {
+    pos = 6;
+    scheme_type = ada::scheme::type::FTP;
+    protocol_end = 4;
+  } else {
+    return false;
   }
+#endif
   if (pos < len && (b[pos] == '/' || b[pos] == '\\')) [[unlikely]] {
     return false;
   }
@@ -1205,12 +1215,13 @@ ada_never_inline bool try_parse_simple_absolute(std::string_view input,
       unicode::to_lower_ascii(host_buf, host_len);
       hv = std::string_view(host_buf, host_len);
     }
-    if (last_label_may_be_a_number(hv)) [[unlikely]] {
+    if (checkers::last_label_may_be_a_number(hv)) [[unlikely]] {
       return false;
     }
-    // Punycode is "xn--...". Skip the search when the host has no 'x'.
+    // Punycode is "xn--...". Skip the search when the host has no '-'.
+    // Hyphen is rarer in common hosts than 'x' (example.com, proxy, next).
     static constexpr std::string_view xn{"xn-", 3};
-    if (hv.find('x') != std::string_view::npos &&
+    if (hv.find('-') != std::string_view::npos &&
         hv.find(xn) != std::string_view::npos) [[unlikely]] {
       return false;
     }

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -535,6 +535,12 @@ TEST(basic_tests, can_parse_consistency_clean_http_frontend) {
            "http://example.0x/",
            "http://foo.0x1/",
            "http://0xffffffff/",
+           "https://foo_bar.com/",
+           "https://foo~bar.com/",
+           "https://foo-bar.com/",
+           "http://ab.cd.ef/",
+           "xxxx://",
+           "http://",
        }) {
     assert_can_parse_consistent(input);
   }
@@ -1759,6 +1765,32 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
     ASSERT_EQ(url->get_hostname(), "www.example.com");
     ASSERT_EQ(url->get_port(), "8080");
   }
+  // 8-byte integer scheme match for https/http/ws/ftp.
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/path");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_protocol(), "https:");
+    ASSERT_EQ(url->get_hostname(), "example.com");
+  }
+  {
+    auto url = ada::parse<TypeParam>("ws://example.com/chat");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_protocol(), "ws:");
+    ASSERT_EQ(url->get_href(), "ws://example.com/chat");
+  }
+  {
+    auto url = ada::parse<TypeParam>("ftp://ftp.example.com/file");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_protocol(), "ftp:");
+    ASSERT_EQ(url->get_hostname(), "ftp.example.com");
+  }
+  // Hyphen in the host is not punycode; 'x' in the path must not reject.
+  {
+    auto url = ada::parse<TypeParam>("https://foo-bar.com/xn--path");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "foo-bar.com");
+    ASSERT_EQ(url->get_pathname(), "/xn--path");
+  }
   {
     auto u = ada::parse<TypeParam>("https://example.com/a%20b/c%2Fd");
     ASSERT_TRUE(u);
@@ -1889,6 +1921,25 @@ TEST(basic_tests, try_parse_simple_absolute_ada_url) {
     ada::url u;
     ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
         std::string_view("https://xn--nxasmq6b.com/"), u));
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("ws://example.com/chat"), u));
+    ASSERT_EQ(u.get_protocol(), "ws:");
+    ASSERT_EQ(u.get_href(), "ws://example.com/chat");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("ftp://ftp.example.com/file"), u));
+    ASSERT_EQ(u.get_hostname(), "ftp.example.com");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://foo-bar.com/x"), u));
+    ASSERT_EQ(u.get_hostname(), "foo-bar.com");
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The common already-canonical `http(s)://host/path` path still paid for extra work on every parse:

- Scheme detection walked bytes after a 4-byte `"http"` compare.
- `can_parse` classified host bytes with eight table lookups per chunk.
- `url::get_href` value-initialized the result (`string(n, '\\0')`) and then overwrote it.
- Punycode rejection scanned for `'x'` first, which hits common hosts like `example.com`.

This change:

1. Matches special schemes with one little-endian `uint64_t` load/`cmp`. Shorter schemes (`http://`, `wss://`, `ftp://`, `ws://`) use the same register with a mask.
2. Replaces the 8-byte `can_parse` host check with range/`eq` SWAR (integer ALU, no table).
3. Assembles `url::get_href` with `reserve` + `append` so the hot path does not memset then memcpy.
4. Gates the `xn-` search on `'-'`, which is absent from typical hosts.

Unlike #1222, this does **not** unroll the host SIMD scan to 32 bytes. That extra code in the `never_inline` fast path was the likely source of the SetHref regression there.

Release assembly for `https://` is a single 8-byte load and compare (`movabs $0x2f2f3a7370747468` / `cmp`).

No public method signatures change. Fast-path misses still fall through to the WHATWG state machine.

Tests cover `ws://` / `ftp://` scheme matching, hyphen hosts that are not punycode, and `can_parse` hosts with `_` / `~` / `-`, plus `xxxx://` so the clean-http frontend cannot reject non-special schemes.

All 330 tests passed in both Release and Debug (development checks on).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01206-5bb9-77c5-986c-c1871966d405?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01206-5bb9-77c5-986c-c1871966d405&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

