### PR TITLE
strip tab/newline and trailing space in the absolute url fast path

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -960,6 +960,16 @@ after_rest:
     }
   }
 
+  // The slow path removes ASCII tab/newline anywhere in the input and trims a
+  // trailing C0 control or space; this fast path does neither. A query or
+  // fragment reaching the helpers below would keep those bytes percent-encoded
+  // ("?a\nb" -> "?a%0Ab", "#f " -> "#f%20") instead of stripped, so hand such
+  // inputs back to the slow path.
+  if (!rest_simple && (unicode::is_c0_control_or_space(input.back()) ||
+                       unicode::has_tabs_or_newline(input))) {
+    return false;
+  }
+
   out.type = scheme_type;
   out.is_valid = true;
   out.has_opaque_path = false;
@@ -1315,6 +1325,16 @@ after_rest:
     if (path_has_dot_segment(path_body)) {
       rest_simple = false;
     }
+  }
+
+  // The slow path removes ASCII tab/newline anywhere in the input and trims a
+  // trailing C0 control or space; this fast path does neither. A query or
+  // fragment reaching the helpers below would keep those bytes percent-encoded
+  // ("?a\nb" -> "?a%0Ab", "#f " -> "#f%20") instead of stripped, so hand such
+  // inputs back to the slow path.
+  if (!rest_simple && (unicode::is_c0_control_or_space(input.back()) ||
+                       unicode::has_tabs_or_newline(input))) {
+    return false;
   }
 
   out.type = scheme_type;

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1935,3 +1935,28 @@ TEST(basic_tests, last_label_may_be_a_number_cases) {
   ASSERT_TRUE(last_label_may_be_a_number("19.68.1.10."));
   ASSERT_TRUE(last_label_may_be_a_number("0xffffffff."));
 }
+
+TYPED_TEST(basic_tests,
+           absolute_fast_path_strips_tab_newline_and_trailing_space) {
+  // The absolute fast path must remove ASCII tab/newline and trim a trailing
+  // C0 control or space just like the general parser; a query or fragment that
+  // reaches the fast path's percent-encoding helpers must not keep those bytes
+  // as %09/%0A/%20.
+  auto check = [](std::string_view input, std::string_view expected) {
+    auto r = ada::parse<TypeParam>(input);
+    ASSERT_TRUE(r);
+    ASSERT_EQ(r->get_href(), expected);
+  };
+  check("wss://ab?x\n9", "wss://ab/?x9");
+  check("http://ab?a\tb", "http://ab/?ab");
+  check("wss://ab?x9 ", "wss://ab/?x9");
+  check("http://ab#f\ng", "http://ab/#fg");
+  check("http://ab#f ", "http://ab/#f");
+  check("http://ab/p ", "http://ab/p");
+  // with an explicit port (finish_simple_absolute_with_port)
+  check("http://ab:81?x\n9", "http://ab:81/?x9");
+  check("http://ab:81/p?x\ty#h", "http://ab:81/p?xy#h");
+  check("http://ab:81#f ", "http://ab:81/#f");
+  // a byte that legitimately needs encoding is still encoded
+  check("http://ab?x y", "http://ab/?x%20y");
+}


### PR DESCRIPTION
The absolute-url fast path runs before the parser removes ASCII tab/newline and trims a trailing C0 control or space, and its non-canonical branch then percent-encodes the query and fragment rather than stripping them, so parse("wss://ab?x\n9") returned wss://ab/?x%0A9 and parse("http://ab#f ") returned http://ab/#f%20 instead of wss://ab/?x9 and http://ab/#f. Both fast-path helpers (try_parse_simple_absolute and finish_simple_absolute_with_port) now hand an input containing a tab/newline or a trailing C0-control-or-space back to the general parser, which does the removal and trim. Added a regression test over both url and url_aggregator.