### PR TITLE
fix is_already_nfc for a composite starter before a lower-class mark

### DIFF
--- a/src/ada_idna.cpp
+++ b/src/ada_idna.cpp
@@ -5330,6 +5330,22 @@ static bool would_compose(std::u32string_view input) noexcept {
   return false;
 }
 
+// Trailing canonical combining class of a character: the combining class of the
+// last code point of its canonical decomposition, or the character's own class
+// when it has none. A precomposed starter such as U+00E1 (a + U+0301, class
+// 230) has class 0 but a nonzero trailing class, so a following mark of lower
+// class reorders past the hidden mark during normalization.
+static uint8_t trailing_ccc(char32_t c) noexcept {
+  const size_t length = canonical_decomp_length(c);
+  if (length == 0) {
+    return get_ccc(c);
+  }
+  const uint16_t* const decomposition =
+      decomposition_block_row(decomposition_index[c >> 8]) + (c % 256);
+  const size_t base = decomposition[0] >> 2;
+  return get_ccc(decomposition_data[base + length - 1]);
+}
+
 bool is_already_nfc(std::u32string_view input) noexcept {
   if (input.empty()) {
     return true;
@@ -5344,14 +5360,16 @@ bool is_already_nfc(std::u32string_view input) noexcept {
       return false;
     }
   }
-  // 2) Combining marks already in canonical order.
+  // 2) Combining marks already in canonical order. prev_ccc carries the
+  //    trailing class of the previous character's canonical decomposition so a
+  //    composite starter followed by a lower-class mark is caught.
   uint8_t prev_ccc = 0;
   for (char32_t c : input) {
     uint8_t ccc = get_ccc(c);
     if (ccc != 0 && prev_ccc > ccc) {
       return false;
     }
-    prev_ccc = ccc;
+    prev_ccc = trailing_ccc(c);
   }
   // 3) No pairwise composition would apply (including Hangul L+V / LV+T).
   return !would_compose(input);

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -263,6 +263,21 @@ TYPED_TEST(basic_tests, readme8) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, host_nfc_reorders_precomposed_starter) {
+  // A precomposed starter followed by a combining mark of lower combining class
+  // is not in NFC: normalization decomposes the starter and reorders the marks.
+  // %C3%A1%CC%A3 is U+00E1 (a + acute, class 230) then U+0323 (dot below, class
+  // 220); NFC is U+1EA1 (a + dot below) with the acute floating -> xn--lsa752l.
+  auto url = ada::parse<TypeParam>("http://%C3%A1%CC%A3/");
+  ASSERT_TRUE(url.has_value());
+  ASSERT_EQ(url->get_hostname(), "xn--lsa752l");
+
+  auto url2 = ada::parse<TypeParam>("https://%C5%9A%CC%A7.example/");
+  ASSERT_TRUE(url2.has_value());
+  ASSERT_EQ(url2->get_hostname(), "xn--nga05f.example");
+  SUCCEED();
+}
+
 TYPED_TEST(basic_tests, nodejs1) {
   auto base = ada::parse<TypeParam>("http://other.com/");
   ASSERT_TRUE(base.has_value());


### PR DESCRIPTION
ada::idna::normalize skips the decompose/compose passes whenever is_already_nfc reports the input is already NFC, and to_ascii/to_unicode lean on the same check. That quick check tracks canonical ordering using each character's own combining class, but a precomposed starter such as U+00E1 (a + U+0301, class 230) has class 0 while its canonical decomposition ends in a class-230 mark. When such a starter is followed by a combining mark of lower class, say U+0323 dot below at class 220, the string is not in NFC: full normalization decomposes the starter, reorders the dot ahead of the acute, and recomposes a+dot to U+1EA1 with the acute left floating. is_already_nfc reported NFC anyway, so the host passed through untouched and IDNA produced the wrong A-label, turning http://%C3%A1%CC%A3/ into xn--1ca07i instead of xn--lsa752l. I ran into it while diffing host serialization against another URL implementation over random Unicode labels. The fix adds a small helper returning the trailing combining class of a character's canonical decomposition and carries that in prev_ccc, so a composite starter ahead of a lower-class mark is caught; it can only defer to the existing full normalization, never skip it wrongly. I added a regression test over both backends and the full suite including wpt stays green.