### PR TITLE
perf: skip redundant href size check for small absolute URLs

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1897,7 +1897,13 @@ result_type parse_url_impl(std::string_view user_input,
           url.is_valid = false;
         }
       } else {
-        if (url.get_href_size() > max_input_length) [[unlikely]] {
+        // For a small absolute input, even worst-case normalization cannot
+        // exceed the limit: percent encoding expands at most 3x and IDNA at
+        // most 4.5x. Avoid traversing every stored component on the common
+        // default-limit path.
+        if ((base_url != nullptr ||
+             user_input.size() > static_cast<size_t>(max_input_length) / 5) &&
+            url.get_href_size() > max_input_length) [[unlikely]] {
           url.is_valid = false;
         }
       }


### PR DESCRIPTION
## Summary

Avoid calling `url::get_href_size()` after the absolute URL fast path when the input is small enough that normalization cannot exceed the configured maximum length.

The exact size check is still used for:

- every parse with a base URL; and
- absolute inputs larger than `max_input_length / 5`.

The factor-five guard matches the conservative bound already used by `can_parse`: percent encoding expands by at most 3x, while the larger sustained IDNA case is below 4.5x.

## Performance

Apple M4 Pro, Apple clang 21, Release build, alternating standalone baseline/contender binaries. Parser entry points were temporarily aligned to identical addresses for measurement only; alignment is not part of this PR.

| Workload | Paired median CPU-time delta |
|---|---:|
| 100,025 URLs, `ada::url` | **-2.42%** |
| 11 URL guard, `ada::url` | **-2.43%** |
| BBC URLs, `ada::url` | **-4.39%** |
| WPT, `ada::url` | **-1.44%** |
| 100,025 URLs, `url_aggregator` | -0.36% |
| WPT, `url_aggregator` | +0.21% |

A final narrowed broad run also kept `can_parse` and `url_aggregator` neutral while improving `ada::url` by 2.6–3.9% on the 11-URL, 100,025-URL, and BBC workloads.

## Correctness

Existing maximum-length tests cover percent-encoding expansion, IDNA expansion, custom limits, relative parsing, and parse/`can_parse` agreement. All continue to pass.

- `ctest --output-on-failure --test-dir build`: **334/334 passed**
- `bash tools/run-clangcldocker.sh`: LLVM 22 format and tidy passed
