### PR TITLE
perf: reduce aggregator credential setter tail movement

### DIFF
--- a/benchmarks/bench_setters.cpp
+++ b/benchmarks/bench_setters.cpp
@@ -59,12 +59,45 @@ static void SetUsername(benchmark::State& state) {
 }
 BENCHMARK(SetUsername);
 
+static void SetUsernameAlternatingLength(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  bool use_long_value = false;
+  run_setter(state, [&] {
+    use_long_value = !use_long_value;
+    benchmark::DoNotOptimize(
+        url.set_username(use_long_value ? "a-much-longer-username" : "x"));
+  });
+}
+BENCHMARK(SetUsernameAlternatingLength);
+
 static void SetPassword(benchmark::State& state) {
   auto url = ada::parse<ada::url_aggregator>(base_url).value();
   run_setter(state,
              [&] { benchmark::DoNotOptimize(url.set_password("newpass")); });
 }
 BENCHMARK(SetPassword);
+
+static void SetPasswordAlternatingLength(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  bool use_long_value = false;
+  run_setter(state, [&] {
+    use_long_value = !use_long_value;
+    benchmark::DoNotOptimize(
+        url.set_password(use_long_value ? "a-much-longer-password" : "y"));
+  });
+}
+BENCHMARK(SetPasswordAlternatingLength);
+
+static void SetPasswordInsertAndClear(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  bool insert_password = false;
+  run_setter(state, [&] {
+    insert_password = !insert_password;
+    benchmark::DoNotOptimize(
+        url.set_password(insert_password ? "newpass" : ""));
+  });
+}
+BENCHMARK(SetPasswordInsertAndClear);
 
 static void SetPort(benchmark::State& state) {
   auto url = ada::parse<ada::url_aggregator>(base_url).value();

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -14,6 +14,7 @@
 #include "ada/log.h"
 
 #include <charconv>
+#include <cstring>
 #include <ostream>
 #include <string_view>
 
@@ -110,7 +111,9 @@ ada_really_inline uint32_t url_aggregator::replace_and_resize(
   if (current_length == 0) {
     buffer.insert(start, input);
   } else if (input_size == current_length) {
-    buffer.replace(start, input_size, input);
+    if (input_size != 0) {
+      std::memmove(buffer.data() + start, input.data(), input_size);
+    }
   } else if (input_size < current_length) {
     buffer.erase(start, current_length - input_size);
     buffer.replace(start, input_size, input);
@@ -456,16 +459,14 @@ inline void url_aggregator::update_base_password(const std::string_view input) {
   uint32_t difference = uint32_t(input.size());
 
   if (password_exists) {
-    uint32_t current_length =
-        components.host_start - components.username_end - 1;
-    buffer.erase(components.username_end + 1, current_length);
-    difference -= current_length;
+    difference = replace_and_resize(components.username_end + 1,
+                                    components.host_start, input);
   } else {
-    buffer.insert(components.username_end, ":");
+    buffer.insert(components.username_end, input.size() + 1, ':');
+    std::memmove(buffer.data() + components.username_end + 1, input.data(),
+                 input.size());
     difference++;
   }
-
-  buffer.insert(components.username_end + 1, input);
   components.host_start += difference;
 
   // The following line is required to add "@" to hostname. When updating

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -454,6 +454,42 @@ TYPED_TEST(basic_tests, should_update_password_correctly) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, credential_replacement_preserves_url_tail) {
+  auto url = ada::parse<TypeParam>(
+      "https://initial:secret@example.com/path?before=yes#fragment");
+  ASSERT_TRUE(url);
+
+  ASSERT_TRUE(url->set_username("changed"));
+  ASSERT_TRUE(url->set_password("planet"));
+  ASSERT_EQ(url->get_href(),
+            "https://changed:planet@example.com/path?before=yes#fragment");
+
+  ASSERT_TRUE(url->set_username("x"));
+  ASSERT_TRUE(url->set_password("y"));
+  ASSERT_EQ(url->get_href(),
+            "https://x:y@example.com/path?before=yes#fragment");
+
+  ASSERT_TRUE(url->set_username("a-much-longer-username"));
+  ASSERT_TRUE(url->set_password("a-much-longer-password"));
+  ASSERT_EQ(url->get_href(),
+            "https://a-much-longer-username:a-much-longer-password@"
+            "example.com/path?before=yes#fragment");
+}
+
+TYPED_TEST(basic_tests, credential_insertion_and_encoding_preserve_url_tail) {
+  auto url = ada::parse<TypeParam>("https://example.com/path?q=1#fragment");
+  ASSERT_TRUE(url);
+
+  ASSERT_TRUE(url->set_username("a b"));
+  ASSERT_TRUE(url->set_password("p@ss"));
+  ASSERT_EQ(url->get_href(),
+            "https://a%20b:p%40ss@example.com/path?q=1#fragment");
+
+  ASSERT_TRUE(url->set_username(""));
+  ASSERT_TRUE(url->set_password(""));
+  ASSERT_EQ(url->get_href(), "https://example.com/path?q=1#fragment");
+}
+
 // https://github.com/nodejs/node/issues/47889
 TYPED_TEST(basic_tests, node_issue_47889) {
   auto urlbase = ada::parse<TypeParam>("a:b");


### PR DESCRIPTION
## Summary

Reduce URL-tail movement in `url_aggregator` credential setters:

- Equal-length `replace_and_resize` operations now use overlap-safe `memmove` instead of the heavier `std::string::replace` path.
- Replacing an existing password uses one `replace_and_resize` operation instead of erasing the old password and inserting the replacement.
- Inserting a previously absent password creates the complete `:` + password span with one structural insertion.

The benchmark now includes alternating lengths and password insert/clear operations so it does not measure only the repeated equal-length steady state.

## Performance

Apple M4 Pro, Apple clang 21, Release build, 20 alternating A/B rounds. Setter entry points were temporarily aligned to identical addresses in both binaries for measurement only; alignment is not part of this PR.

| Workload | Paired median CPU-time delta |
|---|---:|
| Username, repeated equal length | **-15.69%** |
| Username, alternating lengths | +0.82% |
| Password, repeated equal length | **-53.19%** |
| Password, alternating lengths | **-11.25%** |
| Password insert/clear | **-18.55%** |

## Correctness

Typed tests cover both URL representations and verify shorter, equal-length, longer, encoded, absent, and cleared credentials while preserving the path, query, and fragment tail.

- `ctest --output-on-failure --test-dir build`: **338/338 passed**
- `bash tools/run-clangcldocker.sh`: LLVM 22 format and tidy passed

There is no public signature or object-layout change.
