### PR TITLE
perf: replace aggregator queries with one structural edit

### DIFF
--- a/benchmarks/bench_setters.cpp
+++ b/benchmarks/bench_setters.cpp
@@ -119,6 +119,36 @@ static void SetSearch(benchmark::State& state) {
 }
 BENCHMARK(SetSearch);
 
+static void SetSearchAlternatingLength(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  bool use_long_value = false;
+  run_setter(state, [&] {
+    use_long_value = !use_long_value;
+    url.set_search(use_long_value ? "?a=much-longer-query-value" : "?x=1");
+  });
+}
+BENCHMARK(SetSearchAlternatingLength);
+
+static void SetSearchEncodedAlternatingLength(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  bool use_long_value = false;
+  run_setter(state, [&] {
+    use_long_value = !use_long_value;
+    url.set_search(use_long_value ? "?a=much longer query value" : "?x= ");
+  });
+}
+BENCHMARK(SetSearchEncodedAlternatingLength);
+
+static void SetSearchInsertAndClear(benchmark::State& state) {
+  auto url = ada::parse<ada::url_aggregator>(base_url).value();
+  bool insert_search = false;
+  run_setter(state, [&] {
+    insert_search = !insert_search;
+    url.set_search(insert_search ? "?a=1&b=2" : "");
+  });
+}
+BENCHMARK(SetSearchInsertAndClear);
+
 static void SetHash(benchmark::State& state) {
   auto url = ada::parse<ada::url_aggregator>(base_url).value();
   run_setter(state, [&] { url.set_hash("#newfragment"); });

--- a/include/ada/url_aggregator-inl.h
+++ b/include/ada/url_aggregator-inl.h
@@ -192,17 +192,17 @@ inline void url_aggregator::update_base_search(std::string_view input) {
     }
 
     buffer.append(input);
+  } else if (components.search_start != url_components::omitted) {
+    const uint32_t difference = replace_and_resize(
+        components.search_start + 1, components.hash_start, input);
+    components.hash_start += difference;
   } else {
-    if (components.search_start == url_components::omitted) {
-      components.search_start = components.hash_start;
-    } else {
-      buffer.erase(components.search_start,
-                   components.hash_start - components.search_start);
-      components.hash_start = components.search_start;
+    components.search_start = components.hash_start;
+    buffer.insert(components.search_start, input.size() + 1, '?');
+    if (!input.empty()) {
+      std::memmove(buffer.data() + components.search_start + 1, input.data(),
+                   input.size());
     }
-
-    buffer.insert(components.search_start, "?");
-    buffer.insert(components.search_start + 1, input);
     components.hash_start += uint32_t(input.size() + 1);  // Do not forget `?`
   }
 
@@ -232,30 +232,29 @@ inline void url_aggregator::update_base_search(
       buffer.append(input);
     }
   } else {
-    if (components.search_start == url_components::omitted) {
-      components.search_start = components.hash_start;
-    } else {
-      buffer.erase(components.search_start,
-                   components.hash_start - components.search_start);
-      components.hash_start = components.search_start;
+    const size_t idx =
+        ada::unicode::percent_encode_index(input, query_percent_encode_set);
+    std::string encoded;
+    std::string_view replacement = input;
+    if (idx != input.size()) {
+      encoded =
+          ada::unicode::percent_encode(input, query_percent_encode_set, idx);
+      replacement = encoded;
     }
 
-    buffer.insert(components.search_start, "?");
-    size_t idx =
-        ada::unicode::percent_encode_index(input, query_percent_encode_set);
-    if (idx == input.size()) {
-      buffer.insert(components.search_start + 1, input);
-      components.hash_start += uint32_t(input.size() + 1);  // Do not forget `?`
+    if (components.search_start != url_components::omitted) {
+      const uint32_t difference = replace_and_resize(
+          components.search_start + 1, components.hash_start, replacement);
+      components.hash_start += difference;
     } else {
-      buffer.insert(components.search_start + 1, input, 0, idx);
-      input.remove_prefix(idx);
-      // We only create a temporary string if we need percent encoding and
-      // we attempt to create as small a temporary string as we can.
-      std::string encoded =
-          ada::unicode::percent_encode(input, query_percent_encode_set);
-      buffer.insert(components.search_start + idx + 1, encoded);
+      components.search_start = components.hash_start;
+      buffer.insert(components.search_start, replacement.size() + 1, '?');
+      if (!replacement.empty()) {
+        std::memmove(buffer.data() + components.search_start + 1,
+                     replacement.data(), replacement.size());
+      }
       components.hash_start +=
-          uint32_t(encoded.size() + idx + 1);  // Do not forget `?`
+          uint32_t(replacement.size() + 1);  // Do not forget `?`
     }
   }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -490,6 +490,36 @@ TYPED_TEST(basic_tests, credential_insertion_and_encoding_preserve_url_tail) {
   ASSERT_EQ(url->get_href(), "https://example.com/path?q=1#fragment");
 }
 
+TYPED_TEST(basic_tests, query_replacement_preserves_url_tail) {
+  auto url = ada::parse<TypeParam>(
+      "https://user:pass@example.com/path?before=yes#fragment");
+  ASSERT_TRUE(url);
+
+  url->set_search("?same=value");
+  ASSERT_EQ(url->get_href(),
+            "https://user:pass@example.com/path?same=value#fragment");
+
+  url->set_search("?a=1");
+  ASSERT_EQ(url->get_href(), "https://user:pass@example.com/path?a=1#fragment");
+
+  url->set_search("?longer query=value");
+  ASSERT_EQ(url->get_href(),
+            "https://user:pass@example.com/path?"
+            "longer%20query=value#fragment");
+}
+
+TYPED_TEST(basic_tests, query_insertion_and_encoding_preserve_url_tail) {
+  auto url = ada::parse<TypeParam>("https://example.com/path#fragment");
+  ASSERT_TRUE(url);
+
+  url->set_search("?value='x y'");
+  ASSERT_EQ(url->get_href(),
+            "https://example.com/path?value=%27x%20y%27#fragment");
+
+  url->set_search("");
+  ASSERT_EQ(url->get_href(), "https://example.com/path#fragment");
+}
+
 // https://github.com/nodejs/node/issues/47889
 TYPED_TEST(basic_tests, node_issue_47889) {
   auto urlbase = ada::parse<TypeParam>("a:b");


### PR DESCRIPTION
## Summary

Replace or insert `url_aggregator` queries with one structural edit when a fragment follows the query.

Previously query replacement could erase the old query, insert `?`, and then insert the plain or encoded value, moving the fragment tail multiple times. This change:

- encodes into a temporary only when needed;
- keeps an existing `?` delimiter and replaces the query value with one `replace_and_resize` call; and
- inserts an absent `?` + query span with one structural insertion.

The benchmark now covers alternating query lengths, encoded queries, and insert/clear operations.

## Performance

Apple M4 Pro, Apple clang 21, Release build, 20 alternating A/B rounds. `url_aggregator::set_search` had the exact same address in both binaries for measurement only; alignment is not part of this PR.

| Workload | Paired median CPU-time delta |
|---|---:|
| Search, repeated equal length | **-27.64%** |
| Search, alternating lengths | **-10.76%** |
| Search, alternating encoded lengths | **-17.58%** |
| Search insert/clear | **-13.18%** |

## Correctness

Typed tests cover both URL representations and verify shorter, equal-length, longer, encoded, absent, and cleared queries while preserving credentials, path, and fragment tails.

- `ctest --output-on-failure --test-dir build`: **338/338 passed**
- `bash tools/run-clangcldocker.sh`: LLVM 22 format and tidy passed

There is no public signature or object-layout change.
