### PR TITLE
perf: SIMD percent-decode and form-urlencoded encode/decode

### DIFF
--- a/include/ada/unicode.h
+++ b/include/ada/unicode.h
@@ -198,6 +198,7 @@ ada_really_inline unsigned constexpr convert_hex_to_binary(char c) noexcept;
 std::string percent_decode(std::string_view input, size_t first_percent);
 
 /**
+ * @private
  * Decode an application/x-www-form-urlencoded component: map '+' to space,
  * then percent-decode. Single allocation; no intermediate string.
  *
@@ -206,6 +207,20 @@ std::string percent_decode(std::string_view input, size_t first_percent);
  * @see https://url.spec.whatwg.org/#concept-urlencoded-parser
  */
 std::string form_urlencoded_decode(std::string_view input);
+
+/**
+ * @private
+ * application/x-www-form-urlencoded byte serializer: percent-encode with the
+ * form set, mapping 0x20 SPACE to '+' instead of '%20'.
+ * @see https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
+ */
+std::string form_urlencoded_encode(std::string_view input);
+
+/**
+ * @private
+ * Append a form-urlencoded component to `out` (no intermediate string).
+ */
+void form_urlencoded_encode_append(std::string_view input, std::string& out);
 
 /**
  * @private

--- a/include/ada/url_search_params-inl.h
+++ b/include/ada/url_search_params-inl.h
@@ -5,7 +5,6 @@
 #ifndef ADA_URL_SEARCH_PARAMS_INL_H
 #define ADA_URL_SEARCH_PARAMS_INL_H
 
-#include "ada/character_sets-inl.h"
 #include "ada/unicode.h"
 #include "ada/url_search_params.h"
 
@@ -120,22 +119,14 @@ inline bool url_search_params::has(std::string_view key,
 }
 
 inline std::string url_search_params::to_string() const {
-  auto character_set = ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE;
   std::string out{};
   for (size_t i = 0; i < params.size(); i++) {
-    auto key = ada::unicode::percent_encode(params[i].first, character_set);
-    auto value = ada::unicode::percent_encode(params[i].second, character_set);
-
-    // Performance optimization: Move this inside percent_encode.
-    std::ranges::replace(key, ' ', '+');
-    std::ranges::replace(value, ' ', '+');
-
     if (i != 0) {
-      out += "&";
+      out += '&';
     }
-    out.append(key);
-    out += "=";
-    out.append(value);
+    unicode::form_urlencoded_encode_append(params[i].first, out);
+    out += '=';
+    unicode::form_urlencoded_encode_append(params[i].second, out);
   }
   return out;
 }

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -40,8 +40,14 @@ ADA_POP_DISABLE_WARNINGS
 
 #ifdef ADA_UNICODE_NEED_SSSE3_TARGET
 #define ADA_UNICODE_SIMD __attribute__((target("ssse3")))
+#define ADA_UNICODE_SIMD_NOINLINE __attribute__((target("ssse3"), noinline))
 #else
 #define ADA_UNICODE_SIMD ada_really_inline
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+#define ADA_UNICODE_SIMD_NOINLINE __declspec(noinline)
+#else
+#define ADA_UNICODE_SIMD_NOINLINE __attribute__((noinline))
+#endif
 #endif
 
 #ifdef ADA_REGULAR_VISUAL_STUDIO
@@ -420,8 +426,8 @@ ada_really_inline unsigned decode_pct_groups(const uint8_t* p,
 }
 
 template <bool space_as_plus>
-void append_encoded_byte(unsigned char c, const uint8_t* set,
-                         std::string& out) {
+ada_really_inline void append_encoded_byte(unsigned char c, const uint8_t* set,
+                                           std::string& out) {
   if (space_as_plus && c == ' ') {
     out.push_back('+');
   } else if (ada::character_sets::bit_at(set, c)) {
@@ -471,55 +477,76 @@ void flush_encode_bits_neon(const char* p, uint64_t bits, const uint8_t* set,
 }
 #endif
 
-template <bool space_as_plus>
-void encode_tail(const char* p, const char* end, const uint8_t* set,
-                 std::string& out) {
 #if ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
-  if (const nibble_tables* tables = nibble_tables_for(set);
-      tables != nullptr && end - p >= 16) {
+// Out of line so short percent_encode (setters, CodSpeed examples) does not
+// grow by the 16-byte classify loop. 48-byte floor: below that, scalar
+// bit_at wins on instruction count (#1218 / #1230).
+template <bool space_as_plus>
+ADA_UNICODE_SIMD_NOINLINE void simd_encode_windows(const char* p,
+                                                   const char* end,
+                                                   const uint8_t* set,
+                                                   const nibble_tables* tables,
+                                                   std::string& out) {
 #if ADA_UNICODE_SSSE3_ENCODE
-    const __m128i lo_tbl =
-        _mm_loadu_si128(reinterpret_cast<const __m128i*>(tables->low));
-    const __m128i hi_tbl =
-        _mm_loadu_si128(reinterpret_cast<const __m128i*>(tables->high));
-    const __m128i space = _mm_set1_epi8(' ');
-    while (p + 16 <= end) {
-      const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
-      int mask = ssse3_nibble_mask(w, lo_tbl, hi_tbl);
-      if constexpr (space_as_plus) {
-        mask |= _mm_movemask_epi8(_mm_cmpeq_epi8(w, space));
-      }
-      if (mask == 0) {
-        out.append(p, 16);
-        p += 16;
-        continue;
-      }
-      flush_encode_mask<space_as_plus>(p, static_cast<uint32_t>(mask), set,
-                                       out);
-      p += 16;
+  const __m128i lo_tbl =
+      _mm_loadu_si128(reinterpret_cast<const __m128i*>(tables->low));
+  const __m128i hi_tbl =
+      _mm_loadu_si128(reinterpret_cast<const __m128i*>(tables->high));
+  const __m128i space = _mm_set1_epi8(' ');
+  while (p + 16 <= end) {
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+    int mask = ssse3_nibble_mask(w, lo_tbl, hi_tbl);
+    if constexpr (space_as_plus) {
+      mask |= _mm_movemask_epi8(_mm_cmpeq_epi8(w, space));
     }
+    if (mask == 0) {
+      out.append(p, 16);
+      p += 16;
+      continue;
+    }
+    flush_encode_mask<space_as_plus>(p, static_cast<uint32_t>(mask), set, out);
+    p += 16;
+  }
 #elif ADA_NEON
-    const uint8x16_t lo_tbl = vld1q_u8(tables->low);
-    const uint8x16_t hi_tbl = vld1q_u8(tables->high);
-    const uint8x16_t space = vdupq_n_u8(' ');
-    while (p + 16 <= end) {
-      const uint8x16_t w = vld1q_u8(reinterpret_cast<const uint8_t*>(p));
-      const uint8x16_t hit =
-          vandq_u8(vqtbl1q_u8(lo_tbl, vandq_u8(w, vdupq_n_u8(0x0F))),
-                   vqtbl1q_u8(hi_tbl, vshrq_n_u8(w, 4)));
-      uint64_t bits = neon_nibble_bits(vtstq_u8(hit, hit));
-      if constexpr (space_as_plus) {
-        bits |= neon_nibble_bits(vceqq_u8(w, space));
-      }
-      if (bits == 0) {
-        out.append(p, 16);
-        p += 16;
-        continue;
-      }
-      flush_encode_bits_neon<space_as_plus>(p, bits, set, out);
-      p += 16;
+  const uint8x16_t lo_tbl = vld1q_u8(tables->low);
+  const uint8x16_t hi_tbl = vld1q_u8(tables->high);
+  const uint8x16_t space = vdupq_n_u8(' ');
+  while (p + 16 <= end) {
+    const uint8x16_t w = vld1q_u8(reinterpret_cast<const uint8_t*>(p));
+    const uint8x16_t hit =
+        vandq_u8(vqtbl1q_u8(lo_tbl, vandq_u8(w, vdupq_n_u8(0x0F))),
+                 vqtbl1q_u8(hi_tbl, vshrq_n_u8(w, 4)));
+    uint64_t bits = neon_nibble_bits(vtstq_u8(hit, hit));
+    if constexpr (space_as_plus) {
+      bits |= neon_nibble_bits(vceqq_u8(w, space));
     }
+    if (bits == 0) {
+      out.append(p, 16);
+      p += 16;
+      continue;
+    }
+    flush_encode_bits_neon<space_as_plus>(p, bits, set, out);
+    p += 16;
+  }
 #endif
+  while (p < end) {
+    append_encoded_byte<space_as_plus>(static_cast<unsigned char>(*p), set,
+                                       out);
+    ++p;
+  }
+}
+#endif  // ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
+
+template <bool space_as_plus>
+ada_really_inline void encode_tail(const char* p, const char* end,
+                                   const uint8_t* set, std::string& out) {
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
+  if (end - p >= 48) {
+    if (const nibble_tables* tables = nibble_tables_for(set);
+        tables != nullptr) {
+      simd_encode_windows<space_as_plus>(p, end, set, tables, out);
+      return;
+    }
   }
 #endif
   while (p < end) {

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -11,9 +11,19 @@ ADA_POP_DISABLE_WARNINGS
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
+
+#include "ada/unicode-inl.h"
 #if ADA_SSSE3
 #include <tmmintrin.h>
+#define ADA_UNICODE_SSSE3_ENCODE 1
+#elif (defined(__x86_64__) || defined(__amd64__)) && defined(__GNUC__) && \
+    !defined(_MSC_VER)
+// gcc/clang honor target("ssse3"). clang-cl and MSVC do not.
+#include <tmmintrin.h>
+#define ADA_UNICODE_SSSE3_ENCODE 1
+#define ADA_UNICODE_NEED_SSSE3_TARGET 1
 #elif ADA_NEON
 #include <arm_neon.h>
 #elif ADA_SSE2
@@ -24,7 +34,502 @@ ADA_POP_DISABLE_WARNINGS
 #include <riscv_vector.h>
 #endif
 
+#ifndef ADA_UNICODE_SSSE3_ENCODE
+#define ADA_UNICODE_SSSE3_ENCODE 0
+#endif
+
+#ifdef ADA_UNICODE_NEED_SSSE3_TARGET
+#define ADA_UNICODE_SIMD __attribute__((target("ssse3")))
+#else
+#define ADA_UNICODE_SIMD ada_really_inline
+#endif
+
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+#include <intrin.h>
+#endif
+
 #include <ranges>
+
+namespace {
+
+ada_really_inline int trailing_zeroes32(uint32_t input_num) noexcept {
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+  unsigned long ret;
+  _BitScanForward(&ret, input_num);
+  return static_cast<int>(ret);
+#else
+  return __builtin_ctz(input_num);
+#endif
+}
+
+#if ADA_NEON
+ada_really_inline int trailing_zeroes64(uint64_t input_num) noexcept {
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+  unsigned long ret;
+  _BitScanForward64(&ret, input_num);
+  return static_cast<int>(ret);
+#else
+  return __builtin_ctzll(input_num);
+#endif
+}
+
+ada_really_inline uint64_t neon_nibble_bits(uint8x16_t matches) noexcept {
+  const uint8x8_t nib = vshrn_n_u16(vreinterpretq_u16_u8(matches), 4);
+  return vget_lane_u64(vreinterpret_u64_u8(nib), 0);
+}
+#endif  // ADA_NEON
+
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
+// Nibble classifier from oven-sh/WebKit#454 / parser.cpp: a byte is a hit
+// when low[b & 0xF] & high[b >> 4] != 0. Built consteval from each 32-byte
+// percent-encode bitset so the vector path cannot disagree with bit_at.
+struct nibble_tables {
+  alignas(16) uint8_t low[16]{};
+  alignas(16) uint8_t high[16]{};
+  bool fits{true};
+};
+
+consteval nibble_tables make_stop_nibble_tables(
+    const std::array<uint8_t, 256>& cls) {
+  nibble_tables t{};
+  uint16_t patterns[16]{};
+  for (int hi = 0; hi < 16; ++hi) {
+    for (int lo = 0; lo < 16; ++lo) {
+      if (cls[static_cast<size_t>((hi << 4) | lo)] != 0) {
+        patterns[hi] = static_cast<uint16_t>(patterns[hi] | (1u << lo));
+      }
+    }
+  }
+  int bits_used = 0;
+  for (int hi = 0; hi < 16; ++hi) {
+    if (patterns[hi] == 0 || t.high[hi] != 0) {
+      continue;
+    }
+    if (bits_used == 8) {
+      t.fits = false;
+      return t;
+    }
+    const uint8_t bit = static_cast<uint8_t>(1u << bits_used++);
+    for (int other = hi; other < 16; ++other) {
+      if (patterns[other] == patterns[hi]) {
+        t.high[other] = static_cast<uint8_t>(t.high[other] | bit);
+      }
+    }
+    for (int lo = 0; lo < 16; ++lo) {
+      if ((patterns[hi] & (1u << lo)) != 0) {
+        t.low[lo] = static_cast<uint8_t>(t.low[lo] | bit);
+      }
+    }
+  }
+  return t;
+}
+
+consteval nibble_tables make_bitset_nibble_tables(const uint8_t (&bits)[32]) {
+  std::array<uint8_t, 256> cls{};
+  for (size_t i = 0; i < 256; ++i) {
+    if ((bits[i >> 3] & static_cast<uint8_t>(1u << (i & 7))) != 0) {
+      cls[i] = 1;
+    }
+  }
+  return make_stop_nibble_tables(cls);
+}
+
+consteval bool nibble_matches_bitset(const nibble_tables& t,
+                                     const uint8_t (&bits)[32]) {
+  for (int i = 0; i < 256; ++i) {
+    const bool bit = (bits[i >> 3] & static_cast<uint8_t>(1u << (i & 7))) != 0;
+    const bool hit = (t.low[i & 0xF] & t.high[i >> 4]) != 0;
+    if (bit != hit) {
+      return false;
+    }
+  }
+  return true;
+}
+
+constexpr nibble_tables k_c0_nibbles =
+    make_bitset_nibble_tables(ada::character_sets::C0_CONTROL_PERCENT_ENCODE);
+constexpr nibble_tables k_special_query_nibbles = make_bitset_nibble_tables(
+    ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE);
+constexpr nibble_tables k_query_nibbles =
+    make_bitset_nibble_tables(ada::character_sets::QUERY_PERCENT_ENCODE);
+constexpr nibble_tables k_fragment_nibbles =
+    make_bitset_nibble_tables(ada::character_sets::FRAGMENT_PERCENT_ENCODE);
+constexpr nibble_tables k_userinfo_nibbles =
+    make_bitset_nibble_tables(ada::character_sets::USERINFO_PERCENT_ENCODE);
+constexpr nibble_tables k_path_nibbles =
+    make_bitset_nibble_tables(ada::character_sets::PATH_PERCENT_ENCODE);
+constexpr nibble_tables k_www_form_nibbles = make_bitset_nibble_tables(
+    ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE);
+static_assert(
+    k_c0_nibbles.fits &&
+    nibble_matches_bitset(k_c0_nibbles,
+                          ada::character_sets::C0_CONTROL_PERCENT_ENCODE));
+static_assert(
+    k_special_query_nibbles.fits &&
+    nibble_matches_bitset(k_special_query_nibbles,
+                          ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE));
+static_assert(k_query_nibbles.fits &&
+              nibble_matches_bitset(k_query_nibbles,
+                                    ada::character_sets::QUERY_PERCENT_ENCODE));
+static_assert(
+    k_fragment_nibbles.fits &&
+    nibble_matches_bitset(k_fragment_nibbles,
+                          ada::character_sets::FRAGMENT_PERCENT_ENCODE));
+static_assert(
+    k_userinfo_nibbles.fits &&
+    nibble_matches_bitset(k_userinfo_nibbles,
+                          ada::character_sets::USERINFO_PERCENT_ENCODE));
+static_assert(k_path_nibbles.fits &&
+              nibble_matches_bitset(k_path_nibbles,
+                                    ada::character_sets::PATH_PERCENT_ENCODE));
+static_assert(k_www_form_nibbles.fits &&
+              nibble_matches_bitset(
+                  k_www_form_nibbles,
+                  ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE));
+
+const nibble_tables* nibble_tables_for(const uint8_t* set) noexcept {
+  if (set == ada::character_sets::FRAGMENT_PERCENT_ENCODE) {
+    return &k_fragment_nibbles;
+  }
+  if (set == ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE) {
+    return &k_special_query_nibbles;
+  }
+  if (set == ada::character_sets::QUERY_PERCENT_ENCODE) {
+    return &k_query_nibbles;
+  }
+  if (set == ada::character_sets::USERINFO_PERCENT_ENCODE) {
+    return &k_userinfo_nibbles;
+  }
+  if (set == ada::character_sets::PATH_PERCENT_ENCODE) {
+    return &k_path_nibbles;
+  }
+  if (set == ada::character_sets::C0_CONTROL_PERCENT_ENCODE) {
+    return &k_c0_nibbles;
+  }
+  if (set == ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE) {
+    return &k_www_form_nibbles;
+  }
+  return nullptr;
+}
+#endif  // ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
+
+#if ADA_UNICODE_SSSE3_ENCODE
+ADA_UNICODE_SIMD int ssse3_nibble_mask(__m128i w, __m128i lo_tbl,
+                                       __m128i hi_tbl) noexcept {
+  const __m128i nibble = _mm_set1_epi8(0x0F);
+  const __m128i lo = _mm_and_si128(w, nibble);
+  const __m128i hi = _mm_and_si128(_mm_srli_epi16(w, 4), nibble);
+  const __m128i hit =
+      _mm_and_si128(_mm_shuffle_epi8(lo_tbl, lo), _mm_shuffle_epi8(hi_tbl, hi));
+  return _mm_movemask_epi8(_mm_cmpeq_epi8(hit, _mm_setzero_si128())) ^ 0xFFFF;
+}
+
+// Decode up to five leading "%XX" groups from a 16-byte load (15 used).
+ADA_UNICODE_SIMD unsigned ssse3_decode_pct_groups(const uint8_t* p,
+                                                  uint8_t* d) noexcept {
+  const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+  const int pct = _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('%')));
+  if ((pct & 1) == 0) {
+    return 0;
+  }
+  const __m128i extract =
+      _mm_setr_epi8(1, 2, 4, 5, 7, 8, 10, 11, 13, 14, -1, -1, -1, -1, -1, -1);
+  const __m128i hexes = _mm_shuffle_epi8(w, extract);
+  const __m128i is_digit = _mm_and_si128(
+      _mm_cmpgt_epi8(hexes, _mm_set1_epi8(static_cast<char>('0' - 1))),
+      _mm_cmpgt_epi8(_mm_set1_epi8(static_cast<char>('9' + 1)), hexes));
+  const __m128i lower = _mm_or_si128(hexes, _mm_set1_epi8(0x20));
+  const __m128i is_letter = _mm_and_si128(
+      _mm_cmpgt_epi8(lower, _mm_set1_epi8(static_cast<char>('a' - 1))),
+      _mm_cmpgt_epi8(_mm_set1_epi8(static_cast<char>('f' + 1)), lower));
+  const int hex_ok = _mm_movemask_epi8(_mm_or_si128(is_digit, is_letter));
+
+  unsigned n = 0;
+  unsigned need_pct = 1;
+  unsigned need_hex = 3;
+  for (; n < 5; ++n) {
+    if ((pct & static_cast<int>(need_pct)) == 0) {
+      break;
+    }
+    if ((hex_ok & static_cast<int>(need_hex)) != static_cast<int>(need_hex)) {
+      break;
+    }
+    need_pct <<= 3;
+    need_hex <<= 2;
+  }
+  if (n == 0) {
+    return 0;
+  }
+
+  const __m128i lo = _mm_and_si128(hexes, _mm_set1_epi8(0x0F));
+  const __m128i hi6 =
+      _mm_and_si128(_mm_srli_epi16(hexes, 6), _mm_set1_epi8(0x03));
+  const __m128i nibbles =
+      _mm_add_epi8(lo, _mm_add_epi8(hi6, _mm_slli_epi16(hi6, 3)));
+  const __m128i packed = _mm_maddubs_epi16(nibbles, _mm_set1_epi16(0x0110));
+  const __m128i bytes = _mm_packus_epi16(packed, _mm_setzero_si128());
+  alignas(16) uint8_t tmp[16];
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(tmp), bytes);
+  std::memcpy(d, tmp, n);
+  return n;
+}
+
+#endif  // ADA_UNICODE_SSSE3_ENCODE
+
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_SSE2
+// Find is SSE2-only (cmpeq + movemask). Keep it off the SSSE3 target so
+// clang-cl/MSVC x64 still get the 16-byte scan.
+ada_really_inline const char* sse2_find_percent(const char* p,
+                                                const char* end) noexcept {
+  const __m128i pct = _mm_set1_epi8('%');
+  while (p + 16 <= end) {
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+    const int mask = _mm_movemask_epi8(_mm_cmpeq_epi8(w, pct));
+    if (mask != 0) {
+      return p + trailing_zeroes32(static_cast<uint32_t>(mask));
+    }
+    p += 16;
+  }
+  return p;
+}
+
+ada_really_inline const char* sse2_find_plus_or_percent(
+    const char* p, const char* end) noexcept {
+  const __m128i pct = _mm_set1_epi8('%');
+  const __m128i plus = _mm_set1_epi8('+');
+  while (p + 16 <= end) {
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+    const int mask = _mm_movemask_epi8(
+        _mm_or_si128(_mm_cmpeq_epi8(w, pct), _mm_cmpeq_epi8(w, plus)));
+    if (mask != 0) {
+      return p + trailing_zeroes32(static_cast<uint32_t>(mask));
+    }
+    p += 16;
+  }
+  return p;
+}
+#endif  // ADA_UNICODE_SSSE3_ENCODE || ADA_SSE2
+
+#if ADA_NEON
+unsigned neon_decode_pct_groups(const uint8_t* p, uint8_t* d) noexcept {
+  const uint8x16_t w = vld1q_u8(p);
+  const uint64_t pct_bits = neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('%')));
+  if ((pct_bits & 0xF) == 0) {
+    return 0;
+  }
+  alignas(16) const uint8_t extract_idx[16] = {1,  2,  4, 5, 7, 8, 10, 11,
+                                               13, 14, 0, 0, 0, 0, 0,  0};
+  const uint8x16_t hexes = vqtbl1q_u8(w, vld1q_u8(extract_idx));
+  const uint8x16_t is_digit = vandq_u8(vcgeq_u8(hexes, vdupq_n_u8('0')),
+                                       vcleq_u8(hexes, vdupq_n_u8('9')));
+  const uint8x16_t lower = vorrq_u8(hexes, vdupq_n_u8(0x20));
+  const uint8x16_t is_letter = vandq_u8(vcgeq_u8(lower, vdupq_n_u8('a')),
+                                        vcleq_u8(lower, vdupq_n_u8('f')));
+  const uint64_t hex_ok = neon_nibble_bits(vorrq_u8(is_digit, is_letter));
+
+  unsigned n = 0;
+  for (; n < 5; ++n) {
+    if ((pct_bits & (uint64_t{0xF} << (12 * n))) == 0) {
+      break;
+    }
+    const uint64_t pair = uint64_t{0xFF} << (8 * n);
+    if ((hex_ok & pair) != pair) {
+      break;
+    }
+  }
+  if (n == 0) {
+    return 0;
+  }
+  const uint8x16_t lo = vandq_u8(hexes, vdupq_n_u8(0x0F));
+  const uint8x16_t hi6 = vshrq_n_u8(hexes, 6);
+  const uint8x16_t nibbles = vaddq_u8(lo, vaddq_u8(hi6, vshlq_n_u8(hi6, 3)));
+  alignas(16) uint8_t nb[16];
+  vst1q_u8(nb, nibbles);
+  for (unsigned i = 0; i < n; ++i) {
+    d[i] = static_cast<uint8_t>((nb[2 * i] << 4) | nb[2 * i + 1]);
+  }
+  return n;
+}
+
+const char* neon_find_percent(const char* p, const char* end) noexcept {
+  const uint8x16_t pct = vdupq_n_u8('%');
+  while (p + 16 <= end) {
+    const uint64_t bits = neon_nibble_bits(
+        vceqq_u8(vld1q_u8(reinterpret_cast<const uint8_t*>(p)), pct));
+    if (bits != 0) {
+      return p + (static_cast<size_t>(trailing_zeroes64(bits)) >> 2);
+    }
+    p += 16;
+  }
+  return p;
+}
+
+const char* neon_find_plus_or_percent(const char* p, const char* end) noexcept {
+  const uint8x16_t pct = vdupq_n_u8('%');
+  const uint8x16_t plus = vdupq_n_u8('+');
+  while (p + 16 <= end) {
+    const uint8x16_t w = vld1q_u8(reinterpret_cast<const uint8_t*>(p));
+    const uint64_t bits =
+        neon_nibble_bits(vorrq_u8(vceqq_u8(w, pct), vceqq_u8(w, plus)));
+    if (bits != 0) {
+      return p + (static_cast<size_t>(trailing_zeroes64(bits)) >> 2);
+    }
+    p += 16;
+  }
+  return p;
+}
+#endif  // ADA_NEON
+
+ada_really_inline const char* find_percent(const char* p,
+                                           const char* end) noexcept {
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_SSE2
+  p = sse2_find_percent(p, end);
+#elif ADA_NEON
+  p = neon_find_percent(p, end);
+#endif
+  while (p < end && *p != '%') {
+    ++p;
+  }
+  return p;
+}
+
+ada_really_inline const char* find_plus_or_percent(const char* p,
+                                                   const char* end) noexcept {
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_SSE2
+  p = sse2_find_plus_or_percent(p, end);
+#elif ADA_NEON
+  p = neon_find_plus_or_percent(p, end);
+#endif
+  while (p < end && *p != '+' && *p != '%') {
+    ++p;
+  }
+  return p;
+}
+
+ada_really_inline unsigned decode_pct_groups(const uint8_t* p,
+                                             uint8_t* d) noexcept {
+#if ADA_UNICODE_SSSE3_ENCODE
+  return ssse3_decode_pct_groups(p, d);
+#elif ADA_NEON
+  return neon_decode_pct_groups(p, d);
+#else
+  (void)p;
+  (void)d;
+  return 0;
+#endif
+}
+
+template <bool space_as_plus>
+void append_encoded_byte(unsigned char c, const uint8_t* set,
+                         std::string& out) {
+  if (space_as_plus && c == ' ') {
+    out.push_back('+');
+  } else if (ada::character_sets::bit_at(set, c)) {
+    out.append(ada::character_sets::hex + static_cast<size_t>(c) * 4, 3);
+  } else {
+    out.push_back(static_cast<char>(c));
+  }
+}
+
+template <bool space_as_plus>
+void flush_encode_mask(const char* p, uint32_t mask, const uint8_t* set,
+                       std::string& out) {
+  unsigned consumed = 0;
+  while (mask != 0) {
+    const unsigned next = static_cast<unsigned>(trailing_zeroes32(mask));
+    if (next > consumed) {
+      out.append(p + consumed, next - consumed);
+    }
+    append_encoded_byte<space_as_plus>(static_cast<unsigned char>(p[next]), set,
+                                       out);
+    consumed = next + 1;
+    mask &= mask - 1;
+  }
+  if (consumed < 16) {
+    out.append(p + consumed, 16 - consumed);
+  }
+}
+
+#if ADA_NEON
+template <bool space_as_plus>
+void flush_encode_bits_neon(const char* p, uint64_t bits, const uint8_t* set,
+                            std::string& out) {
+  unsigned consumed = 0;
+  while (bits != 0) {
+    const unsigned next = static_cast<unsigned>(trailing_zeroes64(bits)) >> 2;
+    if (next > consumed) {
+      out.append(p + consumed, next - consumed);
+    }
+    append_encoded_byte<space_as_plus>(static_cast<unsigned char>(p[next]), set,
+                                       out);
+    consumed = next + 1;
+    bits &= ~(uint64_t{0xF} << (next * 4));
+  }
+  if (consumed < 16) {
+    out.append(p + consumed, 16 - consumed);
+  }
+}
+#endif
+
+template <bool space_as_plus>
+void encode_tail(const char* p, const char* end, const uint8_t* set,
+                 std::string& out) {
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
+  if (const nibble_tables* tables = nibble_tables_for(set);
+      tables != nullptr && end - p >= 16) {
+#if ADA_UNICODE_SSSE3_ENCODE
+    const __m128i lo_tbl =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(tables->low));
+    const __m128i hi_tbl =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(tables->high));
+    const __m128i space = _mm_set1_epi8(' ');
+    while (p + 16 <= end) {
+      const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
+      int mask = ssse3_nibble_mask(w, lo_tbl, hi_tbl);
+      if constexpr (space_as_plus) {
+        mask |= _mm_movemask_epi8(_mm_cmpeq_epi8(w, space));
+      }
+      if (mask == 0) {
+        out.append(p, 16);
+        p += 16;
+        continue;
+      }
+      flush_encode_mask<space_as_plus>(p, static_cast<uint32_t>(mask), set,
+                                       out);
+      p += 16;
+    }
+#elif ADA_NEON
+    const uint8x16_t lo_tbl = vld1q_u8(tables->low);
+    const uint8x16_t hi_tbl = vld1q_u8(tables->high);
+    const uint8x16_t space = vdupq_n_u8(' ');
+    while (p + 16 <= end) {
+      const uint8x16_t w = vld1q_u8(reinterpret_cast<const uint8_t*>(p));
+      const uint8x16_t hit =
+          vandq_u8(vqtbl1q_u8(lo_tbl, vandq_u8(w, vdupq_n_u8(0x0F))),
+                   vqtbl1q_u8(hi_tbl, vshrq_n_u8(w, 4)));
+      uint64_t bits = neon_nibble_bits(vtstq_u8(hit, hit));
+      if constexpr (space_as_plus) {
+        bits |= neon_nibble_bits(vceqq_u8(w, space));
+      }
+      if (bits == 0) {
+        out.append(p, 16);
+        p += 16;
+        continue;
+      }
+      flush_encode_bits_neon<space_as_plus>(p, bits, set, out);
+      p += 16;
+    }
+#endif
+  }
+#endif
+  while (p < end) {
+    append_encoded_byte<space_as_plus>(static_cast<unsigned char>(*p), set,
+                                       out);
+    ++p;
+  }
+}
+
+}  // namespace
 
 namespace ada::unicode {
 
@@ -455,6 +960,54 @@ unsigned constexpr convert_hex_to_binary(const char c) noexcept {
   return hex_to_binary_table[c - '0'];
 }
 
+// 0..15 for hex digits, 0xFF otherwise - validate and decode with two loads.
+constexpr static std::array<uint8_t, 256> unhex_table = []() consteval {
+  std::array<uint8_t, 256> t{};
+  for (size_t i = 0; i < 256; ++i) {
+    t[i] = 0xFF;
+  }
+  for (uint8_t i = 0; i < 10; ++i) {
+    t[static_cast<size_t>('0') + i] = i;
+  }
+  for (uint8_t i = 0; i < 6; ++i) {
+    t[static_cast<size_t>('A') + i] = static_cast<uint8_t>(10 + i);
+    t[static_cast<size_t>('a') + i] = static_cast<uint8_t>(10 + i);
+  }
+  return t;
+}();
+
+// Consume a run of valid %XX (or a literal '%' if the escape is invalid).
+// Dense percent-encoded query values decode five triplets per 16-byte load.
+ada_really_inline void consume_pct_run(const char*& p, const char* end,
+                                       char*& d) {
+#if ADA_UNICODE_SSSE3_ENCODE || ADA_NEON
+  while (p + 16 <= end && *p == '%') {
+    const unsigned n = decode_pct_groups(reinterpret_cast<const uint8_t*>(p),
+                                         reinterpret_cast<uint8_t*>(d));
+    if (n == 0) {
+      break;
+    }
+    d += n;
+    p += static_cast<size_t>(n) * 3;
+    if (n < 5) {
+      break;
+    }
+  }
+#endif
+  while (p + 2 < end && *p == '%') {
+    const uint8_t hi = unhex_table[static_cast<uint8_t>(p[1])];
+    const uint8_t lo = unhex_table[static_cast<uint8_t>(p[2])];
+    if ((hi | lo) >= 16) {
+      break;
+    }
+    *d++ = static_cast<char>((hi << 4) | lo);
+    p += 3;
+  }
+  if (p < end && *p == '%') {
+    *d++ = *p++;
+  }
+}
+
 std::string percent_decode(const std::string_view input, size_t first_percent) {
   // next line is for safety only, we expect users to avoid calling
   // percent_decode when first_percent is outside the range.
@@ -479,24 +1032,9 @@ std::string percent_decode(const std::string_view input, size_t first_percent) {
   const char* p = src + first_percent;
   while (p < end) {
     if (*p == '%') {
-      // Decode runs of valid %XX tightly (common for nested/encoded URLs).
-      while (p + 2 < end && *p == '%') {
-        if (!is_ascii_hex_digit(p[1]) || !is_ascii_hex_digit(p[2])) {
-          break;
-        }
-        *d++ = static_cast<char>(convert_hex_to_binary(p[1]) * 16 +
-                                 convert_hex_to_binary(p[2]));
-        p += 3;
-      }
-      if (p < end && *p == '%') {
-        // Not a valid escape (too few chars left or bad hex): copy '%'
-        // literally and keep scanning after it.
-        *d++ = *p++;
-      }
+      consume_pct_run(p, end, d);
     } else {
-      const char* q = static_cast<const char*>(
-          std::memchr(p, '%', static_cast<size_t>(end - p)));
-      const char* run_end = q ? q : end;
+      const char* run_end = find_percent(p, end);
       const size_t n = static_cast<size_t>(run_end - p);
       std::memcpy(d, p, n);
       d += n;
@@ -508,22 +1046,6 @@ std::string percent_decode(const std::string_view input, size_t first_percent) {
   return out;
 }
 
-// 0..15 for hex digits, 0xFF otherwise - validate and decode with two loads.
-constexpr static std::array<uint8_t, 256> unhex_table = []() consteval {
-  std::array<uint8_t, 256> t{};
-  for (size_t i = 0; i < 256; ++i) {
-    t[i] = 0xFF;
-  }
-  for (uint8_t i = 0; i < 10; ++i) {
-    t[static_cast<size_t>('0') + i] = i;
-  }
-  for (uint8_t i = 0; i < 6; ++i) {
-    t[static_cast<size_t>('A') + i] = static_cast<uint8_t>(10 + i);
-    t[static_cast<size_t>('a') + i] = static_cast<uint8_t>(10 + i);
-  }
-  return t;
-}();
-
 std::string form_urlencoded_decode(const std::string_view input) {
   const size_t len = input.size();
   if (len == 0) [[unlikely]] {
@@ -533,12 +1055,7 @@ std::string form_urlencoded_decode(const std::string_view input) {
   // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
   const char* const src = input.data();
   const char* const end = src + len;
-  const char* p = src;
-
-  // Advance over the untransformed prefix.
-  while (p < end && *p != '+' && *p != '%') {
-    ++p;
-  }
+  const char* p = find_plus_or_percent(src, end);
   if (p == end) {
     return std::string(input);
   }
@@ -559,30 +1076,13 @@ std::string form_urlencoded_decode(const std::string_view input) {
       *d++ = ' ';
       ++p;
     } else if (c == '%') {
-      // Decode runs of valid %XX tightly (common for nested URL query values).
-      while (p + 2 < end && *p == '%') {
-        const uint8_t hi = unhex_table[static_cast<uint8_t>(p[1])];
-        const uint8_t lo = unhex_table[static_cast<uint8_t>(p[2])];
-        if ((hi | lo) >= 16) {
-          break;
-        }
-        *d++ = static_cast<char>((hi << 4) | lo);
-        p += 3;
-      }
-      if (p < end && *p == '%') {
-        // Invalid escape: copy '%' literally and continue.
-        *d++ = *p++;
-      }
+      consume_pct_run(p, end, d);
     } else {
-      // Copy a plain run until the next '+' or '%'.
-      const char* start = p;
-      ++p;
-      while (p < end && *p != '+' && *p != '%') {
-        ++p;
-      }
-      const size_t n = static_cast<size_t>(p - start);
-      std::memcpy(d, start, n);
+      const char* run_end = find_plus_or_percent(p, end);
+      const size_t n = static_cast<size_t>(run_end - p);
+      std::memcpy(d, p, n);
       d += n;
+      p = run_end;
     }
   }
 
@@ -590,30 +1090,39 @@ std::string form_urlencoded_decode(const std::string_view input) {
   return out;
 }
 
+void form_urlencoded_encode_append(const std::string_view input,
+                                   std::string& out) {
+  const uint8_t* set = character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE;
+  const size_t n = input.size();
+  size_t idx = percent_encode_index(input, set);
+  const size_t space = input.find(' ');
+  if (space < idx) {
+    idx = space;
+  }
+  if (idx == n) {
+    out.append(input);
+    return;
+  }
+  // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
+  out.append(input.data(), idx);
+  const size_t remaining = n - idx;
+  out.reserve(out.size() + remaining * 3);
+  encode_tail<true>(input.data() + idx, input.data() + n, set, out);
+}
+
+std::string form_urlencoded_encode(const std::string_view input) {
+  std::string out;
+  form_urlencoded_encode_append(input, out);
+  return out;
+}
+
 std::string percent_encode(const std::string_view input,
                            const uint8_t character_set[]) {
-  auto pointer = std::ranges::find_if(input, [character_set](const char c) {
-    return character_sets::bit_at(character_set, c);
-  });
-  // Optimization: Don't iterate if percent encode is not required
-  if (pointer == input.end()) {
+  const size_t idx = percent_encode_index(input, character_set);
+  if (idx == input.size()) {
     return std::string(input);
   }
-
-  std::string result;
-  result.reserve(input.length());  // in the worst case, percent encoding might
-                                   // produce 3 characters.
-  result.append(input.substr(0, std::distance(input.begin(), pointer)));
-
-  for (; pointer != input.end(); pointer++) {
-    if (character_sets::bit_at(character_set, *pointer)) {
-      result.append(character_sets::hex + uint8_t(*pointer) * 4, 3);
-    } else {
-      result += *pointer;
-    }
-  }
-
-  return result;
+  return percent_encode(input, character_set, idx);
 }
 
 template <bool append>
@@ -621,33 +1130,25 @@ bool percent_encode(const std::string_view input, const uint8_t character_set[],
                     std::string& out) {
   ada_log("percent_encode ", input, " to output string while ",
           append ? "appending" : "overwriting");
-  auto pointer = std::ranges::find_if(input, [character_set](const char c) {
-    return character_sets::bit_at(character_set, c);
-  });
-  ada_log("percent_encode done checking, moved to ",
-          std::distance(input.begin(), pointer));
+  const size_t idx = percent_encode_index(input, character_set);
+  ada_log("percent_encode done checking, moved to ", idx);
 
   // Optimization: Don't iterate if percent encode is not required
-  if (pointer == input.end()) {
+  if (idx == input.size()) {
     ada_log("percent_encode encoding not needed.");
     return false;
   }
   if constexpr (!append) {
     out.clear();
   }
-  ada_log("percent_encode appending ", std::distance(input.begin(), pointer),
-          " bytes");
+  ada_log("percent_encode appending ", idx, " bytes");
   // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
-  out.append(input.data(), std::distance(input.begin(), pointer));
-  ada_log("percent_encode processing ", std::distance(pointer, input.end()),
-          " bytes");
-  for (; pointer != input.end(); pointer++) {
-    if (character_sets::bit_at(character_set, *pointer)) {
-      out.append(character_sets::hex + uint8_t(*pointer) * 4, 3);
-    } else {
-      out += *pointer;
-    }
-  }
+  out.append(input.data(), idx);
+  ada_log("percent_encode processing ", input.size() - idx, " bytes");
+  const size_t remaining = input.size() - idx;
+  out.reserve(out.size() + remaining * 3);
+  encode_tail<false>(input.data() + idx, input.data() + input.size(),
+                     character_set, out);
   return true;
 }
 
@@ -674,14 +1175,10 @@ std::string percent_encode(const std::string_view input,
   std::string out;
   // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
   out.append(input.data(), index);
-  auto pointer = input.begin() + index;
-  for (; pointer != input.end(); pointer++) {
-    if (character_sets::bit_at(character_set, *pointer)) {
-      out.append(character_sets::hex + uint8_t(*pointer) * 4, 3);
-    } else {
-      out += *pointer;
-    }
-  }
+  const size_t remaining = input.size() - index;
+  out.reserve(out.size() + remaining * 3);
+  encode_tail<false>(input.data() + index, input.data() + input.size(),
+                     character_set, out);
   return out;
 }
 

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -1,7 +1,12 @@
 #include "ada.h"
+#include "ada/character_sets-inl.h"
+#include "ada/unicode-inl.h"
 #include "gtest/gtest.h"
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using Types = testing::Types<ada::url, ada::url_aggregator>;
 template <class T>
@@ -2091,4 +2096,211 @@ TYPED_TEST(basic_tests,
   check("http://ab:81#f ", "http://ab:81/#f");
   // a byte that legitimately needs encoding is still encoded
   check("http://ab?x y", "http://ab/?x%20y");
+}
+
+namespace {
+std::string scalar_percent_encode(std::string_view input, const uint8_t* set) {
+  std::string out;
+  for (unsigned char c : input) {
+    if (ada::character_sets::bit_at(set, c)) {
+      out.append(ada::character_sets::hex + static_cast<size_t>(c) * 4, 3);
+    } else {
+      out.push_back(static_cast<char>(c));
+    }
+  }
+  return out;
+}
+
+size_t scalar_percent_encode_index(std::string_view input, const uint8_t* set) {
+  for (size_t i = 0; i < input.size(); ++i) {
+    if (ada::character_sets::bit_at(set, static_cast<uint8_t>(input[i]))) {
+      return i;
+    }
+  }
+  return input.size();
+}
+
+std::string percent_escape(unsigned char c, bool lowercase) {
+  constexpr char kUpper[] = "0123456789ABCDEF";
+  constexpr char kLower[] = "0123456789abcdef";
+  const char* hex = lowercase ? kLower : kUpper;
+  std::string out = "%";
+  out.push_back(hex[c >> 4]);
+  out.push_back(hex[c & 0xF]);
+  return out;
+}
+
+std::string scalar_form_urlencoded_encode(std::string_view input) {
+  const uint8_t* set = ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE;
+  std::string out;
+  for (unsigned char c : input) {
+    if (c == ' ') {
+      out.push_back('+');
+    } else if (ada::character_sets::bit_at(set, c)) {
+      out.append(ada::character_sets::hex + static_cast<size_t>(c) * 4, 3);
+    } else {
+      out.push_back(static_cast<char>(c));
+    }
+  }
+  return out;
+}
+}  // namespace
+
+TEST(basic_tests, percent_encode_matches_scalar) {
+  const uint8_t* sets[] = {
+      ada::character_sets::C0_CONTROL_PERCENT_ENCODE,
+      ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE,
+      ada::character_sets::QUERY_PERCENT_ENCODE,
+      ada::character_sets::FRAGMENT_PERCENT_ENCODE,
+      ada::character_sets::USERINFO_PERCENT_ENCODE,
+      ada::character_sets::PATH_PERCENT_ENCODE,
+      ada::character_sets::WWW_FORM_URLENCODED_PERCENT_ENCODE,
+  };
+  std::vector<std::string> samples = {
+      "",
+      "abc",
+      "hello world",
+      std::string(15, 'a') + " ",
+      std::string(16, 'a'),
+      std::string(16, 'a') + " ",
+      std::string(17, 'a') + "#",
+      std::string(31, 'x') + "?",
+      std::string(32, 'z'),
+      std::string(40, 'b') + "|" + std::string(20, 'c'),
+      std::string("\x01") + std::string(20, 'a'),
+      std::string(16, 'a') + std::string(1, static_cast<char>(0xE1)),
+      "user:pass",
+      "path/to/file",
+      "%3A%2F%2Falready",
+  };
+  for (int i = 0; i < 256; ++i) {
+    samples.emplace_back(1, static_cast<char>(i));
+  }
+  // Dirty byte in every 16-byte lane, plus a long mixed tail.
+  std::string every_lane(64, 'a');
+  for (size_t i = 0; i < every_lane.size(); i += 16) {
+    every_lane[i + 15] = ' ';
+  }
+  samples.push_back(every_lane);
+
+  for (const uint8_t* set : sets) {
+    for (const std::string& s : samples) {
+      const std::string expected = scalar_percent_encode(s, set);
+      ASSERT_EQ(ada::unicode::percent_encode_index(s, set),
+                scalar_percent_encode_index(s, set));
+      ASSERT_EQ(ada::unicode::percent_encode(s, set), expected);
+      const size_t idx = ada::unicode::percent_encode_index(s, set);
+      ASSERT_EQ(ada::unicode::percent_encode(s, set, idx), expected);
+      std::string appended = "pre";
+      const bool needed = ada::unicode::percent_encode<true>(s, set, appended);
+      if (idx == s.size()) {
+        ASSERT_FALSE(needed);
+        ASSERT_EQ(appended, "pre");
+      } else {
+        ASSERT_TRUE(needed);
+        ASSERT_EQ(appended, "pre" + expected);
+      }
+    }
+  }
+}
+
+TEST(basic_tests, percent_decode_dense_and_malformed) {
+  const std::string dense = "%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2";
+  ASSERT_EQ(ada::unicode::percent_decode(dense, 0),
+            "://example.com/path?a=1&b=2");
+
+  const std::string at_15 = std::string(15, 'a') + "%41" + std::string(16, 'b');
+  ASSERT_EQ(ada::unicode::percent_decode(at_15, at_15.find('%')),
+            std::string(15, 'a') + "A" + std::string(16, 'b'));
+
+  const std::string at_16 = std::string(16, 'a') + "%20" + std::string(15, 'b');
+  ASSERT_EQ(ada::unicode::percent_decode(at_16, at_16.find('%')),
+            std::string(16, 'a') + " " + std::string(15, 'b'));
+
+  const std::string invalid =
+      std::string(15, 'a') + "%G1" + std::string(16, 'b') + "%";
+  ASSERT_EQ(ada::unicode::percent_decode(invalid, invalid.find('%')), invalid);
+
+  const std::string truncated = std::string(16, 'a') + "%4";
+  ASSERT_EQ(ada::unicode::percent_decode(truncated, truncated.find('%')),
+            truncated);
+
+  const std::string mixed = "%3Ahello%2F%ZZ%41";
+  ASSERT_EQ(ada::unicode::percent_decode(mixed, 0), ":hello/%ZZA");
+
+  ASSERT_EQ(ada::unicode::percent_decode("plain-text", std::string_view::npos),
+            "plain-text");
+
+  std::string eighty_in;
+  std::string eighty_out;
+  for (int i = 0; i < 80; ++i) {
+    eighty_in +=
+        percent_escape(static_cast<unsigned char>('A' + (i % 26)), i & 1);
+    eighty_out.push_back(static_cast<char>('A' + (i % 26)));
+  }
+  ASSERT_EQ(ada::unicode::percent_decode(eighty_in, 0), eighty_out);
+
+  for (int i = 0; i < 256; ++i) {
+    const auto c = static_cast<unsigned char>(i);
+    ASSERT_EQ(ada::unicode::percent_decode(percent_escape(c, false), 0),
+              std::string(1, static_cast<char>(c)));
+    ASSERT_EQ(ada::unicode::percent_decode(percent_escape(c, true), 0),
+              std::string(1, static_cast<char>(c)));
+  }
+}
+
+TEST(basic_tests, form_urlencoded_round_trip_spaces_and_dense) {
+  ASSERT_EQ(ada::unicode::form_urlencoded_encode("a b+c"), "a+b%2Bc");
+  ASSERT_EQ(ada::unicode::form_urlencoded_decode("a+b%2Bc"), "a b+c");
+
+  const std::string long_spaces = std::string(20, 'a') + " " +
+                                  std::string(20, 'b') + "  " +
+                                  std::string(20, 'c');
+  const std::string encoded = ada::unicode::form_urlencoded_encode(long_spaces);
+  ASSERT_EQ(encoded.find(' '), std::string::npos);
+  ASSERT_EQ(encoded, scalar_form_urlencoded_encode(long_spaces));
+  ASSERT_EQ(ada::unicode::form_urlencoded_decode(encoded), long_spaces);
+
+  const std::string dense =
+      "https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2%26c%3D3";
+  ASSERT_EQ(ada::unicode::form_urlencoded_decode(dense),
+            "https://example.com/path?a=1&b=2&c=3");
+
+  std::string appended;
+  ada::unicode::form_urlencoded_encode_append("x y", appended);
+  ada::unicode::form_urlencoded_encode_append("z", appended);
+  ASSERT_EQ(appended, "x+yz");
+
+  for (int i = 0; i < 256; ++i) {
+    const std::string in(1, static_cast<char>(i));
+    const std::string got = ada::unicode::form_urlencoded_encode(in);
+    ASSERT_EQ(got, scalar_form_urlencoded_encode(in));
+    if (i != '+') {
+      ASSERT_EQ(ada::unicode::form_urlencoded_decode(got), in);
+    }
+  }
+
+  ada::url_search_params params;
+  const std::string key = std::string(24, 'k') + " " + std::string(24, 'y');
+  const std::string value =
+      "https://example.com/path?a=1&b=2 " + std::string(32, 'z');
+  params.append(key, value);
+  ASSERT_EQ(params.to_string(),
+            ada::unicode::form_urlencoded_encode(key) + "=" +
+                ada::unicode::form_urlencoded_encode(value));
+
+  std::string query;
+  for (int i = 0; i < 20; ++i) {
+    if (i != 0) {
+      query += '&';
+    }
+    query += "k";
+    query += static_cast<char>('0' + (i % 10));
+    query += "=https%3A%2F%2Fexample.com%2F";
+    query += static_cast<char>('0' + (i % 10));
+  }
+  ada::url_search_params parsed(query);
+  ASSERT_EQ(parsed.size(), 20U);
+  ASSERT_EQ(parsed.get("k0").value_or(""), "https://example.com/0");
+  ASSERT_EQ(parsed.get("k9").value_or(""), "https://example.com/9");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Percent-encode/decode and `application/x-www-form-urlencoded` were still scalar after the absolute-URL fast path grew nibble-table SIMD (#1216). Issue #1120 called this out. Prior attempts missed:

- #1218 / #1230: SIMD `percent_encode_index` or 16-byte encode classify regresses short setters on CodSpeed
- #1124: moved the index scan out of line and built LUTs at runtime

This keeps the inlined 8-byte `percent_encode_index` and converts the remaining hot **tails**.

## What changed

- **Decode:** 16-byte SSE2/NEON scans for `%` (and `+` in form-urlencoded). Dense `%XX` runs decode five triplets per 16-byte load (SSSE3 `pshufb` + `maddubs`, or NEON `tbl`).
- **Encode tail:** consteval nibble tables from each official 32-byte percent-encode set (`static_assert` that every table matches `bit_at`). SIMD classify is **noinline** and only runs when the remaining suffix is at least 48 bytes, so SetHash / UserInfo / the official `percent_encode` examples stay on scalar `bit_at`.
- **Search params:** `to_string()` appends encoded keys/values in one pass, mapping space to `+` instead of percent-encode then `replace`.

## Local results

`ctest --output-on-failure --test-dir build`: **345/345 passed** (g++ 13.3, Debug).

Release, g++ 13.3, same inputs vs `main` at 18ca958b (wall-clock, noisy):

| Path | `main` | this PR |
|---|---:|---:|
| `percent_decode` of 80×`%3A` | ~216 ns | ~98 ns |
| `form_urlencoded_decode` (prefix + dense `%XX` + `+`) | ~199 ns | ~117 ns |
| `percent_encode` tiny (`hello world`) | ~32 ns | ~29 ns |
| `percent_encode` ~200-byte fragment | ~340 ns | ~222 ns |
| `url_search_params::to_string` (dense keys/values) | ~3.5 µs | ~1.6 µs |

No public signature or object-layout change. New `form_urlencoded_encode` / `form_urlencoded_encode_append` are internal (`ada::unicode`).

Closes #1120.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02543-4058-77b3-a368-d49ccc388260?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02543-4058-77b3-a368-d49ccc388260&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

