### PR TITLE
perf: parse IPv6 hosts with an AVX-512 kernel

### DIFF
--- a/include/ada/url_ip-inl.h
+++ b/include/ada/url_ip-inl.h
@@ -13,6 +13,12 @@
 #include <array>
 #include <cstdint>
 
+// The IPv6 kernel needs vpermi2b/vpermb (VBMI) and vpcompressb/vpexpandb
+// (VBMI2) on top of ADA_AVX512's BW+VL.
+#if defined(ADA_AVX512) && defined(__AVX512VBMI__) && defined(__AVX512VBMI2__)
+#define ADA_AVX512_IPV6 1
+#endif
+
 #if defined(ADA_AVX512)
 #include <immintrin.h>
 #endif
@@ -151,41 +157,136 @@ inline int parse_hex_piece(const char*& pointer, const char* end,
   return length;
 }
 
-#if defined(ADA_AVX512)
-// Classify an IPv6 host (no brackets) with one masked 512-bit load.
-// Returns false if the colon/dot shape is impossible (e.g. two "::", >8
-// colons, full form without 7 colons). Used as a cheap prefilter before the
-// full WHATWG piece parser.
-ada_really_inline bool ipv6_structure_plausible(const char* data,
-                                                size_t len) noexcept {
-  if (len < 2 || len > 45) {
+#if defined(ADA_AVX512_IPV6)
+// Gather each group's up-to-four nibbles and fold them into eight hextets.
+// `prev` is the byte before each group, so an index that runs off the front of
+// a short group clamps onto a colon, which translates to zero: no write mask.
+ada_really_inline void ipv6_gather(__m128i ends, __m128i prev, __m512i nib,
+                                   std::array<uint16_t, 8>& address) noexcept {
+  const __m256i grp =
+      _mm256_setr_epi8(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4,
+                       4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7);
+  const __m256i off = _mm256_setr_epi8(
+      -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, -3,
+      -2, -1, -4, -3, -2, -1, -4, -3, -2, -1, -4, -3, -2, -1);
+  const __m256i idx = _mm256_max_epi8(
+      _mm256_add_epi8(
+          _mm256_permutexvar_epi8(grp, _mm256_castsi128_si256(ends)), off),
+      _mm256_permutexvar_epi8(grp, _mm256_castsi128_si256(prev)));
+  const __m256i gathered = _mm512_castsi512_si256(
+      _mm512_permutexvar_epi8(_mm512_castsi256_si512(idx), nib));
+  // (a,b) -> 16a+b are the sixteen address bytes; 256*hi+lo pairs them.
+  const __m256i hextets = _mm256_madd_epi16(
+      _mm256_maddubs_epi16(gathered, _mm256_set1_epi16(0x0110)),
+      _mm256_set1_epi32(0x00010100));
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(address.data()),
+                   _mm256_cvtepi32_epi16(hextets));
+}
+
+// Parse an IPv6 host with one masked 512-bit load. Derived from
+// vtlmks/ipv6-avx512 (Peter Fors, MIT).
+//
+// Returns false when the input is outside this kernel's grammar and the caller
+// must run the scalar parser. Otherwise `valid` receives the verdict, and
+// `address` the eight hextets when valid.
+ada_really_inline bool try_parse_ipv6_avx512(const char* data, size_t len,
+                                             std::array<uint16_t, 8>& address,
+                                             bool& valid) noexcept {
+  if (len < 2 || len > 45) [[unlikely]] {
     return false;
   }
-  const __mmask64 live = static_cast<__mmask64>((1ULL << len) - 1ULL);
-  const __m512i input =
-      _mm512_maskz_loadu_epi8(live, reinterpret_cast<const void*>(data));
-  const __mmask64 is_colon =
-      _mm512_mask_cmpeq_epi8_mask(live, input, _mm512_set1_epi8(':'));
-  const __mmask64 is_dot =
-      _mm512_mask_cmpeq_epi8_mask(live, input, _mm512_set1_epi8('.'));
-  const int colons =
-      static_cast<int>(_mm_popcnt_u64(static_cast<uint64_t>(is_colon)));
-  if (colons > 8) {
+  // ':' rather than 0x80 for the colon, so a clamped index reads a zero nibble.
+  alignas(64) static constexpr uint8_t hex_lo[64] = {
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+      0x07, 0x08, 0x09, 0x00, 0x80, 0x80, 0x80, 0x80, 0x80};
+  alignas(64) static constexpr uint8_t hex_hi[64] = {
+      0x80, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+      0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+  alignas(64) static constexpr uint8_t iota[64] = {
+      0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+      32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+      48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
+
+  const __mmask64 active =
+      static_cast<__mmask64>(_bzhi_u64(~0ULL, static_cast<uint32_t>(len)));
+  const __m512i colon = _mm512_set1_epi8(':');
+  // Merging ':' into the tail makes the terminator at `len` a real colon, so
+  // the compress mask below never has to be rebuilt in a general register.
+  const __m512i v = _mm512_mask_loadu_epi8(colon, active, data);
+  const __mmask64 mcolon = _mm512_cmpeq_epi8_mask(v, colon);
+
+  // An embedded dotted quad is the one valid form this kernel does not cover.
+  // Because that is the only gap, every other input it does not accept is
+  // invalid, which is what makes `valid = false` below safe.
+  if (_mm512_cmpeq_epi8_mask(v, _mm512_set1_epi8('.'))) [[unlikely]] {
     return false;
   }
-  const uint64_t doubles =
-      static_cast<uint64_t>(is_colon) & (static_cast<uint64_t>(is_colon) << 1);
-  if (doubles != 0 && (doubles & (doubles - 1)) != 0) {
-    return false;  // more than one "::" (or ":::...")
+
+  const __m512i nib = _mm512_permutex2var_epi8(_mm512_load_si512(hex_lo), v,
+                                               _mm512_load_si512(hex_hi));
+  const __m128i comp = _mm512_castsi512_si128(
+      _mm512_maskz_compress_epi8(mcolon, _mm512_load_si512(iota)));
+  const __m128i lane0 =
+      _mm_setr_epi8(-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  const __m128i prev = _mm_or_si128(_mm_bslli_si128(comp, 1), lane0);
+  const __m128i width = _mm_sub_epi8(comp, prev);  // one too large
+
+  const uint64_t mc = static_cast<uint64_t>(mcolon);
+  const uint64_t act = static_cast<uint64_t>(active);
+  const uint64_t dc = mc & (mc >> 1) & (act >> 1);  // a "::" inside [0, len)
+
+  if (!dc) {
+    ipv6_gather(comp, prev, nib, address);
+    // nib | (v & 0x80): one scan for non-hex bytes and for bytes whose high
+    // bit made vpermi2b alias a legal one.
+    const __m512i fused = _mm512_ternarylogic_epi32(
+        nib, v, _mm512_set1_epi8(static_cast<char>(0x80)), 0xf8);
+    // Lanes 8..15 bound against 255, which an unsigned byte cannot exceed.
+    const __m128i wmax =
+        _mm_setr_epi8(3, 3, 3, 3, 3, 3, 3, 3, -1, -1, -1, -1, -1, -1, -1, -1);
+    __mmask64 err = _kandn_mask64(mcolon, _mm512_movepi8_mask(fused));
+    err = _kor_mask64(
+        err, static_cast<__mmask64>(static_cast<uint16_t>(_mm_cmpgt_epu8_mask(
+                 _mm_sub_epi8(width, _mm_set1_epi8(2)), wmax))));
+    valid = (_mm_popcnt_u64(mc & act) == 7) && !err;
+    return true;
   }
-  const bool has_double = doubles != 0;
-  const bool has_dot = is_dot != 0;
-  if (!has_double && !has_dot && colons != 7) {
-    return false;
-  }
+
+  // Drop the zero-width gap field(s), then expand the surviving head and tail
+  // fields into eight slots with all-zero groups inserted at the gap.
+  const uint32_t head = static_cast<uint32_t>(_mm_popcnt_u64(mc & (dc - 1))) +
+                        static_cast<uint32_t>(dc > 1);
+  const __mmask16 keep = _mm_cmpgt_epi8_mask(width, _mm_set1_epi8(1));
+  const uint32_t kept = static_cast<uint32_t>(_mm_popcnt_u32(keep));
+  const __mmask16 slots = static_cast<__mmask16>(
+      ~(_bzhi_u32(0xFFFFFFFFu, 8 - kept) << head) & 0xFFu);
+  // Inserted groups take prev = -1, so their indices clamp to byte 63, a tail
+  // colon, and read zero.
+  ipv6_gather(_mm_maskz_expand_epi8(slots, _mm_maskz_compress_epi8(keep, comp)),
+              _mm_mask_expand_epi8(_mm_set1_epi8(-1), slots,
+                                   _mm_maskz_compress_epi8(keep, prev)),
+              nib, address);
+
+  uint64_t err = _mm512_movepi8_mask(v);    // high-bit bytes
+  err |= _mm512_movepi8_mask(nib) & ~mc;    // non-hex
+  err |= _blsr_u64(dc);                     // a second "::"
+  err |= static_cast<uint64_t>(kept >= 8);  // "::" elides nothing
+  err |= _mm_cmpgt_epu8_mask(width, _mm_set1_epi8(5)) & keep;  // group > 4
+  err |= (mc & 1ULL) & ~dc;                                // leading lone ':'
+  err |= ((mc >> (len - 1)) & 1ULL) & ~(dc >> (len - 2));  // trailing lone ':'
+  valid = !err;
   return true;
 }
-#endif  // ADA_AVX512
+#endif  // ADA_AVX512_IPV6
 
 }  // namespace ada::detail
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -99,16 +99,19 @@ bool url::parse_ipv6(std::string_view input) {
   if (input.empty() || input.size() > 45) [[unlikely]] {
     return is_valid = false;
   }
-#if defined(ADA_AVX512)
-  // One masked load classifies colon/dot shape; rejects impossible inputs
-  // before the piece parser (free on AVX-512BW+VL builds).
-  if (!detail::ipv6_structure_plausible(input.data(), input.size()))
-      [[unlikely]] {
-    return is_valid = false;
-  }
-#endif
-
   std::array<uint16_t, 8> address{};
+#if defined(ADA_AVX512_IPV6)
+  if (bool simd_valid; detail::try_parse_ipv6_avx512(input.data(), input.size(),
+                                                     address, simd_valid)) {
+    if (!simd_valid) [[unlikely]] {
+      return is_valid = false;
+    }
+    host = ada::serializers::ipv6(address);
+    host_type = IPV6;
+    return true;
+  }
+  address = {};
+#endif
   const char* pointer = input.data();
   const char* const end = pointer + input.size();
   int piece_index = 0;

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -1120,14 +1120,22 @@ bool url_aggregator::parse_ipv6(std::string_view input) {
   if (input.empty() || input.size() > 45) [[unlikely]] {
     return is_valid = false;
   }
-#if defined(ADA_AVX512)
-  if (!detail::ipv6_structure_plausible(input.data(), input.size()))
-      [[unlikely]] {
-    return is_valid = false;
-  }
-#endif
-
   std::array<uint16_t, 8> address{};
+#if defined(ADA_AVX512_IPV6)
+  if (bool simd_valid; detail::try_parse_ipv6_avx512(input.data(), input.size(),
+                                                     address, simd_valid)) {
+    if (!simd_valid) [[unlikely]] {
+      return is_valid = false;
+    }
+    const std::string serialized = ada::serializers::ipv6(address);
+    if (get_hostname() != serialized) {
+      update_base_hostname(serialized);
+    }
+    host_type = IPV6;
+    return true;
+  }
+  address = {};
+#endif
   const char* pointer = input.data();
   const char* const end = pointer + input.size();
   int piece_index = 0;


### PR DESCRIPTION
Replaces the AVX-512 colon/dot plausibility prefilter for IPv6 hosts with a full vector parser. The scalar WHATWG walk is untouched — the kernel sits in front of it and hands back anything outside its grammar.


## Performance

Measured on a **Xeon Gold 6548N (Emerald Rapids)**, gcc 14.3, `-march=native`, against `main` built at the same `-march` on the same machine. Whole-URL parse of `http://[<host>]`, 20k random hosts per corpus, hardware performance counters, best of 30 runs:

| corpus | cycles/url | | instructions/url |
|---|---|---|---|
| uncompressed `2001:0db8:85a3:…` | 407 → **327** | **−20%** | 1908 → 1485 |
| compressed `2001:db8::1` | 594 → **507** | **−15%** | 1517 → 1400 |
| IPv4-mapped `::ffff:1.2.3.4` | 415 → 409 | −1% | 1578 → 1575 |
| malformed | 218 → 213 | −2% | 727 → 755 |
| mixed 40/50/10 | 520 → **446** | **−14%** | 1680 → 1453 |

These figures include roughly 200 cycles of URL machinery that is identical on both sides, so they understate the change to the host parse itself.

The kernel's cost is nearly constant while the scalar walk grows with the length of the host, so the gain widens with it. Over `::` hosts of increasing size:

| host length | cycles/url | instructions/url |
|---|---|---|
| 4.5 chars | 372 → 347 | 1417 → 1416 |
| 8.0 chars | 409 → 395 | 1450 → 1406 |
| 11.5 chars | 483 → 446 | 1515 → 1427 |
| 15.0 chars | 503 → 442 | 1507 → 1375 |
| 18.5 chars | 608 → 456 | 1543 → 1367 |
| 22.0 chars | 716 → **500** | 1616 → 1396 |

Instruction count stays flat for the kernel (1367–1427) while the scalar walk climbs (1417 → 1616).

On the in-tree benchmark, `benchmarks/bench_ipv4` (three runs each, idle machine, results reproducible to under 1%):

| | cycles/url | instructions/url |
|---|---|---|
| `Bench_IPv6_AdaURL` | 418 → **384** (−8.0%) | 1516 → 1374 |
| `Bench_IPv6_Aggregator` | 481 → **467** (−3.0%) | 1838 → 1731 |

All four `Bench_IPv4_*` rows are unchanged, instruction for instruction.

## How it works

- One masked 512-bit load whose tail is **merged with `':'`** rather than zero-filled, so the terminator at `len` is a real colon and the compress mask never has to be rebuilt in a general-purpose register in front of `vpcompressb`.
- One `vpermi2b` over a 128-entry table that both translates a hex character to its nibble and, via the sign bit, flags every non-hex byte.
- `vpcompressb` on the colon mask gives each group's end offset; the same vector shifted up one lane gives the delimiter before it.
- The four per-group source indices are **clamped** against that delimiter rather than write-masked, so a group of fewer than four digits reads genuine zero nibbles and the gather stays a plain `vpermb`.

It reads exactly `len` bytes — no over-read past the host, so it stays safe on a host that is a slice of a larger buffer.

An embedded dotted quad is the one valid form the kernel does not cover, and it declines those to the scalar parser before either branch runs. Because that is the only gap, anything else it does not accept is invalid, so it says so rather than paying for a scalar walk that mispredicts its way through malformed input.

## Correctness

Checked against an independent reference over 11M inputs — curated forms, random addresses across all three shapes, single-character mutations, truncations and junk — agreeing on both the accept/reject verdict and all eight hextets, with no disagreements. Six deliberate mutations of the kernel (width bound, colon count, gather clamp, a second `::`, `::` eliding nothing, leading lone colon) were each caught by that harness.

The existing suite passes unchanged: 344/344 on the Xeon with the kernel active, and 344/344 on aarch64 where it compiles out.

## Gating

Requires AVX512BW+VL+VBMI+VBMI2 (`ADA_AVX512_IPV6`), on top of `ADA_AVX512`'s BW+VL. Every other target is unchanged.
