### PR TITLE
enforce max_input_length on parse_url_impl early returns

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1851,6 +1851,29 @@ result_type parse_url_impl(std::string_view user_input,
 
   const uint32_t max_input_length = ada::get_max_input_length();
 
+  // Normalization (percent-encoding, IDNA) can push the serialized URL past
+  // max_input_length even when the input fit under it. The check at the end of
+  // the state machine covers URLs that run to completion, but several states
+  // return early after appending a query or fragment, so run the same check on
+  // those exits too. Without this, a query- or fragment-terminated URL such as
+  // file://x/?<...> or https://user@x/?<...> is accepted while the equivalent
+  // https://x/?<...> that takes the absolute fast path is rejected.
+  const auto enforce_max_input_length = [&]() {
+    if constexpr (store_values) {
+      if (url.is_valid) {
+        if constexpr (result_type_is_ada_url_aggregator) {
+          if (url.buffer.size() > max_input_length) [[unlikely]] {
+            url.is_valid = false;
+          }
+        } else {
+          if (url.get_href_size() > max_input_length) [[unlikely]] {
+            url.is_valid = false;
+          }
+        }
+      }
+    }
+  };
+
   // We refuse to parse URL strings that exceed the maximum input length.
   // By default, this is 4GB but can be configured via
   // ada::set_max_input_length().
@@ -2088,6 +2111,7 @@ result_type parse_url_impl(std::string_view user_input,
             }
           }
           url.update_unencoded_base_hash(*fragment);
+          enforce_max_input_length();
           return url;
         }
         // Otherwise, if base's scheme is not "file", set state to relative
@@ -2223,6 +2247,7 @@ result_type parse_url_impl(std::string_view user_input,
                 url.update_unencoded_base_hash(*fragment);
               }
             }
+            enforce_max_input_length();
             return url;
           }
           input_position = end_of_authority + 1;
@@ -2436,6 +2461,7 @@ result_type parse_url_impl(std::string_view user_input,
             url.update_unencoded_base_hash(*fragment);
           }
         }
+        enforce_max_input_length();
         return url;
       }
       case state::HOST: {
@@ -2566,6 +2592,7 @@ result_type parse_url_impl(std::string_view user_input,
                 url.update_unencoded_base_hash(*fragment);
               }
             }
+            enforce_max_input_length();
             return url;
           }
           // If c is neither U+002F (/) nor U+005C (\), then decrease pointer
@@ -2821,22 +2848,7 @@ result_type parse_url_impl(std::string_view user_input,
       url.update_unencoded_base_hash(*fragment);
     }
   }
-  // Check the resulting (normalized) URL size against the maximum input length.
-  // Normalization (percent-encoding, IDNA, etc.) can expand the URL beyond the
-  // original input size.
-  if constexpr (store_values) {
-    if (url.is_valid) {
-      if constexpr (result_type_is_ada_url_aggregator) {
-        if (url.buffer.size() > max_input_length) {
-          url.is_valid = false;
-        }
-      } else {
-        if (url.get_href_size() > max_input_length) {
-          url.is_valid = false;
-        }
-      }
-    }
-  }
+  enforce_max_input_length();
   return url;
 }
 

--- a/tests/max_input_length.cpp
+++ b/tests/max_input_length.cpp
@@ -208,6 +208,31 @@ TYPED_TEST(max_input_length_tests, parse_normalized_just_under_limit) {
   ASSERT_LE(result->get_href().size(), small_limit);
 }
 
+TYPED_TEST(max_input_length_tests, parse_query_normalized_exceeds_limit) {
+  // A URL that terminates in the query state returns before the end-of-parse
+  // length check. file:// takes that slow path (unlike http://x/? which hits
+  // the absolute fast path), so its expanded query must still be rejected.
+  // Normalized = 10 ("file://x/?") + 3*339 spaces + 1 ("y") = 1028 > 1024.
+  std::string input = "file://x/?" + std::string(339, ' ') + "y";
+  ASSERT_LE(input.size(), small_limit);
+  auto result = ada::parse<TypeParam>(input);
+  ASSERT_FALSE(result);
+  ASSERT_FALSE(ada::can_parse(input));
+}
+
+TYPED_TEST(max_input_length_tests, parse_fragment_normalized_exceeds_limit) {
+  // Userinfo forces the slow path, and an authority with no path terminated by
+  // a fragment returns from the authority state after appending the fragment,
+  // before the end-of-parse length check. The expanded fragment must still be
+  // rejected.
+  // Normalized = 11 ("http://u@x#") + 3*339 spaces + 1 ("y") = 1029 > 1024.
+  std::string input = "http://u@x#" + std::string(339, ' ') + "y";
+  ASSERT_LE(input.size(), small_limit);
+  auto result = ada::parse<TypeParam>(input);
+  ASSERT_FALSE(result);
+  ASSERT_FALSE(ada::can_parse(input));
+}
+
 TYPED_TEST(max_input_length_tests, can_parse_matches_parse_for_idna_expansion) {
   // IDNA expands a host by more than the 3x that percent-encoding produces:
   // U+337F is 3 UTF-8 bytes and becomes the 17-byte "xn--6oqv20b1zgzxr", so a


### PR DESCRIPTION
parse_url_impl only re-checks the normalized url against max_input_length at the end of the state machine, but the query state and the authority and path-start early returns append a percent-encoded query or fragment and return before reaching it. a url whose input is under the limit but whose normalized href is not is therefore accepted when the parse lands on one of those slow-path returns (file://x/?<spaces>y, http://u@x#<spaces>y, http://[::1]#<spaces>y) while the equivalent https://x/?<spaces>y that takes the absolute fast path is rejected, so validity depends on which terminal state the parse happens to hit. this hoists the existing end-of-parse size check into an enforce_max_input_length helper and runs it on those early returns too. added typed regression tests over url and url_aggregator for the query and fragment paths.