### PR TITLE
perf: isolate can_parse, simple-absolute, and finish helpers

### DIFF
--- a/.github/workflows/lint_and_format_check.yml
+++ b/.github/workflows/lint_and_format_check.yml
@@ -44,14 +44,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-tidy-22 libc++-22-dev libc++abi-22-dev
 
-      # Run clang-tidy only on src/ada.cpp, the single translation unit that
-      # #includes every first-party .cpp. This keeps tests, benchmarks, the
-      # generated singleheader amalgamation, and vendored deps out of scope,
-      # matching tools/run-clangcldocker.sh. Setting CMAKE_CXX_CLANG_TIDY
-      # instead would lint those generated/third-party units too.
+      # Run clang-tidy on the unity TU, parser TUs, and can_parse. This keeps
+      # tests, benchmarks, the generated singleheader amalgamation, and
+      # vendored deps out of scope, matching tools/run-clangcldocker.sh.
+      # Setting CMAKE_CXX_CLANG_TIDY instead would lint those
+      # generated/third-party units too.
       - name: Run clang-tidy
         run: >
           cmake -B build -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS="-stdlib=libc++" &&
-          clang-tidy-22 -p build src/ada.cpp
+          clang-tidy-22 -p build src/ada.cpp src/parser_hot.cpp src/parser_finish.cpp src/can_parse.cpp
         env:
           CXX: clang++-22

--- a/include/ada/checkers-inl.h
+++ b/include/ada/checkers-inl.h
@@ -21,8 +21,28 @@ constexpr bool is_digit(char x) noexcept { return (x >= '0') & (x <= '9'); }
 
 constexpr bool is_ipv4_number_char(char x) noexcept {
   const unsigned char c = static_cast<unsigned char>(x);
+  // .com/.org/.net end with 'm'/'g'/'t', all > 'f'. Two compares reject them
+  // without walking the 0-9 / a-f / A-F ranges. 'X' is 0x58 and is not > 'f'.
+  if (c > 'f') {
+    return c == 'x';
+  }
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
-         (c >= 'A' && c <= 'F') || c == 'x' || c == 'X';
+         (c >= 'A' && c <= 'F') || c == 'X';
+}
+
+// ".com" / ".COM" after an optional trailing dot.
+constexpr bool ends_with_dot_com(const char* start, size_t n) noexcept {
+  if (n > 0 && start[n - 1] == '.') {
+    --n;
+  }
+  if (n < 4) {
+    return false;
+  }
+  const uint32_t last4 = uint32_t(uint8_t(start[n - 4])) |
+                         (uint32_t(uint8_t(start[n - 3])) << 8) |
+                         (uint32_t(uint8_t(start[n - 2])) << 16) |
+                         (uint32_t(uint8_t(start[n - 1])) << 24);
+  return (last4 | 0x20202020u) == 0x6d6f632eu;
 }
 
 constexpr bool last_label_may_be_a_number(std::string_view view) noexcept {
@@ -37,6 +57,7 @@ constexpr bool last_label_may_be_a_number(std::string_view view) noexcept {
       return false;
     }
   }
+  // .com / .org / .net / .gov / ... end with a letter outside 0-9a-fxX.
   if (!is_ipv4_number_char(end[-1])) {
     return false;
   }

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -11,6 +11,7 @@
 
 // https://en.cppreference.com/w/cpp/feature_test#Library_features
 // detect C++20 features
+#include <cstdint>
 #include <version>
 
 #ifdef _MSC_VER

--- a/include/ada/common_defs.h
+++ b/include/ada/common_defs.h
@@ -53,6 +53,7 @@
 
 #define ada_really_inline __forceinline
 #define ada_never_inline __declspec(noinline)
+#define ada_cold
 
 #define ada_unused
 #define ada_warn_unused
@@ -84,6 +85,7 @@
 
 #define ada_really_inline inline __attribute__((always_inline))
 #define ada_never_inline inline __attribute__((noinline))
+#define ada_cold __attribute__((cold))
 
 #define ada_unused __attribute__((unused))
 #define ada_warn_unused __attribute__((warn_unused_result))

--- a/include/ada/parser-inl.h
+++ b/include/ada/parser-inl.h
@@ -4,10 +4,10 @@
 #ifndef ADA_PARSER_INL_H
 #define ADA_PARSER_INL_H
 
+#include "ada/parser.h"
 #include "ada/expected.h"
 #include "ada/url_pattern.h"
 #include "ada/url_pattern_helpers.h"
-#include "ada/parser.h"
 
 #include <string>
 #include <string_view>

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -118,6 +118,12 @@ bool try_finish_simple_userinfo(std::string_view input, result_type& out,
                                 ada::scheme::type scheme_type,
                                 uint32_t protocol_end, size_t auth_start);
 
+/** @private Cold bracket-IPv6 finish after the host scanner misses on '['. */
+template <class result_type>
+bool try_finish_simple_ipv6(std::string_view input, result_type& out,
+                            ada::scheme::type scheme_type,
+                            uint32_t protocol_end, size_t host_start);
+
 /** @private Cold rest_simple=false tail; kept out of the hot I-cache. */
 template <class result_type>
 void finish_simple_absolute_handoff(std::string_view input, result_type& out,

--- a/include/ada/parser.h
+++ b/include/ada/parser.h
@@ -16,6 +16,7 @@
 
 #include "ada/expected.h"
 #include "ada/scheme.h"
+#include "ada/url_base.h"
 
 #include "ada/url_pattern_regex.h"
 #include "ada/url_pattern_init.h"
@@ -73,6 +74,24 @@ extern template url_aggregator parse_url_impl<url_aggregator, false>(
 extern template url parse_url_impl<url, true>(std::string_view user_input,
                                               const url* base_url);
 
+/** @private Fill `url` in place. `try_fast_path` is false when parse()
+ *  already ran try_parse_simple_absolute. */
+template <typename result_type, bool store_values = true>
+result_type& parse_url_impl_into(result_type& url, std::string_view user_input,
+                                 const result_type* base_url,
+                                 bool try_fast_path);
+
+extern template url_aggregator& parse_url_impl_into<url_aggregator, true>(
+    url_aggregator& out, std::string_view user_input,
+    const url_aggregator* base_url, bool try_fast_path);
+extern template url_aggregator& parse_url_impl_into<url_aggregator, false>(
+    url_aggregator& out, std::string_view user_input,
+    const url_aggregator* base_url, bool try_fast_path);
+extern template url& parse_url_impl_into<url, true>(url& out,
+                                                    std::string_view user_input,
+                                                    const url* base_url,
+                                                    bool try_fast_path);
+
 /** @private */
 template <class result_type>
 bool try_parse_simple_absolute(std::string_view input, result_type& out);
@@ -84,6 +103,29 @@ bool finish_simple_absolute_with_port(std::string_view input, result_type& out,
                                       uint32_t protocol_end, size_t host_start,
                                       size_t host_end, size_t host_len,
                                       bool has_upper);
+
+/** @private Write a host that is not a slice of `input` (canonical IPv4/IPv6).
+ */
+template <class result_type>
+bool finish_simple_absolute_literal_host(
+    std::string_view input, result_type& out, ada::scheme::type scheme_type,
+    uint32_t protocol_end, size_t host_start, size_t host_end,
+    std::string_view host, url_host_type parsed_host_type);
+
+/** @private Cold already-canonical userinfo finish (`user[:pass]@host`). */
+template <class result_type>
+bool try_finish_simple_userinfo(std::string_view input, result_type& out,
+                                ada::scheme::type scheme_type,
+                                uint32_t protocol_end, size_t auth_start);
+
+/** @private Cold rest_simple=false tail; kept out of the hot I-cache. */
+template <class result_type>
+void finish_simple_absolute_handoff(std::string_view input, result_type& out,
+                                    size_t host_start, size_t host_end,
+                                    size_t host_len, uint32_t protocol_end,
+                                    bool has_upper, bool has_path,
+                                    size_t path_start, size_t path_end,
+                                    size_t query_start, size_t hash_start);
 
 /** @private */
 template <class result_type>

--- a/include/ada/scheme-inl.h
+++ b/include/ada/scheme-inl.h
@@ -18,6 +18,9 @@ namespace details {
 // Spaces, if present, are removed from URL.
 constexpr std::string_view is_special_list[] = {"http", " ",   "https", "ws",
                                                 "ftp",  "wss", "file",  " "};
+// scheme + "://" for href assembly, indexed by ada::scheme::type
+constexpr std::string_view special_href_prefix[] = {
+    "http://", "", "https://", "ws://", "ftp://", "wss://", "file://", ""};
 // for use with get_special_port
 constexpr uint16_t special_ports[] = {80, 0, 443, 80, 21, 443, 0, 0};
 

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -186,7 +186,76 @@ constexpr void url::copy_scheme(const ada::url& u) {
   type = u.type;
 }
 
+namespace href_detail {
+// Constant prefix length so https:// and http:// do not cmov the size.
+// query/hash use `if (opt)` so clang-tidy sees the optional is engaged.
+template <size_t PrefixSize>
+[[nodiscard]] ada_really_inline std::string write_plain_special_href(
+    const char* prefix, const std::string& hostname,
+    const std::string& pathname, const std::optional<std::string>& query,
+    const std::optional<std::string>& hash) {
+  const size_t host_size = hostname.size();
+  const size_t path_size = pathname.size();
+  const size_t q_n = query ? query->size() + 1 : 0;
+  const size_t h_n = hash ? hash->size() + 1 : 0;
+  const size_t total = PrefixSize + host_size + path_size + q_n + h_n;
+#if defined(__cpp_lib_string_resize_and_overwrite)
+  std::string output;
+  output.resize_and_overwrite(total, [&](char* p, size_t) {
+    std::memcpy(p, prefix, PrefixSize);
+    char* w = p + PrefixSize;
+    // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+    std::memcpy(w, hostname.data(), host_size);
+    w += host_size;
+    std::memcpy(w, pathname.data(), path_size);
+    w += path_size;
+    if (query) {
+      *w++ = '?';
+      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+      std::memcpy(w, query->data(), query->size());
+      w += query->size();
+    }
+    if (hash) {
+      *w++ = '#';
+      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+      std::memcpy(w, hash->data(), hash->size());
+    }
+    return total;
+  });
+  return output;
+#else
+  std::string output;
+  output.reserve(total);
+  output.append(prefix, PrefixSize);
+  output.append(hostname);
+  output.append(pathname);
+  if (query) {
+    output += '?';
+    output.append(*query);
+  }
+  if (hash) {
+    output += '#';
+    output.append(*hash);
+  }
+  return output;
+#endif
+}
+}  // namespace href_detail
+
 [[nodiscard]] ada_really_inline std::string url::get_href() const {
+  // ~96% of the dataset is https without userinfo or a port. Keep this
+  // branch HTTPS-only so the common path does not cmov the prefix length
+  // or choose between "https://" and "http://". HTTP is the next ~4%.
+  if (type == ada::scheme::type::HTTPS && host.has_value() &&
+      username.empty() && password.empty() && !port.has_value()) [[likely]] {
+    return href_detail::write_plain_special_href<8>("https://", *host, path,
+                                                    query, hash);
+  }
+  if (type == ada::scheme::type::HTTP && host.has_value() && username.empty() &&
+      password.empty() && !port.has_value()) {
+    return href_detail::write_plain_special_href<7>("http://", *host, path,
+                                                    query, hash);
+  }
   if (is_special() && host.has_value() && username.empty() && password.empty())
       [[likely]] {
     const size_t host_size = host->size();
@@ -195,37 +264,6 @@ constexpr void url::copy_scheme(const ada::url& u) {
     const bool has_h = hash.has_value();
     const bool has_p = port.has_value();
     const bool is_https = type == ada::scheme::type::HTTPS;
-    const bool is_http = type == ada::scheme::type::HTTP;
-    if (!has_q && !has_h && !has_p && (is_https || is_http)) [[likely]] {
-      const size_t prefix_n = is_https ? size_t{8} : size_t{7};
-      const size_t total = prefix_n + host_size + path_size;
-#if defined(__cpp_lib_string_resize_and_overwrite)
-      std::string output;
-      output.resize_and_overwrite(total, [&](char* p, size_t) {
-        if (is_https) {
-          std::memcpy(p, "https://", 8);
-        } else {
-          std::memcpy(p, "http://", 7);
-        }
-        // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-        std::memcpy(p + prefix_n, host->data(), host_size);
-        std::memcpy(p + prefix_n + host_size, path.data(), path_size);
-        return total;
-      });
-      return output;
-#else
-      std::string output;
-      output.reserve(total);
-      if (is_https) {
-        output.append("https://", 8);
-      } else {
-        output.append("http://", 7);
-      }
-      output.append(*host);
-      output.append(path);
-      return output;
-#endif
-    }
     const std::string_view prefix =
         is_https ? std::string_view{"https://", 8}
                  : ada::scheme::details::special_href_prefix[type];

--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -7,6 +7,7 @@
 
 #include "ada/url.h"
 #include "ada/url_components.h"
+#include "ada/scheme-inl.h"
 
 #include <charconv>
 #include <cstring>
@@ -186,41 +187,157 @@ constexpr void url::copy_scheme(const ada::url& u) {
 }
 
 [[nodiscard]] ada_really_inline std::string url::get_href() const {
-  if (is_special() && host.has_value() && username.empty() &&
-      password.empty() && !port.has_value()) [[likely]] {
-    const std::string_view scheme = ada::scheme::details::is_special_list[type];
+  if (is_special() && host.has_value() && username.empty() && password.empty())
+      [[likely]] {
     const size_t host_size = host->size();
     const size_t path_size = path.size();
-    const size_t query_size = query.has_value() ? query->size() : 0;
-    const size_t hash_size = hash.has_value() ? hash->size() : 0;
-    const size_t total = scheme.size() + 3 + host_size + path_size +
-                         (query.has_value() ? query_size + 1 : 0) +
-                         (hash.has_value() ? hash_size + 1 : 0);
-    std::string output(total, '\0');
-    char* p = output.data();
-    std::memcpy(p, scheme.data(), scheme.size());
-    p += scheme.size();
-    p[0] = ':';
-    p[1] = '/';
-    p[2] = '/';
-    p += 3;
-    // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-    std::memcpy(p, host->data(), host_size);
-    p += host_size;
-    std::memcpy(p, path.data(), path_size);
-    p += path_size;
-    if (query.has_value()) {
-      *p++ = '?';
-      // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-      std::memcpy(p, query->data(), query_size);
-      p += query_size;
+    const bool has_q = query.has_value();
+    const bool has_h = hash.has_value();
+    const bool has_p = port.has_value();
+    const bool is_https = type == ada::scheme::type::HTTPS;
+    const bool is_http = type == ada::scheme::type::HTTP;
+    if (!has_q && !has_h && !has_p && (is_https || is_http)) [[likely]] {
+      const size_t prefix_n = is_https ? size_t{8} : size_t{7};
+      const size_t total = prefix_n + host_size + path_size;
+#if defined(__cpp_lib_string_resize_and_overwrite)
+      std::string output;
+      output.resize_and_overwrite(total, [&](char* p, size_t) {
+        if (is_https) {
+          std::memcpy(p, "https://", 8);
+        } else {
+          std::memcpy(p, "http://", 7);
+        }
+        // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+        std::memcpy(p + prefix_n, host->data(), host_size);
+        std::memcpy(p + prefix_n + host_size, path.data(), path_size);
+        return total;
+      });
+      return output;
+#else
+      std::string output;
+      output.reserve(total);
+      if (is_https) {
+        output.append("https://", 8);
+      } else {
+        output.append("http://", 7);
+      }
+      output.append(*host);
+      output.append(path);
+      return output;
+#endif
     }
-    if (hash.has_value()) {
-      *p++ = '#';
+    const std::string_view prefix =
+        is_https ? std::string_view{"https://", 8}
+                 : ada::scheme::details::special_href_prefix[type];
+    const size_t prefix_size = is_https ? size_t{8} : prefix.size();
+#if !defined(__cpp_lib_string_resize_and_overwrite)
+    auto append_prefix = [&](std::string& output) {
+      if (is_https) [[likely]] {
+        output.append("https://", 8);
+      } else {
+        output.append(prefix);
+      }
+    };
+#endif
+#if defined(__cpp_lib_string_resize_and_overwrite)
+    auto write_prefix = [&](char* p) -> char* {
+      if (is_https) [[likely]] {
+        std::memcpy(p, "https://", 8);
+        return p + 8;
+      }
+      std::memcpy(p, prefix.data(), prefix.size());
+      return p + prefix.size();
+    };
+    auto finish = [&](size_t total, auto&& write) -> std::string {
+      std::string output;
+      output.resize_and_overwrite(total, [&](char* p, size_t) {
+        write(p);
+        return total;
+      });
+      return output;
+    };
+#endif
+    if (!has_q && !has_h && !has_p) [[likely]] {
+      const size_t total = prefix_size + host_size + path_size;
+#if defined(__cpp_lib_string_resize_and_overwrite)
+      return finish(total, [&](char* p) {
+        p = write_prefix(p);
+        // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+        std::memcpy(p, host->data(), host_size);
+        p += host_size;
+        std::memcpy(p, path.data(), path_size);
+      });
+#else
+      // reserve+append writes straight into the string. A stack buffer
+      // plus string(buf, n) copies the href twice.
+      std::string output;
+      output.reserve(total);
+      append_prefix(output);
+      output.append(*host);
+      output.append(path);
+      return output;
+#endif
+    }
+    const size_t query_size = has_q ? query->size() : 0;
+    const size_t hash_size = has_h ? hash->size() : 0;
+    uint16_t port_val = 0;
+    int port_digits = 0;
+    if (has_p) {
+      port_val = *port;
+      port_digits = helpers::fast_digit_count(port_val);
+    }
+    const size_t total =
+        prefix_size + host_size + (has_p ? size_t(1 + port_digits) : 0) +
+        path_size + (has_q ? query_size + 1 : 0) + (has_h ? hash_size + 1 : 0);
+#if defined(__cpp_lib_string_resize_and_overwrite)
+    return finish(total, [&](char* p) {
+      p = write_prefix(p);
       // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
-      std::memcpy(p, hash->data(), hash_size);
+      std::memcpy(p, host->data(), host_size);
+      p += host_size;
+      if (has_p) {
+        *p++ = ':';
+        auto [ptr, ec] = std::to_chars(p, p + 5, port_val);
+        (void)ec;
+        p = ptr;
+      }
+      std::memcpy(p, path.data(), path_size);
+      p += path_size;
+      if (has_q) {
+        *p++ = '?';
+        // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+        std::memcpy(p, query->data(), query_size);
+        p += query_size;
+      }
+      if (has_h) {
+        *p++ = '#';
+        // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
+        std::memcpy(p, hash->data(), hash_size);
+      }
+    });
+#else
+    std::string output;
+    output.reserve(total);
+    append_prefix(output);
+    output.append(*host);
+    if (has_p) {
+      output += ':';
+      char port_buf[5];
+      auto [ptr, ec] = std::to_chars(port_buf, port_buf + 5, port_val);
+      (void)ec;
+      output.append(port_buf, static_cast<size_t>(ptr - port_buf));
+    }
+    output.append(path);
+    if (has_q) {
+      output += '?';
+      output.append(*query);
+    }
+    if (has_h) {
+      output += '#';
+      output.append(*hash);
     }
     return output;
+#endif
   }
 
   std::string output;

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -509,6 +509,9 @@ struct url : url_base {
    * @see https://url.spec.whatwg.org/
    */
   ada_really_inline void parse_path(std::string_view input);
+  // Out-of-line thunk so finish helpers in parser_finish.cpp can call
+  // parse_path (always_inline body lives only in the unity TU).
+  void parse_path_outlined(std::string_view input);
 
   /**
    * Set the scheme for this URL. The provided scheme should be a valid

--- a/include/ada/url.h
+++ b/include/ada/url.h
@@ -382,6 +382,14 @@ struct url : url_base {
       ada::url_aggregator, true>(std::string_view, const ada::url_aggregator*);
   friend ada::url_aggregator ada::parser::parse_url_impl<
       ada::url_aggregator, false>(std::string_view, const ada::url_aggregator*);
+  friend ada::url& ada::parser::parse_url_impl_into<ada::url, true>(
+      ada::url&, std::string_view, const ada::url*, bool);
+  friend ada::url_aggregator&
+  ada::parser::parse_url_impl_into<ada::url_aggregator, true>(
+      ada::url_aggregator&, std::string_view, const ada::url_aggregator*, bool);
+  friend ada::url_aggregator&
+  ada::parser::parse_url_impl_into<ada::url_aggregator, false>(
+      ada::url_aggregator&, std::string_view, const ada::url_aggregator*, bool);
   template <class result_type>
   friend bool ada::parser::try_parse_simple_absolute(std::string_view,
                                                      result_type&);
@@ -389,6 +397,19 @@ struct url : url_base {
   friend bool ada::parser::finish_simple_absolute_with_port(
       std::string_view, result_type&, ada::scheme::type, uint32_t, size_t,
       size_t, size_t, bool);
+  template <class result_type>
+  friend bool ada::parser::finish_simple_absolute_literal_host(
+      std::string_view, result_type&, ada::scheme::type, uint32_t, size_t,
+      size_t, std::string_view, url_host_type);
+  template <class result_type>
+  friend bool ada::parser::try_finish_simple_userinfo(std::string_view,
+                                                      result_type&,
+                                                      ada::scheme::type,
+                                                      uint32_t, size_t);
+  template <class result_type>
+  friend void ada::parser::finish_simple_absolute_handoff(
+      std::string_view, result_type&, size_t, size_t, size_t, uint32_t, bool,
+      bool, size_t, size_t, size_t, size_t);
   template <class result_type>
   friend bool ada::parser::try_parse_simple_relative(std::string_view,
                                                      const result_type&,

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -322,6 +322,10 @@ struct url_aggregator : url_base {
       std::string_view, const url_aggregator*);
   friend url_aggregator parser::parse_url_impl<url_aggregator, false>(
       std::string_view, const url_aggregator*);
+  friend url_aggregator& parser::parse_url_impl_into<url_aggregator, true>(
+      url_aggregator&, std::string_view, const url_aggregator*, bool);
+  friend url_aggregator& parser::parse_url_impl_into<url_aggregator, false>(
+      url_aggregator&, std::string_view, const url_aggregator*, bool);
   template <class result_type>
   friend bool parser::try_parse_simple_absolute(std::string_view, result_type&);
   template <class result_type>
@@ -330,6 +334,20 @@ struct url_aggregator : url_base {
                                                        ada::scheme::type,
                                                        uint32_t, size_t, size_t,
                                                        size_t, bool);
+  template <class result_type>
+  friend bool parser::finish_simple_absolute_literal_host(
+      std::string_view, result_type&, ada::scheme::type, uint32_t, size_t,
+      size_t, std::string_view, url_host_type);
+  template <class result_type>
+  friend bool parser::try_finish_simple_userinfo(std::string_view, result_type&,
+                                                 ada::scheme::type, uint32_t,
+                                                 size_t);
+  template <class result_type>
+  friend void parser::finish_simple_absolute_handoff(std::string_view,
+                                                     result_type&, size_t,
+                                                     size_t, size_t, uint32_t,
+                                                     bool, bool, size_t, size_t,
+                                                     size_t, size_t);
   template <class result_type>
   friend bool parser::try_parse_simple_relative(std::string_view,
                                                 const result_type&,

--- a/include/ada/url_aggregator.h
+++ b/include/ada/url_aggregator.h
@@ -411,6 +411,9 @@ struct url_aggregator : url_base {
   [[nodiscard]] bool parse_opaque_host(std::string_view input);
 
   ada_really_inline void parse_path(std::string_view input);
+  // Out-of-line thunk so finish helpers in parser_finish.cpp can call
+  // parse_path (always_inline body lives only in the unity TU).
+  void parse_path_outlined(std::string_view input);
 
   /**
    * A URL cannot have a username/password/port if its host is null or the empty

--- a/include/ada/url_ip-inl.h
+++ b/include/ada/url_ip-inl.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <cstdint>
+#include <string_view>
 
 // The IPv6 kernel needs vpermi2b/vpermb (VBMI) and vpcompressb/vpexpandb
 // (VBMI2) on top of ADA_AVX512's BW+VL.
@@ -287,6 +288,136 @@ ada_really_inline bool try_parse_ipv6_avx512(const char* data, size_t len,
   return true;
 }
 #endif  // ADA_AVX512_IPV6
+
+// Parse an IPv6 host (no surrounding brackets). Shared by url, url_aggregator,
+// and the simple-absolute fast path.
+inline bool parse_ipv6_address(std::string_view input,
+                               std::array<uint16_t, 8>& address) noexcept {
+  if (input.empty() || input.size() > 45) [[unlikely]] {
+    return false;
+  }
+#if defined(ADA_AVX512_IPV6)
+  if (bool simd_valid;
+      try_parse_ipv6_avx512(input.data(), input.size(), address, simd_valid)) {
+    return simd_valid;
+  }
+  address = {};
+#endif
+  const char* pointer = input.data();
+  const char* const end = pointer + input.size();
+  int piece_index = 0;
+  int compress = -1;
+
+  if (*pointer == ':') {
+    if (input.size() == 1 || pointer[1] != ':') [[unlikely]] {
+      return false;
+    }
+    pointer += 2;
+    compress = ++piece_index;
+  }
+
+  while (pointer != end) {
+    if (piece_index == 8) [[unlikely]] {
+      return false;
+    }
+    if (*pointer == ':') {
+      if (compress != -1) [[unlikely]] {
+        return false;
+      }
+      ++pointer;
+      compress = ++piece_index;
+      continue;
+    }
+
+    uint16_t value = 0;
+    const int length = parse_hex_piece(pointer, end, value);
+
+    if (pointer != end && *pointer == '.') {
+      if (length == 0) [[unlikely]] {
+        return false;
+      }
+      pointer -= length;
+      if (piece_index > 6) [[unlikely]] {
+        return false;
+      }
+
+      int numbers_seen = 0;
+      while (pointer != end) {
+        int ipv4_piece = -1;
+        if (numbers_seen > 0) {
+          if (*pointer == '.' && numbers_seen < 4) {
+            ++pointer;
+          } else {
+            return false;
+          }
+        }
+        if (pointer == end || *pointer < '0' || *pointer > '9') [[unlikely]] {
+          return false;
+        }
+        ipv4_piece = *pointer - '0';
+        ++pointer;
+        if (pointer != end && *pointer >= '0' && *pointer <= '9') {
+          if (ipv4_piece == 0) [[unlikely]] {
+            return false;
+          }
+          ipv4_piece = ipv4_piece * 10 + (*pointer - '0');
+          ++pointer;
+          if (pointer != end && *pointer >= '0' && *pointer <= '9') {
+            ipv4_piece = ipv4_piece * 10 + (*pointer - '0');
+            ++pointer;
+            if (ipv4_piece > 255) [[unlikely]] {
+              return false;
+            }
+          }
+        }
+        address[static_cast<size_t>(piece_index)] = static_cast<uint16_t>(
+            address[static_cast<size_t>(piece_index)] * 0x100 +
+            static_cast<uint16_t>(ipv4_piece));
+        ++numbers_seen;
+        if (numbers_seen == 2 || numbers_seen == 4) {
+          ++piece_index;
+        }
+      }
+      if (numbers_seen != 4) [[unlikely]] {
+        return false;
+      }
+      break;
+    }
+
+    if (length == 0) [[unlikely]] {
+      return false;
+    }
+
+    if (pointer != end && *pointer == ':') {
+      ++pointer;
+      if (pointer == end) [[unlikely]] {
+        return false;
+      }
+    } else if (pointer != end) [[unlikely]] {
+      return false;
+    }
+
+    address[static_cast<size_t>(piece_index)] = value;
+    ++piece_index;
+  }
+
+  if (compress != -1) {
+    const int right = piece_index - compress;
+    if (right > 0) {
+      const size_t dest = static_cast<size_t>(8 - right);
+      const size_t src = static_cast<size_t>(compress);
+      if (dest != src) {
+        for (size_t i = static_cast<size_t>(right); i-- > 0;) {
+          address[dest + i] = address[src + i];
+          address[src + i] = 0;
+        }
+      }
+    }
+  } else if (piece_index != 8) [[unlikely]] {
+    return false;
+  }
+  return true;
+}
 
 }  // namespace ada::detail
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(ada-include-source INTERFACE $<BUILD_INTERFACE:${CMAK
 add_library(ada-source INTERFACE)
 target_sources(ada-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/ada.cpp)
 target_link_libraries(ada-source INTERFACE ada-include-source)
-add_library(ada ada.cpp unicode_percent_encode.cpp)
+add_library(ada ada.cpp unicode_percent_encode.cpp parser_hot.cpp parser_finish.cpp can_parse.cpp)
 target_compile_features(ada PUBLIC cxx_std_20)
 target_include_directories(ada PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
 target_include_directories(ada PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
@@ -60,9 +60,13 @@ if(ADA_TESTING)
   target_compile_definitions(ada PRIVATE ADA_TESTING=1)
 endif()
 
-# Keep the SIMD percent-encode kernel in its own TU so the unity ada.cpp
-# inlining budget for setters matches main.
+# Keep the SIMD percent-encode kernel, the simple-absolute fast path,
+# the cold finish helpers (including relative resolution), and can_parse
+# in their own TUs so the unity ada.cpp inlining budget for setters
+# matches main.
 target_compile_definitions(ada PRIVATE ADA_PERCENT_ENCODE_SIMD_SEPARATE_TU=1)
+target_compile_definitions(ada PRIVATE ADA_PARSER_FINISH_SEPARATE_TU=1)
+target_compile_definitions(ada PRIVATE ADA_CAN_PARSE_SEPARATE_TU=1)
 
 if(ADA_INCLUDE_URL_PATTERN)
   target_compile_definitions(ada PRIVATE ADA_INCLUDE_URL_PATTERN=1)

--- a/src/ada.cpp
+++ b/src/ada.cpp
@@ -6,8 +6,16 @@
 #endif
 #include "serializers.cpp"
 #include "implementation.cpp"
+#if !defined(ADA_CAN_PARSE_SEPARATE_TU)
+#include "can_parse.cpp"
+#endif
 #include "helpers.cpp"
 #include "url.cpp"
+#if defined(ADA_PARSER_FINISH_SEPARATE_TU)
+#define ADA_SKIP_PARSER_FINISH
+#define ADA_SKIP_PARSER_FASTPATH
+#define ADA_SKIP_PARSER_RELATIVE
+#endif
 #include "parser.cpp"
 #include "url_components.cpp"
 #include "url_aggregator.cpp"

--- a/src/can_parse.cpp
+++ b/src/can_parse.cpp
@@ -1,0 +1,687 @@
+#include <array>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <string_view>
+
+#include "ada/common_defs.h"
+#include "ada/checkers-inl.h"
+#include "ada/checkers.h"
+#include "ada/scheme-inl.h"
+
+#if ADA_NEON
+#include <arm_neon.h>
+#elif defined(__SSSE3__)
+#include <tmmintrin.h>
+#define ADA_CAN_PARSE_SSSE3 1
+#elif (defined(__x86_64__) || defined(__amd64__)) && defined(__GNUC__) && \
+    !defined(_MSC_VER)
+#include <tmmintrin.h>
+#define ADA_CAN_PARSE_SSSE3 1
+#define ADA_CAN_PARSE_NEED_SSSE3_TARGET 1
+#elif ADA_SSE2
+#include <emmintrin.h>
+#endif
+#ifndef ADA_CAN_PARSE_SSSE3
+#define ADA_CAN_PARSE_SSSE3 0
+#endif
+
+#ifdef ADA_CAN_PARSE_NEED_SSSE3_TARGET
+#if defined(__clang__)
+#define ADA_CAN_PARSE_SIMD inline __attribute__((target("ssse3")))
+#define ADA_CAN_PARSE_FASTPATH __attribute__((target("ssse3"), noinline))
+#else
+#define ADA_CAN_PARSE_SIMD ada_really_inline
+#define ADA_CAN_PARSE_FASTPATH ada_never_inline
+#define ADA_CAN_PARSE_ENABLE_SSSE3_PRAGMA 1
+#endif
+#else
+#define ADA_CAN_PARSE_SIMD ada_really_inline
+#define ADA_CAN_PARSE_FASTPATH
+#endif
+
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+#include <intrin.h>
+#endif
+
+#ifdef ADA_CAN_PARSE_ENABLE_SSSE3_PRAGMA
+#pragma GCC push_options
+#pragma GCC target("ssse3")
+#endif
+
+namespace ada {
+extern bool max_input_length_customized;
+uint32_t get_max_input_length();
+// Full parser fallback; lives in the unity TU so always_inline helpers
+// (parse_port, pathname, ...) are visible. This file must not include
+// url.h or clang-cl / clang-tidy report undefined-inline.
+bool can_parse_fallback(std::string_view input,
+                        const std::string_view* base_input);
+
+namespace {
+
+// Local copy: unicode::is_alnum_plus is always_inline in unicode.cpp
+// and has no standalone symbol for this TU.
+ada_really_inline constexpr bool is_alnum_plus(char c) noexcept {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') ||
+         (c >= 'A' && c <= 'Z') || c == '+' || c == '-' || c == '.';
+}
+
+constexpr std::array<uint8_t, 256> clean_http_host_byte = []() consteval {
+  std::array<uint8_t, 256> result{};
+  for (size_t i = 0; i < result.size(); ++i) {
+    const auto c = static_cast<uint8_t>(i);
+    result[i] =
+        static_cast<uint8_t>((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                             c == '-' || c == '.' || c == '_' || c == '~');
+  }
+  return result;
+}();
+
+#if ADA_CAN_PARSE_SSSE3
+// Stop on any byte that is not a clean HTTP host byte [a-z0-9-._~].
+constexpr std::array<uint8_t, 256> k_clean_http_stop = []() consteval {
+  std::array<uint8_t, 256> t{};
+  for (size_t i = 0; i < 256; ++i) {
+    t[i] = static_cast<uint8_t>(clean_http_host_byte[i] == 0);
+  }
+  return t;
+}();
+
+struct nibble_tables {
+  alignas(16) uint8_t low[16]{};
+  alignas(16) uint8_t high[16]{};
+  bool fits{true};
+};
+
+consteval nibble_tables make_stop_nibble_tables(
+    const std::array<uint8_t, 256>& cls) {
+  nibble_tables t{};
+  uint16_t patterns[16]{};
+  for (int hi = 0; hi < 16; ++hi) {
+    for (int lo = 0; lo < 16; ++lo) {
+      if (cls[static_cast<size_t>((hi << 4) | lo)] != 0) {
+        patterns[hi] = static_cast<uint16_t>(patterns[hi] | (1u << lo));
+      }
+    }
+  }
+  int bits_used = 0;
+  for (int hi = 0; hi < 16; ++hi) {
+    if (patterns[hi] == 0 || t.high[hi] != 0) {
+      continue;
+    }
+    if (bits_used == 8) {
+      t.fits = false;
+      return t;
+    }
+    const uint8_t bit = static_cast<uint8_t>(1u << bits_used++);
+    for (int other = hi; other < 16; ++other) {
+      if (patterns[other] == patterns[hi]) {
+        t.high[other] = static_cast<uint8_t>(t.high[other] | bit);
+      }
+    }
+    for (int lo = 0; lo < 16; ++lo) {
+      if ((patterns[hi] & (1u << lo)) != 0) {
+        t.low[lo] = static_cast<uint8_t>(t.low[lo] | bit);
+      }
+    }
+  }
+  return t;
+}
+
+constexpr nibble_tables k_clean_http_nibbles =
+    make_stop_nibble_tables(k_clean_http_stop);
+static_assert(k_clean_http_nibbles.fits);
+
+ADA_CAN_PARSE_SIMD int ssse3_nibble_mask(__m128i w, __m128i lo_tbl,
+                                         __m128i hi_tbl) noexcept {
+  const __m128i nibble = _mm_set1_epi8(0x0F);
+  const __m128i lo = _mm_and_si128(w, nibble);
+  const __m128i hi = _mm_and_si128(_mm_srli_epi16(w, 4), nibble);
+  const __m128i hit =
+      _mm_and_si128(_mm_shuffle_epi8(lo_tbl, lo), _mm_shuffle_epi8(hi_tbl, hi));
+  return _mm_movemask_epi8(_mm_cmpeq_epi8(hit, _mm_setzero_si128())) ^ 0xFFFF;
+}
+#endif
+
+// SWAR: eight ASCII host bytes in [a-z0-9-._~] without 8 table lookups.
+// High bits must be clear first so the range subtracts cannot borrow
+// across bytes.
+// High-bit-cleared ASCII only. Subtracts cannot borrow across bytes because
+// each (hi|0x80) byte is >= 0x80 and each data byte is <= 0x7F. Do not use
+// has-zero (x-ones)&~x: a match followed by match^1 (e.g. "./" or "_^")
+// produces a false positive via borrow.
+ada_really_inline uint64_t swar_in_range(uint64_t w, uint8_t lo,
+                                         uint8_t hi) noexcept {
+  constexpr uint64_t k_ones = 0x0101010101010101ull;
+  constexpr uint64_t k_high = 0x8080808080808080ull;
+  const uint64_t ge_lo = (w | k_high) - (k_ones * lo);
+  const uint64_t le_hi = ((k_ones * hi) | k_high) - w;
+  return ge_lo & le_hi & k_high;
+}
+
+ada_really_inline bool eight_clean_http_host_bytes(
+    const uint8_t* input) noexcept {
+  uint64_t w = 0;
+  std::memcpy(&w, input, 8);
+  constexpr uint64_t k_high = 0x8080808080808080ull;
+  if ((w & k_high) != 0) {
+    return false;
+  }
+  const uint64_t ok = swar_in_range(w, 'a', 'z') | swar_in_range(w, '0', '9') |
+                      swar_in_range(w, '-', '-') | swar_in_range(w, '.', '.') |
+                      swar_in_range(w, '_', '_') | swar_in_range(w, '~', '~');
+  return ok == k_high;
+}
+
+#if ADA_CAN_PARSE_SSSE3 || ADA_SSE2
+ada_really_inline int ctz32(unsigned bits) noexcept {
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+  unsigned long ret;
+  _BitScanForward(&ret, bits);
+  return static_cast<int>(ret);
+#else
+  return __builtin_ctz(bits);
+#endif
+}
+
+#if !ADA_CAN_PARSE_SSSE3 && ADA_SSE2
+// Bits set where the byte is not in [a-z0-9-._~]. That includes / ? #.
+ada_really_inline int sse2_unclean_http_host(__m128i w) noexcept {
+  const __m128i az = _mm_and_si128(
+      _mm_cmpgt_epi8(w, _mm_set1_epi8(static_cast<char>('a' - 1))),
+      _mm_cmplt_epi8(w, _mm_set1_epi8(static_cast<char>('z' + 1))));
+  const __m128i d09 = _mm_and_si128(
+      _mm_cmpgt_epi8(w, _mm_set1_epi8(static_cast<char>('0' - 1))),
+      _mm_cmplt_epi8(w, _mm_set1_epi8(static_cast<char>('9' + 1))));
+  const __m128i spec =
+      _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('-')),
+                                _mm_cmpeq_epi8(w, _mm_set1_epi8('.'))),
+                   _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('_')),
+                                _mm_cmpeq_epi8(w, _mm_set1_epi8('~'))));
+  return _mm_movemask_epi8(_mm_or_si128(_mm_or_si128(az, d09), spec)) ^ 0xFFFF;
+}
+#endif  // !ADA_CAN_PARSE_SSSE3 && ADA_SSE2
+
+ada_really_inline bool sse2_http_host_delim(uint8_t c) noexcept {
+  return c == '/' || c == '?' || c == '#';
+}
+
+ada_really_inline bool mask_has_xn(const uint8_t* bytes, size_t at, int x_mask,
+                                   size_t length) noexcept {
+  if (x_mask == 0) {
+    return false;
+  }
+  unsigned bits = static_cast<unsigned>(x_mask);
+  do {
+    const size_t pos = at + static_cast<size_t>(ctz32(bits));
+    if (pos + 2 < length && bytes[pos + 1] == 'n' && bytes[pos + 2] == '-') {
+      return true;
+    }
+    bits &= bits - 1;
+  } while (bits != 0);
+  return false;
+}
+#endif  // ADA_CAN_PARSE_SSSE3 || ADA_SSE2
+
+// Minimal front end for the overwhelmingly common already-canonical HTTP(S)
+// case. It deliberately handles fewer inputs than
+// try_can_parse_absolute_fast: anything requiring normalization or detailed
+// host parsing falls through to that broader validator.
+#if defined(_MSC_VER) || \
+    (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+constexpr bool k_can_parse_little_endian = true;
+#else
+constexpr bool k_can_parse_little_endian = false;
+#endif
+
+ADA_CAN_PARSE_FASTPATH std::optional<bool> try_can_parse_clean_http(
+    std::string_view input) noexcept {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(input.data());
+  const size_t length = input.size();
+  if (length < 7) {
+    return std::nullopt;
+  }
+
+  size_t authority_start;
+  if constexpr (k_can_parse_little_endian) {
+    if (length >= 8) {
+      uint64_t first8 = 0;
+      std::memcpy(&first8, bytes, 8);
+      if (first8 == 0x2f2f3a7370747468ull) {  // "https://"
+        authority_start = 8;
+      } else if ((first8 & 0x00ffffffffffffffull) ==
+                 0x002f2f3a70747468ull) {  // "http://"
+        authority_start = 7;
+      } else {
+        return std::nullopt;
+      }
+    } else if (bytes[0] == 'h' && bytes[1] == 't' && bytes[2] == 't' &&
+               bytes[3] == 'p' && bytes[4] == ':' && bytes[5] == '/' &&
+               bytes[6] == '/') {
+      authority_start = 7;
+    } else {
+      return std::nullopt;
+    }
+  } else {
+    uint32_t first4{};
+    std::memcpy(&first4, bytes, 4);
+    if (first4 != 0x68747470u) {  // "http"
+      return std::nullopt;
+    }
+    if (length >= 8 && bytes[4] == 's' && bytes[5] == ':' && bytes[6] == '/' &&
+        bytes[7] == '/') {
+      authority_start = 8;
+    } else if (bytes[4] == ':' && bytes[5] == '/' && bytes[6] == '/') {
+      authority_start = 7;
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  if (authority_start >= length) {
+    return false;
+  }
+
+  size_t cursor = authority_start;
+#if ADA_CAN_PARSE_SSSE3 || ADA_SSE2
+  const __m128i x_splat = _mm_set1_epi8('x');
+#if ADA_CAN_PARSE_SSSE3
+  const __m128i lo_tbl = _mm_load_si128(
+      reinterpret_cast<const __m128i*>(k_clean_http_nibbles.low));
+  const __m128i hi_tbl = _mm_load_si128(
+      reinterpret_cast<const __m128i*>(k_clean_http_nibbles.high));
+#endif
+  // 0 = window was clean (keep scanning), 1 = host delimiter, -1 = fall through
+  auto visit16 = [&](size_t at, int keep) -> int {
+    const __m128i w =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes + at));
+#if ADA_CAN_PARSE_SSSE3
+    const int unclean = ssse3_nibble_mask(w, lo_tbl, hi_tbl) & keep;
+#else
+    const int unclean = sse2_unclean_http_host(w) & keep;
+#endif
+    const int xs = _mm_movemask_epi8(_mm_cmpeq_epi8(w, x_splat)) & keep;
+    if (unclean == 0) {
+      return (xs != 0 && mask_has_xn(bytes, at, xs, length)) ? -1 : 0;
+    }
+    const int hit = ctz32(static_cast<unsigned>(unclean));
+    const int valid = (1 << hit) - 1;
+    if (mask_has_xn(bytes, at, xs & valid, length)) {
+      return -1;
+    }
+    cursor = at + static_cast<size_t>(hit);
+    return sse2_http_host_delim(bytes[cursor]) ? 1 : -1;
+  };
+
+  if (length - authority_start >= 16) {
+    for (; cursor + 16 <= length; cursor += 16) {
+      const int r = visit16(cursor, 0xFFFF);
+      if (r < 0) {
+        return std::nullopt;
+      }
+      if (r > 0) {
+        goto host_done;
+      }
+    }
+    if (cursor < length) {
+      const size_t at = length - 16;
+      const int skip = static_cast<int>(cursor - at);
+      const int keep = static_cast<int>(~((1u << skip) - 1u));
+      const int r = visit16(at, keep);
+      if (r < 0) {
+        return std::nullopt;
+      }
+      if (r > 0) {
+        goto host_done;
+      }
+      cursor = length;
+    }
+  } else if (length >= 16) {
+    const size_t at = length - 16;
+    const int skip = static_cast<int>(authority_start - at);
+    const int keep = static_cast<int>(~((1u << skip) - 1u));
+    const int r = visit16(at, keep);
+    if (r < 0) {
+      return std::nullopt;
+    }
+    if (r > 0) {
+      goto host_done;
+    }
+    cursor = length;
+  } else
+#endif
+  {
+    while (cursor + 8 <= length &&
+           eight_clean_http_host_bytes(bytes + cursor)) {
+      if (std::memchr(bytes + cursor, 'x', 8) != nullptr) {
+        for (size_t k = 0; k < 8; ++k) {
+          const size_t pos = cursor + k;
+          if (bytes[pos] == 'x' && pos + 2 < length && bytes[pos + 1] == 'n' &&
+              bytes[pos + 2] == '-') {
+            return std::nullopt;
+          }
+        }
+      }
+      cursor += 8;
+    }
+    while (cursor < length) {
+      const uint8_t c = bytes[cursor];
+      if (c == '/' || c == '?' || c == '#') {
+        break;
+      }
+      if (!clean_http_host_byte[c]) {
+        return std::nullopt;
+      }
+      if (c == 'x' && cursor + 2 < length && bytes[cursor + 1] == 'n' &&
+          bytes[cursor + 2] == '-') {
+        return std::nullopt;
+      }
+      ++cursor;
+    }
+  }
+
+host_done:
+  const size_t host_length = cursor - authority_start;
+  if (host_length == 0) {
+    // Extra special-scheme slashes are normalization, not an empty host.
+    if (bytes[authority_start] == '/' || bytes[authority_start] == '\\') {
+      return std::nullopt;
+    }
+    return false;
+  }
+  if (host_length > 253 || bytes[cursor - 1] == '.') {
+    return std::nullopt;
+  }
+
+  const char lastc = static_cast<char>(bytes[cursor - 1]);
+  // 'm'/'g'/... are not IPv4 number chars, so .com/.org never walk.
+  if (checkers::is_ipv4_number_char(lastc) &&
+      checkers::last_label_may_be_a_number(
+          std::string_view(input.data() + authority_start, host_length))) {
+    return std::nullopt;
+  }
+
+  // Once a special URL has a valid host, path/query/fragment bytes cannot make
+  // it structurally invalid: the full parser percent-encodes them as needed.
+  return true;
+}
+
+// @private
+// Fast-path validator for can_parse.
+//
+// Validates absolute special (non-file) URLs without constructing any
+// url_aggregator object and without running the state machine.
+// Performs a single forward scan over the input bytes.
+//
+// Returns:
+//   true      -- URL is structurally valid
+//   false     -- URL is definitely invalid
+//   nullopt   -- edge case; fall through to the full parser
+//               (credentials, IDNA, IPv4/6, tabs/newlines, relative URLs, ...)
+std::optional<bool> try_can_parse_absolute_fast(
+    std::string_view input) noexcept {
+  const uint8_t* b = reinterpret_cast<const uint8_t*>(input.data());
+  size_t len = input.size();
+
+  // -- Inline C0 whitespace trim (no allocation) --------------------------
+  // Note: \t (0x09), \n (0x0a), \r (0x0d) are all <= 0x20, so any
+  // leading/trailing tabs or newlines are correctly stripped here, matching
+  // the WHATWG spec's "remove leading/trailing C0 control and space" step.
+  while (len > 0 && b[0] <= 0x20) {
+    b++;
+    len--;
+  }
+  while (len > 0 && b[len - 1] <= 0x20) {
+    len--;
+  }
+  if (len == 0) return false;
+
+  // -- Scheme detection -----------------------------------------------------
+  // Fast path for HTTP and HTTPS (covers ~90%+ of real-world URLs).
+  // Avoids the general scheme loop, buffer copy, and perfect hash lookup.
+  // We know HTTP and HTTPS are special non-file schemes, so no further
+  // scheme_type checks are needed on the fast path -- only `pos` matters.
+  size_t pos;
+
+  if (len >= 7 && (b[0] | 0x20) == 'h' && (b[1] | 0x20) == 't' &&
+      (b[2] | 0x20) == 't' && (b[3] | 0x20) == 'p') {
+    if (b[4] == ':' && b[5] == '/' && b[6] == '/') {
+      pos = 7;
+      goto skip_extra_slashes;
+    }
+    if (len >= 8 && (b[4] | 0x20) == 's' && b[5] == ':' && b[6] == '/' &&
+        b[7] == '/') {
+      pos = 8;
+      goto skip_extra_slashes;
+    }
+    // Fall through: could be "httpe://", tabs in scheme, etc.
+  }
+
+  {
+    // General scheme detection for ws, wss, ftp, and edge cases.
+    if (!checkers::is_alpha(static_cast<char>(b[0]))) return false;
+
+    // Scan for ':' within the first 7 bytes. All special schemes are <= 5
+    // chars ("https"), so any URL whose first ':' is beyond byte 6 is either
+    // non-special or relative -- both require the full parser.
+    size_t colon_pos = 0;
+    for (size_t i = 1;; ++i) {
+      if (i >= 7 || i >= len) return std::nullopt;
+      const char c = static_cast<char>(b[i]);
+      if (c == ':') {
+        colon_pos = i;
+        break;
+      }
+      // Tabs/newlines in the scheme require the full parser to strip them.
+      if (c == '\t' || c == '\n' || c == '\r') return std::nullopt;
+      if (!is_alnum_plus(c)) return false;
+    }
+
+    // Lowercase scheme bytes inline and classify via the existing perfect
+    // hash.
+    char scheme_buf[6];
+    scheme_buf[0] = static_cast<char>(b[0] | 0x20);
+    for (size_t i = 1; i < colon_pos; ++i)
+      scheme_buf[i] = static_cast<char>(b[i] | 0x20);
+
+    const ada::scheme::type scheme_type =
+        ada::scheme::get_scheme_type({scheme_buf, colon_pos});
+
+    // Only handle special, non-file schemes.
+    if (scheme_type == ada::scheme::NOT_SPECIAL) return std::nullopt;
+    if (scheme_type == ada::scheme::FILE) return std::nullopt;
+
+    // Per WHATWG, special URLs don't require "//": "http:example.com" is valid
+    // (SPECIAL_AUTHORITY_IGNORE_SLASHES just skips leading slashes and
+    // proceeds to AUTHORITY).  Defer to the inline fallback for any input
+    // without "://".
+    pos = colon_pos + 1;
+    if (pos + 2 > len || b[pos] != '/' || b[pos + 1] != '/') {
+      return std::nullopt;
+    }
+    pos += 2;
+  }
+
+skip_extra_slashes:
+  // SPECIAL_AUTHORITY_IGNORE_SLASHES: the full parser skips any additional
+  // leading '/' or '\' after the initial "//".  Mirror that here so we don't
+  // mis-identify the host as empty when there are extra slashes.
+  while (pos < len && (b[pos] == '/' || b[pos] == '\\')) {
+    ++pos;
+  }
+
+  // Early IPv6 bail-out: if the authority starts with '[', it's an IPv6
+  // literal which requires the full parser.  Checking here avoids scanning
+  // the entire bracketed address only to bail out afterward.
+  if (pos < len && b[pos] == '[') return std::nullopt;
+
+  // -- Merged authority + host scan ------------------------------------------
+  // A single forward pass over the authority bytes that simultaneously:
+  //   - finds the authority end and port colon
+  //   - validates host characters (forbidden domain code points)
+  //   - tracks IPv4 indicators (all-decimal-dots, last non-dot char)
+  //   - detects xn-- prefixes (IDNA punycode)
+  //   - detects tabs/newlines (which require the full parser to strip)
+  // This replaces 4 separate scans over the host bytes.
+  const size_t auth_start = pos;
+  size_t auth_end = pos;
+  size_t port_colon = SIZE_MAX;
+  bool all_dec_dots = true;
+
+  for (; auth_end < len; ++auth_end) {
+    const uint8_t c = b[auth_end];
+
+    // Non-ASCII -> needs IDNA processing -> full parser.
+    if (c >= 0x80) return std::nullopt;
+
+    // Authority delimiters.
+    if (c == '/' || c == '?' || c == '#' || c == '\\') break;
+
+    // Port separator.
+    if (c == ':') {
+      if (port_colon == SIZE_MAX) port_colon = auth_end;
+      continue;
+    }
+
+    // Credentials or percent-encoding -> full parser.
+    if (c == '@' || c == '%') return std::nullopt;
+
+    // Tabs/newlines anywhere in the authority require the full parser to
+    // strip them before validation.  Without this, a tab in the port (e.g.
+    // "http://host:8\t0/") would be mis-rejected by port validation.
+    if (c == '\t' || c == '\n' || c == '\r') return std::nullopt;
+
+    // Skip remaining host-specific checks for port bytes.  Port digits are
+    // validated separately below, and no forbidden-domain-code-point check
+    // is needed on port characters.
+    if (port_colon != SIZE_MAX) continue;
+
+    // -- Host byte validation (inlined) ------------------------------------
+    // Forbidden domain code points that are not already caught above:
+    //   C0 controls and space (0x00-0x20), DEL (0x7F), <, >, [, ], ^, |.
+    // At this stage, the input may still be userinfo or be normalized later
+    // (e.g., percent-encoded), so we do not reject here and defer to the
+    // parser. Characters already caught: >= 0x80 (non-ASCII), '/' '?' '#' '\\'
+    // (delimiters), ':' (port), '@' '%' (bail), '\t' '\n' '\r' (bail).
+    if (c <= 0x20 || c == 0x7F || c == '<' || c == '>' || c == '[' ||
+        c == ']' || c == '^' || c == '|') {
+      return std::nullopt;
+    }
+
+    // Track whether host is all decimal digits and dots (potential IPv4).
+    if (c != '.' && (c < '0' || c > '9')) all_dec_dots = false;
+
+    // Detect xn-- prefix inline (IDNA punycode -> needs full parser).
+    // Checking at every position mirrors the original behavior: any
+    // occurrence of "xn--" in the host (not just at label boundaries)
+    // triggers a bail-out to the full IDNA validator.
+    if ((c | 0x20) == 'x' && auth_end + 4 <= len &&
+        (b[auth_end + 1] | 0x20) == 'n' && b[auth_end + 2] == '-' &&
+        b[auth_end + 3] == '-') {
+      return std::nullopt;
+    }
+  }
+
+  const size_t host_end = (port_colon != SIZE_MAX) ? port_colon : auth_end;
+
+  // Empty host is invalid for special URLs.
+  if (auth_start == host_end) return false;
+
+  // -- IPv4 handling ---------------------------------------------------------
+  const char* host_ptr = reinterpret_cast<const char*>(b + auth_start);
+  const size_t host_len = host_end - auth_start;
+
+  if (all_dec_dots) {
+    // Host is all decimal digits and dots -> try the fast IPv4 parser.
+    if (checkers::try_parse_ipv4_fast({host_ptr, host_len}) !=
+        checkers::ipv4_fast_fail) {
+      // Valid decimal IPv4 host.  Do NOT return true yet: the port still
+      // needs to be validated below before we can declare the URL valid.
+      goto validate_port;
+    }
+    // Fast IPv4 parsing failed (e.g. host is ".", "..", "1.2.3.500").
+    // Such hosts may still be valid domain names; defer to the full parser.
+    return std::nullopt;
+  }
+
+  if (checkers::last_label_may_be_a_number({host_ptr, host_len})) {
+    return std::nullopt;
+  }
+
+  // -- Port validation -------------------------------------------------------
+validate_port:
+  if (port_colon != SIZE_MAX) {
+    const uint8_t* pp = b + port_colon + 1;
+    size_t pl = auth_end - port_colon - 1;
+    if (pl > 0) {
+      // Strip leading zeros: "0000001" == 1, "0000000000000" == 0, both valid.
+      // Only the significant digits count toward the 5-digit maximum.
+      while (pl > 0 && *pp == '0') {
+        ++pp;
+        --pl;
+      }
+      if (pl > 5) return false;  // significant digits > 99999
+      uint32_t pv = 0;
+      for (size_t i = 0; i < pl; ++i) {
+        if (pp[i] < '0' || pp[i] > '9') return false;
+        pv = pv * 10 + (pp[i] - '0');
+      }
+      if (pv > 65535) return false;
+    }
+  }
+
+  // Path, query, and fragment are structurally always valid for can_parse --
+  // the parser would encode whatever is there.
+  return true;
+}
+
+}  // namespace
+
+bool can_parse(std::string_view input, const std::string_view* base_input) {
+  // Must match parse().has_value(), including post-normalization max length.
+  // Percent-encoding expands a byte by at most 3x, but IDNA expands more: a
+  // 3-byte UTF-8 label such as U+337F becomes the 17-byte "xn--6oqv20b1zgzxr",
+  // so a dotted host sustains 4.5x. When the input (plus base, if any) fits in
+  // max_length/5, the normalized href cannot exceed max_length, so
+  // validation-only parsing (store_values=false) is safe.
+
+  // Hot path first: absolute special URLs, no base. Avoid loading max_length
+  // until we need it (common absolute-fast true/false cases).
+  if (base_input == nullptr) {
+    auto r = try_can_parse_clean_http(input);
+    if (!r.has_value()) {
+      r = try_can_parse_absolute_fast(input);
+    }
+    if (r.has_value()) {
+      if (!*r) {
+        return false;
+      }
+      // size <= max/5 => normalized href cannot exceed max (4.5x expansion).
+      // Default max is ~4 GB: skip the atomic on typical inputs.
+      if (!max_input_length_customized) [[likely]] {
+        if (input.size() > std::numeric_limits<uint32_t>::max() / 5)
+            [[unlikely]] {
+          return can_parse_fallback(input, nullptr);
+        }
+        return true;
+      }
+      const uint32_t max_length = get_max_input_length();
+      if (input.size() <= static_cast<size_t>(max_length) / 5) {
+        return true;
+      }
+      if (input.size() > max_length) {
+        return false;
+      }
+      return can_parse_fallback(input, nullptr);
+    }
+  }
+
+  return can_parse_fallback(input, base_input);
+}
+
+}  // namespace ada
+
+#ifdef ADA_CAN_PARSE_ENABLE_SSSE3_PRAGMA
+#pragma GCC pop_options
+#endif

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,26 +1,15 @@
 #include "ada/implementation-inl.h"
 
-#include <array>
 #include <atomic>
-#include <cstring>
 #include <limits>
-#include <optional>
+#include <string>
 #include <string_view>
 
-#if ADA_SSE2
-#include <emmintrin.h>
-#ifdef ADA_REGULAR_VISUAL_STUDIO
-#include <intrin.h>
-#endif
-#endif
-
-#include "ada/checkers-inl.h"
-#include "ada/checkers.h"
 #include "ada/common_defs.h"
+#include "ada/helpers.h"
 #include "ada/parser.h"
 #include "ada/scheme.h"
-#include "ada/unicode-inl.h"
-#include "ada/url.h"
+#include "ada/unicode.h"
 #include "ada/url_aggregator.h"
 
 namespace ada {
@@ -41,547 +30,47 @@ uint32_t get_max_input_length() {
   return max_input_length_.load(std::memory_order_relaxed);
 }
 
-namespace {
-
-constexpr std::array<uint8_t, 256> clean_http_host_byte = []() consteval {
-  std::array<uint8_t, 256> result{};
-  for (size_t i = 0; i < result.size(); ++i) {
-    const auto c = static_cast<uint8_t>(i);
-    result[i] =
-        static_cast<uint8_t>((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-                             c == '-' || c == '.' || c == '_' || c == '~');
-  }
-  return result;
-}();
-
-// SWAR: eight ASCII host bytes in [a-z0-9-._~] without 8 table lookups.
-// High bits must be clear first so the range subtracts cannot borrow
-// across bytes.
-// High-bit-cleared ASCII only. Subtracts cannot borrow across bytes because
-// each (hi|0x80) byte is >= 0x80 and each data byte is <= 0x7F. Do not use
-// has-zero (x-ones)&~x: a match followed by match^1 (e.g. "./" or "_^")
-// produces a false positive via borrow.
-ada_really_inline uint64_t swar_in_range(uint64_t w, uint8_t lo,
-                                         uint8_t hi) noexcept {
-  constexpr uint64_t k_ones = 0x0101010101010101ull;
-  constexpr uint64_t k_high = 0x8080808080808080ull;
-  const uint64_t ge_lo = (w | k_high) - (k_ones * lo);
-  const uint64_t le_hi = ((k_ones * hi) | k_high) - w;
-  return ge_lo & le_hi & k_high;
-}
-
-ada_really_inline bool eight_clean_http_host_bytes(
-    const uint8_t* input) noexcept {
-  uint64_t w = 0;
-  std::memcpy(&w, input, 8);
-  constexpr uint64_t k_high = 0x8080808080808080ull;
-  if ((w & k_high) != 0) {
+bool can_parse_fallback(std::string_view input,
+                        const std::string_view* base_input) {
+  const uint32_t max_length = get_max_input_length();
+  if (input.size() > max_length) {
     return false;
   }
-  const uint64_t ok = swar_in_range(w, 'a', 'z') | swar_in_range(w, '0', '9') |
-                      swar_in_range(w, '-', '-') | swar_in_range(w, '.', '.') |
-                      swar_in_range(w, '_', '_') | swar_in_range(w, '~', '~');
-  return ok == k_high;
-}
-
-#if ADA_SSE2
-ada_really_inline int ctz32(unsigned bits) noexcept {
-#ifdef ADA_REGULAR_VISUAL_STUDIO
-  unsigned long ret;
-  _BitScanForward(&ret, bits);
-  return static_cast<int>(ret);
-#else
-  return __builtin_ctz(bits);
-#endif
-}
-
-// Bits set where the byte is not in [a-z0-9-._~]. That includes / ? #.
-ada_really_inline int sse2_unclean_http_host(__m128i w) noexcept {
-  const __m128i az = _mm_and_si128(
-      _mm_cmpgt_epi8(w, _mm_set1_epi8(static_cast<char>('a' - 1))),
-      _mm_cmplt_epi8(w, _mm_set1_epi8(static_cast<char>('z' + 1))));
-  const __m128i d09 = _mm_and_si128(
-      _mm_cmpgt_epi8(w, _mm_set1_epi8(static_cast<char>('0' - 1))),
-      _mm_cmplt_epi8(w, _mm_set1_epi8(static_cast<char>('9' + 1))));
-  const __m128i spec =
-      _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('-')),
-                                _mm_cmpeq_epi8(w, _mm_set1_epi8('.'))),
-                   _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('_')),
-                                _mm_cmpeq_epi8(w, _mm_set1_epi8('~'))));
-  return _mm_movemask_epi8(_mm_or_si128(_mm_or_si128(az, d09), spec)) ^ 0xFFFF;
-}
-
-ada_really_inline bool sse2_http_host_delim(uint8_t c) noexcept {
-  return c == '/' || c == '?' || c == '#';
-}
-
-ada_really_inline bool mask_has_xn(const uint8_t* bytes, size_t at, int x_mask,
-                                   size_t length) noexcept {
-  if (x_mask == 0) {
-    return false;
-  }
-  unsigned bits = static_cast<unsigned>(x_mask);
-  do {
-    const size_t pos = at + static_cast<size_t>(ctz32(bits));
-    if (pos + 2 < length && bytes[pos + 1] == 'n' && bytes[pos + 2] == '-') {
-      return true;
-    }
-    bits &= bits - 1;
-  } while (bits != 0);
-  return false;
-}
-#endif
-
-// Minimal front end for the overwhelmingly common already-canonical HTTP(S)
-// case. It deliberately handles fewer inputs than
-// try_can_parse_absolute_fast: anything requiring normalization or detailed
-// host parsing falls through to that broader validator.
-#if defined(_MSC_VER) || \
-    (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-constexpr bool k_can_parse_little_endian = true;
-#else
-constexpr bool k_can_parse_little_endian = false;
-#endif
-
-std::optional<bool> try_can_parse_clean_http(std::string_view input) noexcept {
-  const auto* bytes = reinterpret_cast<const uint8_t*>(input.data());
-  const size_t length = input.size();
-  if (length < 7) {
-    return std::nullopt;
-  }
-
-  size_t authority_start;
-  if constexpr (k_can_parse_little_endian) {
-    if (length >= 8) {
-      uint64_t first8 = 0;
-      std::memcpy(&first8, bytes, 8);
-      if (first8 == 0x2f2f3a7370747468ull) {  // "https://"
-        authority_start = 8;
-      } else if ((first8 & 0x00ffffffffffffffull) ==
-                 0x002f2f3a70747468ull) {  // "http://"
-        authority_start = 7;
-      } else {
-        return std::nullopt;
-      }
-    } else if (bytes[0] == 'h' && bytes[1] == 't' && bytes[2] == 't' &&
-               bytes[3] == 'p' && bytes[4] == ':' && bytes[5] == '/' &&
-               bytes[6] == '/') {
-      authority_start = 7;
-    } else {
-      return std::nullopt;
-    }
-  } else {
-    uint32_t first4{};
-    std::memcpy(&first4, bytes, 4);
-    if (first4 != 0x68747470u) {  // "http"
-      return std::nullopt;
-    }
-    if (length >= 8 && bytes[4] == 's' && bytes[5] == ':' && bytes[6] == '/' &&
-        bytes[7] == '/') {
-      authority_start = 8;
-    } else if (bytes[4] == ':' && bytes[5] == '/' && bytes[6] == '/') {
-      authority_start = 7;
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  if (authority_start >= length) {
+  if (base_input != nullptr && base_input->size() > max_length) {
     return false;
   }
 
-  size_t cursor = authority_start;
-#if ADA_SSE2
-  const __m128i x_splat = _mm_set1_epi8('x');
-  // 0 = window was clean (keep scanning), 1 = host delimiter, -1 = fall through
-  auto visit16 = [&](size_t at, int keep) -> int {
-    const __m128i w =
-        _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes + at));
-    const int unclean = sse2_unclean_http_host(w) & keep;
-    const int xs = _mm_movemask_epi8(_mm_cmpeq_epi8(w, x_splat)) & keep;
-    if (unclean == 0) {
-      return (xs != 0 && mask_has_xn(bytes, at, xs, length)) ? -1 : 0;
-    }
-    const int hit = ctz32(static_cast<unsigned>(unclean));
-    const int valid = (1 << hit) - 1;
-    if (mask_has_xn(bytes, at, xs & valid, length)) {
-      return -1;
-    }
-    cursor = at + static_cast<size_t>(hit);
-    return sse2_http_host_delim(bytes[cursor]) ? 1 : -1;
-  };
+  const size_t combined =
+      input.size() + (base_input == nullptr ? 0 : base_input->size());
+  const bool size_safe = combined <= static_cast<size_t>(max_length) / 5;
 
-  if (length - authority_start >= 16) {
-    for (; cursor + 16 <= length; cursor += 16) {
-      const int r = visit16(cursor, 0xFFFF);
-      if (r < 0) {
-        return std::nullopt;
+  if (size_safe) {
+    url_aggregator base_agg;
+    url_aggregator* base_ptr = nullptr;
+    if (base_input != nullptr) {
+      base_agg =
+          parser::parse_url_impl<url_aggregator, false>(*base_input, nullptr);
+      if (!base_agg.is_valid) {
+        return false;
       }
-      if (r > 0) {
-        goto host_done;
-      }
+      base_ptr = &base_agg;
     }
-    if (cursor < length) {
-      const size_t at = length - 16;
-      const int skip = static_cast<int>(cursor - at);
-      const int keep = static_cast<int>(~((1u << skip) - 1u));
-      const int r = visit16(at, keep);
-      if (r < 0) {
-        return std::nullopt;
-      }
-      if (r > 0) {
-        goto host_done;
-      }
-      cursor = length;
-    }
-  } else if (length >= 16) {
-    const size_t at = length - 16;
-    const int skip = static_cast<int>(authority_start - at);
-    const int keep = static_cast<int>(~((1u << skip) - 1u));
-    const int r = visit16(at, keep);
-    if (r < 0) {
-      return std::nullopt;
-    }
-    if (r > 0) {
-      goto host_done;
-    }
-    cursor = length;
-  } else
-#endif
-  {
-    while (cursor + 8 <= length &&
-           eight_clean_http_host_bytes(bytes + cursor)) {
-      if (std::memchr(bytes + cursor, 'x', 8) != nullptr) {
-        for (size_t k = 0; k < 8; ++k) {
-          const size_t pos = cursor + k;
-          if (bytes[pos] == 'x' && pos + 2 < length && bytes[pos + 1] == 'n' &&
-              bytes[pos + 2] == '-') {
-            return std::nullopt;
-          }
-        }
-      }
-      cursor += 8;
-    }
-    while (cursor < length) {
-      const uint8_t c = bytes[cursor];
-      if (c == '/' || c == '?' || c == '#') {
-        break;
-      }
-      if (!clean_http_host_byte[c]) {
-        return std::nullopt;
-      }
-      if (c == 'x' && cursor + 2 < length && bytes[cursor + 1] == 'n' &&
-          bytes[cursor + 2] == '-') {
-        return std::nullopt;
-      }
-      ++cursor;
-    }
+    return parser::parse_url_impl<url_aggregator, false>(input, base_ptr)
+        .is_valid;
   }
 
-host_done:
-  const size_t host_length = cursor - authority_start;
-  if (host_length == 0) {
-    // Extra special-scheme slashes are normalization, not an empty host.
-    if (bytes[authority_start] == '/' || bytes[authority_start] == '\\') {
-      return std::nullopt;
-    }
+  if (base_input == nullptr) {
+    return parser::parse_url_impl<url_aggregator, true>(input, nullptr)
+        .is_valid;
+  }
+  url_aggregator base_agg =
+      parser::parse_url_impl<url_aggregator, true>(*base_input, nullptr);
+  if (!base_agg.is_valid) {
     return false;
   }
-  if (host_length > 253 || bytes[cursor - 1] == '.') {
-    return std::nullopt;
-  }
-
-  const char lastc = static_cast<char>(bytes[cursor - 1]);
-  // 'm'/'g'/... are not IPv4 number chars, so .com/.org never walk.
-  if (checkers::is_ipv4_number_char(lastc) &&
-      checkers::last_label_may_be_a_number(
-          std::string_view(input.data() + authority_start, host_length))) {
-    return std::nullopt;
-  }
-
-  // Once a special URL has a valid host, path/query/fragment bytes cannot make
-  // it structurally invalid: the full parser percent-encodes them as needed.
-  return true;
+  return parser::parse_url_impl<url_aggregator, true>(input, &base_agg)
+      .is_valid;
 }
-
-// @private
-// Fast-path validator for can_parse.
-//
-// Validates absolute special (non-file) URLs without constructing any
-// url_aggregator object and without running the state machine.
-// Performs a single forward scan over the input bytes.
-//
-// Returns:
-//   true      -- URL is structurally valid
-//   false     -- URL is definitely invalid
-//   nullopt   -- edge case; fall through to the full parser
-//               (credentials, IDNA, IPv4/6, tabs/newlines, relative URLs, ...)
-std::optional<bool> try_can_parse_absolute_fast(
-    std::string_view input) noexcept {
-  const uint8_t* b = reinterpret_cast<const uint8_t*>(input.data());
-  size_t len = input.size();
-
-  // -- Inline C0 whitespace trim (no allocation) --------------------------
-  // Note: \t (0x09), \n (0x0a), \r (0x0d) are all <= 0x20, so any
-  // leading/trailing tabs or newlines are correctly stripped here, matching
-  // the WHATWG spec's "remove leading/trailing C0 control and space" step.
-  while (len > 0 && b[0] <= 0x20) {
-    b++;
-    len--;
-  }
-  while (len > 0 && b[len - 1] <= 0x20) {
-    len--;
-  }
-  if (len == 0) return false;
-
-  // -- Scheme detection -----------------------------------------------------
-  // Fast path for HTTP and HTTPS (covers ~90%+ of real-world URLs).
-  // Avoids the general scheme loop, buffer copy, and perfect hash lookup.
-  // We know HTTP and HTTPS are special non-file schemes, so no further
-  // scheme_type checks are needed on the fast path -- only `pos` matters.
-  size_t pos;
-
-  if (len >= 7 && (b[0] | 0x20) == 'h' && (b[1] | 0x20) == 't' &&
-      (b[2] | 0x20) == 't' && (b[3] | 0x20) == 'p') {
-    if (b[4] == ':' && b[5] == '/' && b[6] == '/') {
-      pos = 7;
-      goto skip_extra_slashes;
-    }
-    if (len >= 8 && (b[4] | 0x20) == 's' && b[5] == ':' && b[6] == '/' &&
-        b[7] == '/') {
-      pos = 8;
-      goto skip_extra_slashes;
-    }
-    // Fall through: could be "httpe://", tabs in scheme, etc.
-  }
-
-  {
-    // General scheme detection for ws, wss, ftp, and edge cases.
-    if (!checkers::is_alpha(static_cast<char>(b[0]))) return false;
-
-    // Scan for ':' within the first 7 bytes. All special schemes are <= 5
-    // chars ("https"), so any URL whose first ':' is beyond byte 6 is either
-    // non-special or relative -- both require the full parser.
-    size_t colon_pos = 0;
-    for (size_t i = 1;; ++i) {
-      if (i >= 7 || i >= len) return std::nullopt;
-      const char c = static_cast<char>(b[i]);
-      if (c == ':') {
-        colon_pos = i;
-        break;
-      }
-      // Tabs/newlines in the scheme require the full parser to strip them.
-      if (c == '\t' || c == '\n' || c == '\r') return std::nullopt;
-      if (!unicode::is_alnum_plus(c)) return false;
-    }
-
-    // Lowercase scheme bytes inline and classify via the existing perfect
-    // hash.
-    char scheme_buf[6];
-    scheme_buf[0] = static_cast<char>(b[0] | 0x20);
-    for (size_t i = 1; i < colon_pos; ++i)
-      scheme_buf[i] = static_cast<char>(b[i] | 0x20);
-
-    const ada::scheme::type scheme_type =
-        ada::scheme::get_scheme_type({scheme_buf, colon_pos});
-
-    // Only handle special, non-file schemes.
-    if (scheme_type == ada::scheme::NOT_SPECIAL) return std::nullopt;
-    if (scheme_type == ada::scheme::FILE) return std::nullopt;
-
-    // Per WHATWG, special URLs don't require "//": "http:example.com" is valid
-    // (SPECIAL_AUTHORITY_IGNORE_SLASHES just skips leading slashes and
-    // proceeds to AUTHORITY).  Defer to the inline fallback for any input
-    // without "://".
-    pos = colon_pos + 1;
-    if (pos + 2 > len || b[pos] != '/' || b[pos + 1] != '/') {
-      return std::nullopt;
-    }
-    pos += 2;
-  }
-
-skip_extra_slashes:
-  // SPECIAL_AUTHORITY_IGNORE_SLASHES: the full parser skips any additional
-  // leading '/' or '\' after the initial "//".  Mirror that here so we don't
-  // mis-identify the host as empty when there are extra slashes.
-  while (pos < len && (b[pos] == '/' || b[pos] == '\\')) {
-    ++pos;
-  }
-
-  // Early IPv6 bail-out: if the authority starts with '[', it's an IPv6
-  // literal which requires the full parser.  Checking here avoids scanning
-  // the entire bracketed address only to bail out afterward.
-  if (pos < len && b[pos] == '[') return std::nullopt;
-
-  // -- Merged authority + host scan ------------------------------------------
-  // A single forward pass over the authority bytes that simultaneously:
-  //   - finds the authority end and port colon
-  //   - validates host characters (forbidden domain code points)
-  //   - tracks IPv4 indicators (all-decimal-dots, last non-dot char)
-  //   - detects xn-- prefixes (IDNA punycode)
-  //   - detects tabs/newlines (which require the full parser to strip)
-  // This replaces 4 separate scans over the host bytes.
-  const size_t auth_start = pos;
-  size_t auth_end = pos;
-  size_t port_colon = SIZE_MAX;
-  bool all_dec_dots = true;
-
-  for (; auth_end < len; ++auth_end) {
-    const uint8_t c = b[auth_end];
-
-    // Non-ASCII -> needs IDNA processing -> full parser.
-    if (c >= 0x80) return std::nullopt;
-
-    // Authority delimiters.
-    if (c == '/' || c == '?' || c == '#' || c == '\\') break;
-
-    // Port separator.
-    if (c == ':') {
-      if (port_colon == SIZE_MAX) port_colon = auth_end;
-      continue;
-    }
-
-    // Credentials or percent-encoding -> full parser.
-    if (c == '@' || c == '%') return std::nullopt;
-
-    // Tabs/newlines anywhere in the authority require the full parser to
-    // strip them before validation.  Without this, a tab in the port (e.g.
-    // "http://host:8\t0/") would be mis-rejected by port validation.
-    if (c == '\t' || c == '\n' || c == '\r') return std::nullopt;
-
-    // Skip remaining host-specific checks for port bytes.  Port digits are
-    // validated separately below, and no forbidden-domain-code-point check
-    // is needed on port characters.
-    if (port_colon != SIZE_MAX) continue;
-
-    // -- Host byte validation (inlined) ------------------------------------
-    // Forbidden domain code points that are not already caught above:
-    //   C0 controls and space (0x00-0x20), DEL (0x7F), <, >, [, ], ^, |.
-    // At this stage, the input may still be userinfo or be normalized later
-    // (e.g., percent-encoded), so we do not reject here and defer to the
-    // parser. Characters already caught: >= 0x80 (non-ASCII), '/' '?' '#' '\\'
-    // (delimiters), ':' (port), '@' '%' (bail), '\t' '\n' '\r' (bail).
-    if (c <= 0x20 || c == 0x7F || c == '<' || c == '>' || c == '[' ||
-        c == ']' || c == '^' || c == '|') {
-      return std::nullopt;
-    }
-
-    // Track whether host is all decimal digits and dots (potential IPv4).
-    if (c != '.' && (c < '0' || c > '9')) all_dec_dots = false;
-
-    // Detect xn-- prefix inline (IDNA punycode -> needs full parser).
-    // Checking at every position mirrors the original behavior: any
-    // occurrence of "xn--" in the host (not just at label boundaries)
-    // triggers a bail-out to the full IDNA validator.
-    if ((c | 0x20) == 'x' && auth_end + 4 <= len &&
-        (b[auth_end + 1] | 0x20) == 'n' && b[auth_end + 2] == '-' &&
-        b[auth_end + 3] == '-') {
-      return std::nullopt;
-    }
-  }
-
-  const size_t host_end = (port_colon != SIZE_MAX) ? port_colon : auth_end;
-
-  // Empty host is invalid for special URLs.
-  if (auth_start == host_end) return false;
-
-  // -- IPv4 handling ---------------------------------------------------------
-  const char* host_ptr = reinterpret_cast<const char*>(b + auth_start);
-  const size_t host_len = host_end - auth_start;
-
-  if (all_dec_dots) {
-    // Host is all decimal digits and dots -> try the fast IPv4 parser.
-    if (checkers::try_parse_ipv4_fast({host_ptr, host_len}) !=
-        checkers::ipv4_fast_fail) {
-      // Valid decimal IPv4 host.  Do NOT return true yet: the port still
-      // needs to be validated below before we can declare the URL valid.
-      goto validate_port;
-    }
-    // Fast IPv4 parsing failed (e.g. host is ".", "..", "1.2.3.500").
-    // Such hosts may still be valid domain names; defer to the full parser.
-    return std::nullopt;
-  }
-
-  if (checkers::last_label_may_be_a_number({host_ptr, host_len})) {
-    return std::nullopt;
-  }
-
-  // -- Port validation -------------------------------------------------------
-validate_port:
-  if (port_colon != SIZE_MAX) {
-    const uint8_t* pp = b + port_colon + 1;
-    size_t pl = auth_end - port_colon - 1;
-    if (pl > 0) {
-      // Strip leading zeros: "0000001" == 1, "0000000000000" == 0, both valid.
-      // Only the significant digits count toward the 5-digit maximum.
-      while (pl > 0 && *pp == '0') {
-        ++pp;
-        --pl;
-      }
-      if (pl > 5) return false;  // significant digits > 99999
-      uint32_t pv = 0;
-      for (size_t i = 0; i < pl; ++i) {
-        if (pp[i] < '0' || pp[i] > '9') return false;
-        pv = pv * 10 + (pp[i] - '0');
-      }
-      if (pv > 65535) return false;
-    }
-  }
-
-  // Path, query, and fragment are structurally always valid for can_parse --
-  // the parser would encode whatever is there.
-  return true;
-}
-
-}  // namespace
-
-template <class result_type>
-ada_warn_unused tl::expected<result_type, errors> parse(
-    std::string_view input, const result_type* base_url) {
-  if (base_url == nullptr) [[likely]] {
-    if (input.size() > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
-      return tl::unexpected(errors::type_error);
-    }
-    if (max_input_length_customized && input.size() > get_max_input_length())
-        [[unlikely]] {
-      return tl::unexpected(errors::type_error);
-    }
-    result_type u{};
-    if (ada::parser::try_parse_simple_absolute(input, u)) [[likely]] {
-      // Default max is ~4 GB; only re-check expansion when the input
-      // could grow past that (or past a customized limit).
-      if (max_input_length_customized) [[unlikely]] {
-        const uint32_t max_length = get_max_input_length();
-        if (input.size() > static_cast<size_t>(max_length) / 5 &&
-            u.get_href_size() > max_length) {
-          return tl::unexpected(errors::type_error);
-        }
-      } else if (input.size() > std::numeric_limits<uint32_t>::max() / 5)
-          [[unlikely]] {
-        if (u.get_href_size() > std::numeric_limits<uint32_t>::max()) {
-          return tl::unexpected(errors::type_error);
-        }
-      }
-      return u;
-    }
-    ada::parser::parse_url_impl_into<result_type, true>(u, input, nullptr,
-                                                        false);
-    if (!u.is_valid) {
-      return tl::unexpected(errors::type_error);
-    }
-    return u;
-  }
-  result_type u = ada::parser::parse_url_impl<result_type>(input, base_url);
-  if (!u.is_valid) {
-    return tl::unexpected(errors::type_error);
-  }
-  return u;
-}
-
-template ada::result<url> parse<url>(std::string_view input,
-                                     const url* base_url = nullptr);
-template ada::result<url_aggregator> parse<url_aggregator>(
-    std::string_view input, const url_aggregator* base_url = nullptr);
 
 std::string href_from_file(std::string_view input) {
   // Match ada::parse / setters: refuse inputs that already exceed the limit.
@@ -616,97 +105,6 @@ std::string href_from_file(std::string_view input) {
     return {};
   }
   return result;
-}
-
-bool can_parse(std::string_view input, const std::string_view* base_input) {
-  // Must match parse().has_value(), including post-normalization max length.
-  // Percent-encoding expands a byte by at most 3x, but IDNA expands more: a
-  // 3-byte UTF-8 label such as U+337F becomes the 17-byte "xn--6oqv20b1zgzxr",
-  // so a dotted host sustains 4.5x. When the input (plus base, if any) fits in
-  // max_length/5, the normalized href cannot exceed max_length, so
-  // validation-only parsing (store_values=false) is safe.
-
-  // Hot path first: absolute special URLs, no base. Avoid loading max_length
-  // until we need it (common absolute-fast true/false cases).
-  if (base_input == nullptr) {
-    auto r = try_can_parse_clean_http(input);
-    if (!r.has_value()) {
-      r = try_can_parse_absolute_fast(input);
-    }
-    if (r.has_value()) {
-      if (!*r) {
-        return false;
-      }
-      // size <= max/5 => normalized href cannot exceed max (4.5x expansion).
-      // Default max is ~4 GB: skip the atomic on typical inputs.
-      if (!max_input_length_customized) [[likely]] {
-        if (input.size() > std::numeric_limits<uint32_t>::max() / 5)
-            [[unlikely]] {
-          return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
-                                                                        nullptr)
-              .is_valid;
-        }
-        return true;
-      }
-      const uint32_t max_length = ada::get_max_input_length();
-      if (input.size() <= static_cast<size_t>(max_length) / 5) {
-        return true;
-      }
-      if (input.size() > max_length) {
-        return false;
-      }
-      return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
-                                                                    nullptr)
-          .is_valid;
-    }
-  }
-
-  const uint32_t max_length = ada::get_max_input_length();
-  if (input.size() > max_length) {
-    return false;
-  }
-  if (base_input != nullptr && base_input->size() > max_length) {
-    return false;
-  }
-
-  // Relative resolution combines base + input; bound the sum so 4.5x expansion
-  // of either side cannot push the final href past max_length.
-  const size_t combined =
-      input.size() + (base_input == nullptr ? 0 : base_input->size());
-  const bool size_safe = combined <= static_cast<size_t>(max_length) / 5;
-
-  if (size_safe) {
-    // Validation-only: no buffer build, host still fully checked.
-    ada::url_aggregator base_agg;
-    ada::url_aggregator* base_ptr = nullptr;
-    if (base_input != nullptr) {
-      base_agg = ada::parser::parse_url_impl<ada::url_aggregator, false>(
-          *base_input, nullptr);
-      if (!base_agg.is_valid) {
-        return false;
-      }
-      base_ptr = &base_agg;
-    }
-    return ada::parser::parse_url_impl<ada::url_aggregator, false>(input,
-                                                                   base_ptr)
-        .is_valid;
-  }
-
-  // Near the limit: full parse so post-normalization length matches parse().
-  if (base_input == nullptr) {
-    return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
-                                                                  nullptr)
-        .is_valid;
-  }
-  ada::url_aggregator base_agg =
-      ada::parser::parse_url_impl<ada::url_aggregator, true>(*base_input,
-                                                             nullptr);
-  if (!base_agg.is_valid) {
-    return false;
-  }
-  return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
-                                                                &base_agg)
-      .is_valid;
 }
 
 ada_warn_unused std::string_view to_string(ada::encoding_type type) {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -7,6 +7,13 @@
 #include <optional>
 #include <string_view>
 
+#if ADA_SSE2
+#include <emmintrin.h>
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+#include <intrin.h>
+#endif
+#endif
+
 #include "ada/checkers-inl.h"
 #include "ada/checkers.h"
 #include "ada/common_defs.h"
@@ -21,8 +28,13 @@ namespace ada {
 static std::atomic<uint32_t> max_input_length_{
     std::numeric_limits<uint32_t>::max()};
 
+// parse() / parse_url_impl read this instead of always hitting the atomic.
+// Restored to false when the limit is set back to the ~4 GB default.
+bool max_input_length_customized = false;
+
 void set_max_input_length(uint32_t length) {
   max_input_length_.store(length, std::memory_order_relaxed);
+  max_input_length_customized = length != std::numeric_limits<uint32_t>::max();
 }
 
 uint32_t get_max_input_length() {
@@ -71,6 +83,54 @@ ada_really_inline bool eight_clean_http_host_bytes(
                       swar_in_range(w, '_', '_') | swar_in_range(w, '~', '~');
   return ok == k_high;
 }
+
+#if ADA_SSE2
+ada_really_inline int ctz32(unsigned bits) noexcept {
+#ifdef ADA_REGULAR_VISUAL_STUDIO
+  unsigned long ret;
+  _BitScanForward(&ret, bits);
+  return static_cast<int>(ret);
+#else
+  return __builtin_ctz(bits);
+#endif
+}
+
+// Bits set where the byte is not in [a-z0-9-._~]. That includes / ? #.
+ada_really_inline int sse2_unclean_http_host(__m128i w) noexcept {
+  const __m128i az = _mm_and_si128(
+      _mm_cmpgt_epi8(w, _mm_set1_epi8(static_cast<char>('a' - 1))),
+      _mm_cmplt_epi8(w, _mm_set1_epi8(static_cast<char>('z' + 1))));
+  const __m128i d09 = _mm_and_si128(
+      _mm_cmpgt_epi8(w, _mm_set1_epi8(static_cast<char>('0' - 1))),
+      _mm_cmplt_epi8(w, _mm_set1_epi8(static_cast<char>('9' + 1))));
+  const __m128i spec =
+      _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('-')),
+                                _mm_cmpeq_epi8(w, _mm_set1_epi8('.'))),
+                   _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('_')),
+                                _mm_cmpeq_epi8(w, _mm_set1_epi8('~'))));
+  return _mm_movemask_epi8(_mm_or_si128(_mm_or_si128(az, d09), spec)) ^ 0xFFFF;
+}
+
+ada_really_inline bool sse2_http_host_delim(uint8_t c) noexcept {
+  return c == '/' || c == '?' || c == '#';
+}
+
+ada_really_inline bool mask_has_xn(const uint8_t* bytes, size_t at, int x_mask,
+                                   size_t length) noexcept {
+  if (x_mask == 0) {
+    return false;
+  }
+  unsigned bits = static_cast<unsigned>(x_mask);
+  do {
+    const size_t pos = at + static_cast<size_t>(ctz32(bits));
+    if (pos + 2 < length && bytes[pos + 1] == 'n' && bytes[pos + 2] == '-') {
+      return true;
+    }
+    bits &= bits - 1;
+  } while (bits != 0);
+  return false;
+}
+#endif
 
 // Minimal front end for the overwhelmingly common already-canonical HTTP(S)
 // case. It deliberately handles fewer inputs than
@@ -131,20 +191,94 @@ std::optional<bool> try_can_parse_clean_http(std::string_view input) noexcept {
   }
 
   size_t cursor = authority_start;
-  while (cursor + 8 <= length && eight_clean_http_host_bytes(bytes + cursor)) {
-    cursor += 8;
-  }
-  while (cursor < length) {
-    const uint8_t c = bytes[cursor];
-    if (c == '/' || c == '?' || c == '#') {
-      break;
+#if ADA_SSE2
+  const __m128i x_splat = _mm_set1_epi8('x');
+  // 0 = window was clean (keep scanning), 1 = host delimiter, -1 = fall through
+  auto visit16 = [&](size_t at, int keep) -> int {
+    const __m128i w =
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(bytes + at));
+    const int unclean = sse2_unclean_http_host(w) & keep;
+    const int xs = _mm_movemask_epi8(_mm_cmpeq_epi8(w, x_splat)) & keep;
+    if (unclean == 0) {
+      return (xs != 0 && mask_has_xn(bytes, at, xs, length)) ? -1 : 0;
     }
-    if (!clean_http_host_byte[c]) {
+    const int hit = ctz32(static_cast<unsigned>(unclean));
+    const int valid = (1 << hit) - 1;
+    if (mask_has_xn(bytes, at, xs & valid, length)) {
+      return -1;
+    }
+    cursor = at + static_cast<size_t>(hit);
+    return sse2_http_host_delim(bytes[cursor]) ? 1 : -1;
+  };
+
+  if (length - authority_start >= 16) {
+    for (; cursor + 16 <= length; cursor += 16) {
+      const int r = visit16(cursor, 0xFFFF);
+      if (r < 0) {
+        return std::nullopt;
+      }
+      if (r > 0) {
+        goto host_done;
+      }
+    }
+    if (cursor < length) {
+      const size_t at = length - 16;
+      const int skip = static_cast<int>(cursor - at);
+      const int keep = static_cast<int>(~((1u << skip) - 1u));
+      const int r = visit16(at, keep);
+      if (r < 0) {
+        return std::nullopt;
+      }
+      if (r > 0) {
+        goto host_done;
+      }
+      cursor = length;
+    }
+  } else if (length >= 16) {
+    const size_t at = length - 16;
+    const int skip = static_cast<int>(authority_start - at);
+    const int keep = static_cast<int>(~((1u << skip) - 1u));
+    const int r = visit16(at, keep);
+    if (r < 0) {
       return std::nullopt;
     }
-    ++cursor;
+    if (r > 0) {
+      goto host_done;
+    }
+    cursor = length;
+  } else
+#endif
+  {
+    while (cursor + 8 <= length &&
+           eight_clean_http_host_bytes(bytes + cursor)) {
+      if (std::memchr(bytes + cursor, 'x', 8) != nullptr) {
+        for (size_t k = 0; k < 8; ++k) {
+          const size_t pos = cursor + k;
+          if (bytes[pos] == 'x' && pos + 2 < length && bytes[pos + 1] == 'n' &&
+              bytes[pos + 2] == '-') {
+            return std::nullopt;
+          }
+        }
+      }
+      cursor += 8;
+    }
+    while (cursor < length) {
+      const uint8_t c = bytes[cursor];
+      if (c == '/' || c == '?' || c == '#') {
+        break;
+      }
+      if (!clean_http_host_byte[c]) {
+        return std::nullopt;
+      }
+      if (c == 'x' && cursor + 2 < length && bytes[cursor + 1] == 'n' &&
+          bytes[cursor + 2] == '-') {
+        return std::nullopt;
+      }
+      ++cursor;
+    }
   }
 
+host_done:
   const size_t host_length = cursor - authority_start;
   if (host_length == 0) {
     // Extra special-scheme slashes are normalization, not an empty host.
@@ -157,12 +291,11 @@ std::optional<bool> try_can_parse_clean_http(std::string_view input) noexcept {
     return std::nullopt;
   }
 
-  const std::string_view host(input.data() + authority_start, host_length);
-  if (checkers::last_label_may_be_a_number(host)) {
-    return std::nullopt;
-  }
-  if (host.find('x') != std::string_view::npos &&
-      host.find("xn-") != std::string_view::npos) {
+  const char lastc = static_cast<char>(bytes[cursor - 1]);
+  // 'm'/'g'/... are not IPv4 number chars, so .com/.org never walk.
+  if (checkers::is_ipv4_number_char(lastc) &&
+      checkers::last_label_may_be_a_number(
+          std::string_view(input.data() + authority_start, host_length))) {
     return std::nullopt;
   }
 
@@ -405,6 +538,39 @@ validate_port:
 template <class result_type>
 ada_warn_unused tl::expected<result_type, errors> parse(
     std::string_view input, const result_type* base_url) {
+  if (base_url == nullptr) [[likely]] {
+    if (input.size() > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
+      return tl::unexpected(errors::type_error);
+    }
+    if (max_input_length_customized && input.size() > get_max_input_length())
+        [[unlikely]] {
+      return tl::unexpected(errors::type_error);
+    }
+    result_type u{};
+    if (ada::parser::try_parse_simple_absolute(input, u)) [[likely]] {
+      // Default max is ~4 GB; only re-check expansion when the input
+      // could grow past that (or past a customized limit).
+      if (max_input_length_customized) [[unlikely]] {
+        const uint32_t max_length = get_max_input_length();
+        if (input.size() > static_cast<size_t>(max_length) / 5 &&
+            u.get_href_size() > max_length) {
+          return tl::unexpected(errors::type_error);
+        }
+      } else if (input.size() > std::numeric_limits<uint32_t>::max() / 5)
+          [[unlikely]] {
+        if (u.get_href_size() > std::numeric_limits<uint32_t>::max()) {
+          return tl::unexpected(errors::type_error);
+        }
+      }
+      return u;
+    }
+    ada::parser::parse_url_impl_into<result_type, true>(u, input, nullptr,
+                                                        false);
+    if (!u.is_valid) {
+      return tl::unexpected(errors::type_error);
+    }
+    return u;
+  }
   result_type u = ada::parser::parse_url_impl<result_type>(input, base_url);
   if (!u.is_valid) {
     return tl::unexpected(errors::type_error);
@@ -472,7 +638,16 @@ bool can_parse(std::string_view input, const std::string_view* base_input) {
         return false;
       }
       // size <= max/5 => normalized href cannot exceed max (4.5x expansion).
-      // Check this first: default max is ~4GB so almost all URLs return true.
+      // Default max is ~4 GB: skip the atomic on typical inputs.
+      if (!max_input_length_customized) [[likely]] {
+        if (input.size() > std::numeric_limits<uint32_t>::max() / 5)
+            [[unlikely]] {
+          return ada::parser::parse_url_impl<ada::url_aggregator, true>(input,
+                                                                        nullptr)
+              .is_valid;
+        }
+        return true;
+      }
       const uint32_t max_length = ada::get_max_input_length();
       if (input.size() <= static_cast<size_t>(max_length) / 5) {
         return true;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,3 +1,5 @@
+#include "ada.h"
+#include "ada/parser.h"
 #include "ada/parser-inl.h"
 
 #include <array>
@@ -18,6 +20,8 @@
 #include "ada/unicode.h"
 #include "ada/serializers.h"
 #include "ada/url.h"
+#include "ada/url-inl.h"
+#include "ada/url_base-inl.h"
 #include "ada/url_aggregator.h"
 #include "ada/url_aggregator-inl.h"
 #include "ada/url_ip-inl.h"
@@ -42,14 +46,21 @@
 #endif
 
 #ifdef ADA_PARSER_NEED_SSSE3_TARGET
-// Scanners and the never_inline fast-path entry points share target("ssse3")
-// so the compiler can inline pshufb loops into try_parse_*. parse_url_impl
-// stays baseline and only calls the noinline entries. COLD helpers also
-// need the target so they can call the pshufb scanners, but they live in
-// .text.unlikely so they do not displace setter I-cache.
-#define ADA_PARSER_SIMD __attribute__((target("ssse3")))
+#if defined(__clang__)
+// clang ignores #pragma GCC target and treats unknown pragmas as
+// errors under -Werror. Per-function target() works; do not
+// always_inline the pshufb helpers (lambdas do not inherit target).
+#define ADA_PARSER_SIMD inline __attribute__((target("ssse3")))
 #define ADA_PARSER_FASTPATH __attribute__((target("ssse3"), noinline))
 #define ADA_PARSER_COLD __attribute__((target("ssse3"), noinline, cold))
+#else
+// gcc: file-scope pragma so lambdas inherit SSSE3 and always_inline
+// pshufb helpers can inline. parse_url_impl stays outside the pragma.
+#define ADA_PARSER_SIMD ada_really_inline
+#define ADA_PARSER_FASTPATH ada_never_inline
+#define ADA_PARSER_COLD ada_never_inline ada_cold
+#define ADA_PARSER_ENABLE_SSSE3_PRAGMA 1
+#endif
 #else
 #define ADA_PARSER_SIMD ada_really_inline
 #define ADA_PARSER_FASTPATH ada_never_inline
@@ -66,6 +77,12 @@ extern bool max_input_length_customized;
 
 namespace ada::parser {
 
+#ifdef ADA_PARSER_ENABLE_SSSE3_PRAGMA
+#pragma GCC push_options
+#pragma GCC target("ssse3")
+#endif
+
+#if !defined(ADA_SKIP_PARSER_FASTPATH) || !defined(ADA_SKIP_PARSER_FINISH)
 // Classification tables and 16-byte run scanners for the absolute-URL fast
 // path. Inspired by oven-sh/WebKit#452 and #454: scan 16 bytes at a time
 // (nibble-table pshufb/tbl when SSSE3 or NEON is available), and when the
@@ -234,6 +251,24 @@ ada_really_inline void set_plain_host_components(
   c.host_start = host_off;
   c.host_end = host_end;
   c.port = port;
+  c.pathname_start = pathname_start;
+  c.search_start = search_start;
+  c.hash_start = hash_start;
+}
+
+// npos truncated to uint32_t is omitted, so the 99% has-path finish
+// can store query/hash starts without a cmov against string_view::npos.
+static_assert(static_cast<uint32_t>(std::string_view::npos) ==
+              url_components::omitted);
+
+// https:// is ~96% of the dataset: protocol_end=6, host at 8, port omitted.
+ada_really_inline void set_https_plain_host_components(
+    url_components& c, uint32_t host_end, uint32_t pathname_start,
+    uint32_t search_start, uint32_t hash_start) noexcept {
+  c.protocol_end = 6;
+  c.username_end = 8;
+  c.host_start = 8;
+  c.host_end = host_end;
   c.pathname_start = pathname_start;
   c.search_start = search_start;
   c.hash_start = hash_start;
@@ -1195,6 +1230,46 @@ bool path_has_dot_segment(std::string_view path) noexcept {
   return false;
 }
 
+// Bodies live here so the finish TU does not depend on always_inline
+// unicode.cpp helpers (no standalone symbol).
+ada_really_inline constexpr bool is_single_dot_seg(
+    std::string_view input) noexcept {
+  return input == "." || input == "%2e" || input == "%2E";
+}
+
+ada_really_inline bool is_double_dot_seg(std::string_view input) noexcept {
+  return input == ".." || input == ".%2e" || input == ".%2E" ||
+         input == "%2e." || input == "%2E." || input == "%2e%2e" ||
+         input == "%2E%2E" || input == "%2E%2e" || input == "%2e%2E";
+}
+
+// Local copy so the fast-path TU does not depend on always_inline
+// unicode.cpp (no standalone symbol).
+ada_really_inline bool ascii_to_lower(char* input, size_t length) noexcept {
+  constexpr uint64_t broadcast_80 = 0x8080808080808080ull;
+  constexpr uint64_t broadcast_Ap = 0x101010101010101ull * (128 - 'A');
+  constexpr uint64_t broadcast_Zp = 0x101010101010101ull * (128 - 'Z' - 1);
+  uint64_t non_ascii = 0;
+  size_t i = 0;
+  for (; i + 7 < length; i += 8) {
+    uint64_t word{};
+    std::memcpy(&word, input + i, sizeof(word));
+    non_ascii |= (word & broadcast_80);
+    word ^=
+        (((word + broadcast_Ap) ^ (word + broadcast_Zp)) & broadcast_80) >> 2;
+    std::memcpy(input + i, &word, sizeof(word));
+  }
+  if (i < length) {
+    uint64_t word{};
+    std::memcpy(&word, input + i, length - i);
+    non_ascii |= (word & broadcast_80);
+    word ^=
+        (((word + broadcast_Ap) ^ (word + broadcast_Zp)) & broadcast_80) >> 2;
+    std::memcpy(input + i, &word, length - i);
+  }
+  return non_ascii == 0;
+}
+
 // True when a path segment is "." / ".." or a percent-encoded form
 // ("%2e", "%2e%2e", ".%2e", "%2e.") that the path helpers would collapse.
 bool path_has_percent_encoded_dot_segment(std::string_view path) noexcept {
@@ -1203,8 +1278,7 @@ bool path_has_percent_encoded_dot_segment(std::string_view path) noexcept {
     const size_t end = path.find('/', i);
     const size_t seg_end = (end == std::string_view::npos) ? path.size() : end;
     const std::string_view seg(path.data() + i, seg_end - i);
-    if (unicode::is_single_dot_path_segment(seg) ||
-        unicode::is_double_dot_path_segment(seg)) {
+    if (is_single_dot_seg(seg) || is_double_dot_seg(seg)) {
       return true;
     }
     if (end == std::string_view::npos) {
@@ -1314,7 +1388,7 @@ ada_never_inline bool reject_uppercase_plain_host(const char* host,
                                                   size_t host_len) noexcept {
   char host_buf[256];
   std::memcpy(host_buf, host, host_len);
-  unicode::to_lower_ascii(host_buf, host_len);
+  ascii_to_lower(host_buf, host_len);
   const std::string_view hv(host_buf, host_len);
   if (ada::checkers::last_label_may_be_a_number(hv)) {
     return true;
@@ -1364,6 +1438,7 @@ ada_cold uint64_t try_parse_ipv4_any(std::string_view input) noexcept {
   return ipv4;
 }
 
+#if !defined(ADA_SKIP_PARSER_FASTPATH)
 ada_really_inline char* write_u8_dec(char* p, uint8_t v) noexcept {
   if (v < 10) {
     *p++ = static_cast<char>('0' + v);
@@ -1390,6 +1465,7 @@ ada_cold size_t write_ipv4_dotted(char* buf, uint32_t addr) noexcept {
   p = write_u8_dec(p, static_cast<uint8_t>(addr));
   return static_cast<size_t>(p - buf);
 }
+#endif  // ADA_SKIP_PARSER_FASTPATH
 
 // true => leave the simple-absolute path. false => stay; may set is_ipv4
 // and ask the caller to rewrite the host to dotted-decimal.
@@ -1416,8 +1492,29 @@ ada_never_inline ada_cold bool reject_or_classify_numeric_last_label(
   return true;
 }
 
-}  // namespace
+// Visible in this TU so finish helpers can run outside the unity build.
+// unicode::has_tabs_or_newline / is_c0_control_or_space are always_inline
+// in unicode.cpp and have no standalone symbol.
+ada_really_inline bool view_has_tab_or_newline(
+    std::string_view input) noexcept {
+  for (const char c : input) {
+    if (c == '\t' || c == '\n' || c == '\r') {
+      return true;
+    }
+  }
+  return false;
+}
 
+ada_really_inline bool trailing_c0_or_tab_newline(
+    std::string_view input) noexcept {
+  return static_cast<unsigned char>(input.back()) <= ' ' ||
+         view_has_tab_or_newline(input);
+}
+
+}  // namespace
+#endif  // scanners (fast path or finish)
+
+#ifndef ADA_SKIP_PARSER_FINISH
 // Percent-encoding / dot-segment handoff. Kept out of the already-canonical
 // fast-path I-cache: this is the uncommon rest_simple=false tail.
 template <class result_type>
@@ -1449,20 +1546,20 @@ ada_never_inline ada_cold void finish_simple_absolute_handoff(
   if constexpr (is_aggregator) {
     out.buffer.assign(input.substr(0, host_end));
     if (has_upper) {
-      unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
+      ascii_to_lower(out.buffer.data() + host_start, host_len);
     }
     set_plain_host_components(out.components, protocol_end,
                               static_cast<uint32_t>(host_end),
                               static_cast<uint32_t>(host_end),
                               url_components::omitted, url_components::omitted);
-    out.parse_path(path_view);
+    out.parse_path_outlined(path_view);
     apply_query_and_hash();
   } else {
     out.host.emplace(input.data() + host_start, host_len);
     if (has_upper) {
-      unicode::to_lower_ascii(out.host->data(), host_len);
+      ascii_to_lower(out.host->data(), host_len);
     }
-    out.parse_path(path_view);
+    out.parse_path_outlined(path_view);
     apply_query_and_hash();
   }
 }
@@ -1603,8 +1700,7 @@ after_rest:
   // fragment reaching the helpers below would keep those bytes percent-encoded
   // ("?a\nb" -> "?a%0Ab", "#f " -> "#f%20") instead of stripped, so hand such
   // inputs back to the slow path.
-  if (!rest_simple && (unicode::is_c0_control_or_space(input.back()) ||
-                       unicode::has_tabs_or_newline(input))) {
+  if (!rest_simple && trailing_c0_or_tab_newline(input)) {
     return false;
   }
 
@@ -1638,23 +1734,23 @@ after_rest:
         append_canonical_port(out.buffer, parsed_port);
       }
       if (has_upper) {
-        unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
+        ascii_to_lower(out.buffer.data() + host_start, host_len);
       }
       set_plain_host_components(
           out.components, protocol_end, static_cast<uint32_t>(host_end),
           static_cast<uint32_t>(out.buffer.size()), url_components::omitted,
           url_components::omitted, parsed_port);
-      out.parse_path(path_view);
+      out.parse_path_outlined(path_view);
       apply_query_and_hash();
     } else {
       out.host.emplace(input.data() + host_start, host_len);
       if (has_upper) {
-        unicode::to_lower_ascii(out.host->data(), host_len);
+        ascii_to_lower(out.host->data(), host_len);
       }
       if (parsed_port != url_components::omitted) {
         out.port = static_cast<uint16_t>(parsed_port);
       }
-      out.parse_path(path_view);
+      out.parse_path_outlined(path_view);
       apply_query_and_hash();
     }
     return true;
@@ -1682,7 +1778,7 @@ after_rest:
       }
     }
     if (has_upper) {
-      unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
+      ascii_to_lower(out.buffer.data() + host_start, host_len);
     }
     const uint32_t pathname_start =
         static_cast<uint32_t>(host_end) + port_bytes;
@@ -1704,13 +1800,13 @@ after_rest:
   } else {
     out.host.emplace(input.data() + host_start, host_len);
     if (has_upper) {
-      unicode::to_lower_ascii(out.host->data(), host_len);
+      ascii_to_lower(out.host->data(), host_len);
     }
     if (parsed_port != url_components::omitted) {
       out.port = static_cast<uint16_t>(parsed_port);
     }
     if (insert_slash) {
-      out.path = "/";
+      out.path.assign(1, '/');
     } else {
       out.path.assign(input.data() + path_start, path_end - path_start);
     }
@@ -1864,8 +1960,7 @@ after_rest:
     }
   }
 
-  if (!rest_simple && (unicode::is_c0_control_or_space(input.back()) ||
-                       unicode::has_tabs_or_newline(input))) {
+  if (!rest_simple && trailing_c0_or_tab_newline(input)) {
     return false;
   }
 
@@ -1909,14 +2004,14 @@ after_rest:
                                 static_cast<uint32_t>(out.buffer.size()),
                                 url_components::omitted,
                                 url_components::omitted, parsed_port);
-      out.parse_path(path_view);
+      out.parse_path_outlined(path_view);
       apply_query_and_hash();
     } else {
       out.host.emplace(host);
       if (parsed_port != url_components::omitted) {
         out.port = static_cast<uint16_t>(parsed_port);
       }
-      out.parse_path(path_view);
+      out.parse_path_outlined(path_view);
       apply_query_and_hash();
     }
     return true;
@@ -1960,7 +2055,7 @@ after_rest:
       out.port = static_cast<uint16_t>(parsed_port);
     }
     if (insert_slash) {
-      out.path = "/";
+      out.path.assign(1, '/');
     } else {
       out.path.assign(input.data() + path_start, path_end - path_start);
     }
@@ -2192,7 +2287,7 @@ ADA_PARSER_COLD bool try_finish_simple_userinfo(std::string_view input,
       }
     }
     if (has_upper) {
-      unicode::to_lower_ascii(out.buffer.data() + host_begin, host_len);
+      ascii_to_lower(out.buffer.data() + host_begin, host_len);
     }
     out.components.protocol_end = protocol_end;
     out.components.username_end = username_end;
@@ -2213,13 +2308,13 @@ ADA_PARSER_COLD bool try_finish_simple_userinfo(std::string_view input,
     out.password.assign(password);
     out.host.emplace(input.substr(host_begin, host_len));
     if (has_upper) {
-      unicode::to_lower_ascii(out.host->data(), host_len);
+      ascii_to_lower(out.host->data(), host_len);
     }
     if (parsed_port != url_components::omitted) {
       out.port = static_cast<uint16_t>(parsed_port);
     }
     if (insert_slash) {
-      out.path = "/";
+      out.path.assign(1, '/');
     } else {
       out.path.assign(input.substr(path_start, path_end - path_start));
     }
@@ -2235,6 +2330,45 @@ ADA_PARSER_COLD bool try_finish_simple_userinfo(std::string_view input,
   return true;
 }
 
+template bool finish_simple_absolute_with_port<url>(std::string_view, url&,
+                                                    ada::scheme::type, uint32_t,
+                                                    size_t, size_t, size_t,
+                                                    bool);
+template bool finish_simple_absolute_with_port<url_aggregator>(
+    std::string_view, url_aggregator&, ada::scheme::type, uint32_t, size_t,
+    size_t, size_t, bool);
+template bool finish_simple_absolute_literal_host<url>(std::string_view, url&,
+                                                       ada::scheme::type,
+                                                       uint32_t, size_t, size_t,
+                                                       std::string_view,
+                                                       url_host_type);
+template bool finish_simple_absolute_literal_host<url_aggregator>(
+    std::string_view, url_aggregator&, ada::scheme::type, uint32_t, size_t,
+    size_t, std::string_view, url_host_type);
+template bool try_finish_simple_userinfo<url>(std::string_view, url&,
+                                              ada::scheme::type, uint32_t,
+                                              size_t);
+template bool try_finish_simple_userinfo<url_aggregator>(std::string_view,
+                                                         url_aggregator&,
+                                                         ada::scheme::type,
+                                                         uint32_t, size_t);
+template bool try_finish_simple_ipv6<url>(std::string_view, url&,
+                                          ada::scheme::type, uint32_t, size_t);
+template bool try_finish_simple_ipv6<url_aggregator>(std::string_view,
+                                                     url_aggregator&,
+                                                     ada::scheme::type,
+                                                     uint32_t, size_t);
+template void finish_simple_absolute_handoff<url>(std::string_view, url&,
+                                                  size_t, size_t, size_t,
+                                                  uint32_t, bool, bool, size_t,
+                                                  size_t, size_t, size_t);
+template void finish_simple_absolute_handoff<url_aggregator>(
+    std::string_view, url_aggregator&, size_t, size_t, size_t, uint32_t, bool,
+    bool, size_t, size_t, size_t, size_t);
+
+#endif  // ADA_SKIP_PARSER_FINISH
+
+#ifndef ADA_SKIP_PARSER_FASTPATH
 // Fast path for already-canonical special-scheme URLs of the shape
 // scheme://host[/path][?query][#fragment]. When the host is a plain domain
 // but the rest needs encoding or dot-segment normalization, the host is
@@ -2311,47 +2445,39 @@ ADA_PARSER_FASTPATH bool try_parse_simple_absolute(std::string_view input,
     if (lastc == '.' && host_len > 1) {
       lastc = b[host_end - 2];
     }
-    if (has_upper) [[unlikely]] {
-      if (reject_uppercase_plain_host(input.data() + host_start, host_len)) {
+    // .com/.org last letters are outside 0-9a-fxX, so this is one
+    // not-taken branch on the common path instead of has_upper /
+    // ipv4-char / has_xn as three separate checks.
+    const bool rare_host =
+        has_xn || has_upper ||
+        ada::checkers::is_ipv4_number_char(static_cast<char>(lastc));
+    if (rare_host) [[unlikely]] {
+      if (has_xn) {
         return false;
       }
-    } else if (ada::checkers::is_ipv4_number_char(static_cast<char>(lastc)))
-        [[unlikely]] {
-      // .com/.org/.net never enter: last letter is not an IPv4 number char
-      // ('m' and 'g' are outside 0-9a-fxX).
-      const std::string_view hv(input.data() + host_start, host_len);
-      uint64_t ipv4_addr = 0;
-      bool rewrite_host = false;
-      if (reject_or_classify_numeric_last_label(hv, is_ipv4, ipv4_addr,
-                                                rewrite_host)) {
-        return false;
-      }
-      if (rewrite_host) {
-        char dotted[16];
-        const size_t n =
-            write_ipv4_dotted(dotted, static_cast<uint32_t>(ipv4_addr));
-        return finish_simple_absolute_literal_host(
-            input, out, scheme_type, protocol_end, host_start, host_end,
-            std::string_view(dotted, n), IPV4);
-      }
-    }
-    if (has_xn) [[unlikely]] {
-      return false;
-    }
-  }
-
-  if (host_end < len && b[host_end] == ':') [[unlikely]] {
-    if (finish_simple_absolute_with_port(input, out, scheme_type, protocol_end,
-                                         host_start, host_end, host_len,
-                                         has_upper)) {
-      if (is_ipv4) {
+      if (has_upper) {
+        if (reject_uppercase_plain_host(input.data() + host_start, host_len)) {
+          return false;
+        }
+      } else {
+        const std::string_view hv(input.data() + host_start, host_len);
+        uint64_t ipv4_addr = 0;
+        bool rewrite_host = false;
+        if (reject_or_classify_numeric_last_label(hv, is_ipv4, ipv4_addr,
+                                                  rewrite_host)) {
+          return false;
+        }
+        if (rewrite_host) {
+          char dotted[16];
+          const size_t n =
+              write_ipv4_dotted(dotted, static_cast<uint32_t>(ipv4_addr));
+          return finish_simple_absolute_literal_host(
+              input, out, scheme_type, protocol_end, host_start, host_end,
+              std::string_view(dotted, n), IPV4);
+        }
         out.host_type = IPV4;
       }
-      return true;
     }
-    // `user:pass@host` looks like a port until the '@'.
-    return try_finish_simple_userinfo(input, out, scheme_type, protocol_end,
-                                      host_start);
   }
 
   size_t i = host_end;
@@ -2364,8 +2490,23 @@ ADA_PARSER_FASTPATH bool try_parse_simple_absolute(std::string_view input,
   bool saw_percent = false;
   bool rest_simple = true;
 
-  if (i < len) {
-    if (b[i] == '/') {
+  if (host_end < len) {
+    const uint8_t delim = b[host_end];
+    if (delim == ':') [[unlikely]] {
+      if (finish_simple_absolute_with_port(input, out, scheme_type,
+                                           protocol_end, host_start, host_end,
+                                           host_len, has_upper)) {
+        if (is_ipv4) {
+          out.host_type = IPV4;
+        }
+        return true;
+      }
+      // `user:pass@host` looks like a port until the '@'.
+      return try_finish_simple_userinfo(input, out, scheme_type, protocol_end,
+                                        host_start);
+    }
+    // scan_plain_host succeeded, so delim is / ? # (or we returned above).
+    if (delim == '/') {
       has_path = true;
       path_start = i;
       ++i;
@@ -2402,7 +2543,7 @@ ADA_PARSER_FASTPATH bool try_parse_simple_absolute(std::string_view input,
         goto after_rest;
       }
       path_end = i;
-    } else if (b[i] == '?') {
+    } else if (delim == '?') {
       query_start = i;
       ++i;
       goto scan_query;
@@ -2457,15 +2598,11 @@ after_rest:
   // fragment reaching the helpers below would keep those bytes percent-encoded
   // ("?a\nb" -> "?a%0Ab", "#f " -> "#f%20") instead of stripped, so hand such
   // inputs back to the slow path.
-  if (!rest_simple && (unicode::is_c0_control_or_space(input.back()) ||
-                       unicode::has_tabs_or_newline(input))) {
+  if (!rest_simple && trailing_c0_or_tab_newline(input)) {
     return false;
   }
 
   out.type = scheme_type;
-  if (is_ipv4) {
-    out.host_type = IPV4;
-  }
 
   if (!rest_simple) {
     finish_simple_absolute_handoff<result_type>(
@@ -2478,19 +2615,25 @@ after_rest:
   if constexpr (is_aggregator) {
     if (!need_slash) [[likely]] {
       // assign copies once. resize()+memcpy would value-init then overwrite.
-      out.buffer.assign(input.data(), input.size());
-      if (has_upper) {
-        unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
+      out.buffer.assign(input);
+      if (has_upper) [[unlikely]] {
+        ascii_to_lower(out.buffer.data() + host_start, host_len);
       }
-      set_plain_host_components(out.components, protocol_end,
-                                static_cast<uint32_t>(host_end),
-                                static_cast<uint32_t>(path_start),
-                                (query_start != std::string_view::npos)
-                                    ? static_cast<uint32_t>(query_start)
-                                    : url_components::omitted,
-                                (hash_start != std::string_view::npos)
-                                    ? static_cast<uint32_t>(hash_start)
-                                    : url_components::omitted);
+      // query_start / hash_start are npos when absent; the uint32_t
+      // truncation is omitted (see static_assert above).
+      if (scheme_type == ada::scheme::type::HTTPS) [[likely]] {
+        set_https_plain_host_components(out.components,
+                                        static_cast<uint32_t>(host_end),
+                                        static_cast<uint32_t>(path_start),
+                                        static_cast<uint32_t>(query_start),
+                                        static_cast<uint32_t>(hash_start));
+      } else {
+        set_plain_host_components(out.components, protocol_end,
+                                  static_cast<uint32_t>(host_end),
+                                  static_cast<uint32_t>(path_start),
+                                  static_cast<uint32_t>(query_start),
+                                  static_cast<uint32_t>(hash_start));
+      }
     } else {
       out.buffer.clear();
       out.buffer.reserve(len + 1);
@@ -2500,25 +2643,37 @@ after_rest:
         out.buffer.append(input.substr(host_end));
       }
       if (has_upper) {
-        unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
+        ascii_to_lower(out.buffer.data() + host_start, host_len);
       }
-      set_plain_host_components(out.components, protocol_end,
-                                static_cast<uint32_t>(host_end),
-                                static_cast<uint32_t>(host_end),
-                                (query_start != std::string_view::npos)
-                                    ? static_cast<uint32_t>(query_start + 1)
-                                    : url_components::omitted,
-                                (hash_start != std::string_view::npos)
-                                    ? static_cast<uint32_t>(hash_start + 1)
-                                    : url_components::omitted);
+      if (scheme_type == ada::scheme::type::HTTPS) {
+        set_https_plain_host_components(
+            out.components, static_cast<uint32_t>(host_end),
+            static_cast<uint32_t>(host_end),
+            (query_start != std::string_view::npos)
+                ? static_cast<uint32_t>(query_start + 1)
+                : url_components::omitted,
+            (hash_start != std::string_view::npos)
+                ? static_cast<uint32_t>(hash_start + 1)
+                : url_components::omitted);
+      } else {
+        set_plain_host_components(out.components, protocol_end,
+                                  static_cast<uint32_t>(host_end),
+                                  static_cast<uint32_t>(host_end),
+                                  (query_start != std::string_view::npos)
+                                      ? static_cast<uint32_t>(query_start + 1)
+                                      : url_components::omitted,
+                                  (hash_start != std::string_view::npos)
+                                      ? static_cast<uint32_t>(hash_start + 1)
+                                      : url_components::omitted);
+      }
     }
   } else {
     out.host.emplace(input.data() + host_start, host_len);
-    if (has_upper) {
-      unicode::to_lower_ascii(out.host->data(), host_len);
+    if (has_upper) [[unlikely]] {
+      ascii_to_lower(out.host->data(), host_len);
     }
     if (need_slash) {
-      out.path = "/";
+      out.path.assign(1, '/');
     } else {
       out.path.assign(input.data() + path_start, path_end - path_start);
     }
@@ -2535,9 +2690,17 @@ after_rest:
   return true;
 }
 
+template bool try_parse_simple_absolute<url>(std::string_view, url&);
+template bool try_parse_simple_absolute<url_aggregator>(std::string_view,
+                                                        url_aggregator&);
+#endif  // ADA_SKIP_PARSER_FASTPATH
+
+#ifndef ADA_SKIP_PARSER_RELATIVE
 // Fast path for `/path`, path-relative (`foo`, `c/d?q`), `?query`, and
 // `#fragment` against a special-scheme base. Scheme-relative (`//`) and
 // scheme-like first segments (`foo:bar`) stay on the state machine.
+// Compiled in the finish TU so the absolute/https I-cache is not
+// displaced by relative resolution.
 template <class result_type>
 ADA_PARSER_FASTPATH bool try_parse_simple_relative(std::string_view input,
                                                    const result_type& base,
@@ -2718,6 +2881,18 @@ ADA_PARSER_FASTPATH bool try_parse_simple_relative(std::string_view input,
   return true;
 }
 
+template bool try_parse_simple_relative<url>(std::string_view, const url&,
+                                             url&);
+template bool try_parse_simple_relative<url_aggregator>(std::string_view,
+                                                        const url_aggregator&,
+                                                        url_aggregator&);
+#endif  // ADA_SKIP_PARSER_RELATIVE
+
+#ifdef ADA_PARSER_ENABLE_SSSE3_PRAGMA
+#pragma GCC pop_options
+#endif
+
+#ifndef ADA_SKIP_PARSER_IMPL
 template <class result_type, bool store_values>
 result_type& parse_url_impl_into(result_type& url, std::string_view user_input,
                                  const result_type* base_url,
@@ -3725,44 +3900,6 @@ result_type& parse_url_impl_into(result_type& url, std::string_view user_input,
   return url;
 }
 
-template bool try_parse_simple_absolute<url>(std::string_view, url&);
-template bool try_parse_simple_absolute<url_aggregator>(std::string_view,
-                                                        url_aggregator&);
-template bool finish_simple_absolute_with_port<url>(std::string_view, url&,
-                                                    ada::scheme::type, uint32_t,
-                                                    size_t, size_t, size_t,
-                                                    bool);
-template bool finish_simple_absolute_with_port<url_aggregator>(
-    std::string_view, url_aggregator&, ada::scheme::type, uint32_t, size_t,
-    size_t, size_t, bool);
-template bool finish_simple_absolute_literal_host<url>(std::string_view, url&,
-                                                       ada::scheme::type,
-                                                       uint32_t, size_t, size_t,
-                                                       std::string_view,
-                                                       url_host_type);
-template bool finish_simple_absolute_literal_host<url_aggregator>(
-    std::string_view, url_aggregator&, ada::scheme::type, uint32_t, size_t,
-    size_t, std::string_view, url_host_type);
-template bool try_finish_simple_userinfo<url>(std::string_view, url&,
-                                              ada::scheme::type, uint32_t,
-                                              size_t);
-template bool try_finish_simple_userinfo<url_aggregator>(std::string_view,
-                                                         url_aggregator&,
-                                                         ada::scheme::type,
-                                                         uint32_t, size_t);
-template void finish_simple_absolute_handoff<url>(std::string_view, url&,
-                                                  size_t, size_t, size_t,
-                                                  uint32_t, bool, bool, size_t,
-                                                  size_t, size_t, size_t);
-template void finish_simple_absolute_handoff<url_aggregator>(
-    std::string_view, url_aggregator&, size_t, size_t, size_t, uint32_t, bool,
-    bool, size_t, size_t, size_t, size_t);
-template bool try_parse_simple_relative<url>(std::string_view, const url&,
-                                             url&);
-template bool try_parse_simple_relative<url_aggregator>(std::string_view,
-                                                        const url_aggregator&,
-                                                        url_aggregator&);
-
 template url& parse_url_impl_into<url, true>(url&, std::string_view, const url*,
                                              bool);
 template url_aggregator& parse_url_impl_into<url_aggregator, true>(
@@ -3796,4 +3933,69 @@ template url parse_url<url>(std::string_view user_input,
                             const url* base_url = nullptr);
 template url_aggregator parse_url<url_aggregator>(
     std::string_view user_input, const url_aggregator* base_url = nullptr);
+#endif  // ADA_SKIP_PARSER_IMPL
 }  // namespace ada::parser
+
+#ifdef ADA_PARSER_ENABLE_SSSE3_PRAGMA
+#pragma GCC push_options
+#pragma GCC target("ssse3")
+#endif
+
+#ifndef ADA_SKIP_PARSER_FASTPATH
+namespace ada {
+
+template <class result_type>
+ada_warn_unused tl::expected<result_type, errors> parse(
+    std::string_view input, const result_type* base_url) {
+  if (base_url == nullptr) [[likely]] {
+    if (input.size() > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
+      return tl::unexpected(errors::type_error);
+    }
+    if (max_input_length_customized && input.size() > get_max_input_length())
+        [[unlikely]] {
+      return tl::unexpected(errors::type_error);
+    }
+    result_type u{};
+    if (ada::parser::try_parse_simple_absolute(input, u)) [[likely]] {
+      // Default max is ~4 GB; only re-check expansion when the input
+      // could grow past that (or past a customized limit).
+      if (max_input_length_customized) [[unlikely]] {
+        const uint32_t max_length = get_max_input_length();
+        if (input.size() > static_cast<size_t>(max_length) / 5 &&
+            u.get_href_size() > max_length) {
+          return tl::unexpected(errors::type_error);
+        }
+      } else if (input.size() > std::numeric_limits<uint32_t>::max() / 5)
+          [[unlikely]] {
+        if (u.get_href_size() > std::numeric_limits<uint32_t>::max()) {
+          return tl::unexpected(errors::type_error);
+        }
+      }
+      return u;
+    }
+    ada::parser::parse_url_impl_into<result_type, true>(u, input, nullptr,
+                                                        false);
+    if (!u.is_valid) {
+      return tl::unexpected(errors::type_error);
+    }
+    return u;
+  }
+  result_type u = ada::parser::parse_url_impl<result_type>(input, base_url);
+  if (!u.is_valid) {
+    return tl::unexpected(errors::type_error);
+  }
+  return u;
+}
+
+template ada::result<url> parse<url>(std::string_view input,
+                                     const url* base_url);
+template ada::result<url_aggregator> parse<url_aggregator>(
+    std::string_view input, const url_aggregator* base_url);
+
+}  // namespace ada
+
+#endif  // ADA_SKIP_PARSER_FASTPATH
+
+#ifdef ADA_PARSER_ENABLE_SSSE3_PRAGMA
+#pragma GCC pop_options
+#endif

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -16,9 +16,11 @@
 #include "ada/scheme-inl.h"
 #include "ada/unicode-inl.h"
 #include "ada/unicode.h"
+#include "ada/serializers.h"
 #include "ada/url.h"
 #include "ada/url_aggregator.h"
 #include "ada/url_aggregator-inl.h"
+#include "ada/url_ip-inl.h"
 
 #if ADA_NEON
 #include <arm_neon.h>
@@ -40,14 +42,27 @@
 #endif
 
 #ifdef ADA_PARSER_NEED_SSSE3_TARGET
+// Scanners and the never_inline fast-path entry points share target("ssse3")
+// so the compiler can inline pshufb loops into try_parse_*. parse_url_impl
+// stays baseline and only calls the noinline entries. COLD helpers also
+// need the target so they can call the pshufb scanners, but they live in
+// .text.unlikely so they do not displace setter I-cache.
 #define ADA_PARSER_SIMD __attribute__((target("ssse3")))
+#define ADA_PARSER_FASTPATH __attribute__((target("ssse3"), noinline))
+#define ADA_PARSER_COLD __attribute__((target("ssse3"), noinline, cold))
 #else
 #define ADA_PARSER_SIMD ada_really_inline
+#define ADA_PARSER_FASTPATH ada_never_inline
+#define ADA_PARSER_COLD ada_never_inline ada_cold
 #endif
 
 #ifdef ADA_REGULAR_VISUAL_STUDIO
 #include <intrin.h>
 #endif
+
+namespace ada {
+extern bool max_input_length_customized;
+}  // namespace ada
 
 namespace ada::parser {
 
@@ -78,7 +93,10 @@ constexpr std::array<uint8_t, 256> k_host_class = []() consteval {
   return t;
 }();
 
-// Path: 0 = copy, 1 = ?/#, 2 = needs work. Apostrophe is copyable in a path.
+// Path: 0 = copy, 1 = ?/#, 2 = needs work. Apostrophe and '%' are
+// copyable. '%' is left as-is by the path percent-encode set; only a
+// whole segment that is "." / ".." / "%2e" / "%2e%2e" (ASCII case
+// insensitive) needs the path helpers.
 constexpr std::array<uint8_t, 256> k_path = []() consteval {
   std::array<uint8_t, 256> t{};
   for (size_t i = 0; i < 256; ++i) {
@@ -90,8 +108,7 @@ constexpr std::array<uint8_t, 256> k_path = []() consteval {
   for (uint8_t c : {static_cast<uint8_t>('"'), static_cast<uint8_t>('<'),
                     static_cast<uint8_t>('>'), static_cast<uint8_t>('`'),
                     static_cast<uint8_t>('{'), static_cast<uint8_t>('}'),
-                    static_cast<uint8_t>('^'), static_cast<uint8_t>('\\'),
-                    static_cast<uint8_t>('%')}) {
+                    static_cast<uint8_t>('^'), static_cast<uint8_t>('\\')}) {
     t[c] = 2;
   }
   t[static_cast<uint8_t>('?')] = 1;
@@ -206,6 +223,22 @@ ada_really_inline void append_canonical_port(std::string& buffer,
   buffer.append(port_buf, static_cast<size_t>(ptr - port_buf));
 }
 
+// One helper for the no-userinfo special-scheme authority offsets.
+ada_really_inline void set_plain_host_components(
+    url_components& c, uint32_t protocol_end, uint32_t host_end,
+    uint32_t pathname_start, uint32_t search_start, uint32_t hash_start,
+    uint32_t port = url_components::omitted) noexcept {
+  const uint32_t host_off = protocol_end + 2;
+  c.protocol_end = protocol_end;
+  c.username_end = host_off;
+  c.host_start = host_off;
+  c.host_end = host_end;
+  c.port = port;
+  c.pathname_start = pathname_start;
+  c.search_start = search_start;
+  c.hash_start = hash_start;
+}
+
 ada_really_inline int trailing_zeroes32(uint32_t input_num) noexcept {
 #ifdef ADA_REGULAR_VISUAL_STUDIO
   unsigned long ret;
@@ -276,18 +309,18 @@ ada_really_inline int sse2_host_stop(__m128i w) noexcept {
 
 ada_really_inline int sse2_path_stop(__m128i w) noexcept {
   const __m128i ctrl = sse2_ctrl_or_nonascii(w);
+  // '%' is copyable in a path (left as-is by the percent-encode set).
   const __m128i spec = _mm_or_si128(
       _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('"')),
                                 _mm_cmpeq_epi8(w, _mm_set1_epi8('#'))),
-                   _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('%')),
-                                _mm_cmpeq_epi8(w, _mm_set1_epi8('<')))),
+                   _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('<')),
+                                _mm_cmpeq_epi8(w, _mm_set1_epi8('>')))),
       _mm_or_si128(
-          _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('>')),
-                                    _mm_cmpeq_epi8(w, _mm_set1_epi8('?'))),
-                       _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('\\')),
-                                    _mm_cmpeq_epi8(w, _mm_set1_epi8('^')))),
-          _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('`')),
-                                    _mm_cmpeq_epi8(w, _mm_set1_epi8('{'))),
+          _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('?')),
+                                    _mm_cmpeq_epi8(w, _mm_set1_epi8('\\'))),
+                       _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('^')),
+                                    _mm_cmpeq_epi8(w, _mm_set1_epi8('`')))),
+          _mm_or_si128(_mm_cmpeq_epi8(w, _mm_set1_epi8('{')),
                        _mm_cmpeq_epi8(w, _mm_set1_epi8('}')))));
   return _mm_movemask_epi8(_mm_or_si128(ctrl, spec));
 }
@@ -341,65 +374,54 @@ ada_really_inline uint64_t neon_uppercase(uint8x16_t w) noexcept {
 }
 #endif  // ADA_NEON
 
-// True when '@' appears in the authority before '/', '?', or '#'.
-// One 16-byte window covers typical userinfo (SetHref's "user:pass@").
-// Longer userinfo still misses inside the never_inline fast path. No
-// '@' is a single load + compare so the parse hot path stays cheap.
-ada_really_inline bool authority_has_at(const uint8_t* p, size_t host_start,
-                                        size_t n) noexcept {
-  const size_t rem = n - host_start;
-  if (rem == 0) {
-    return false;
+// Punycode "xn-" at pos. Path bytes after a host delimiter are never "n-",
+// so a host-final 'x' cannot false-positive.
+ada_really_inline void note_xn_prefix(const uint8_t* b, size_t pos, size_t len,
+                                      bool& has_xn) noexcept {
+  if (!has_xn && pos + 2 < len && b[pos + 1] == 'n' && b[pos + 2] == '-') {
+    has_xn = true;
   }
+}
+
+ada_really_inline void note_xn_mask(const uint8_t* b, size_t at, int x_mask,
+                                    size_t len, bool& has_xn) noexcept {
+  if (has_xn || x_mask == 0) {
+    return;
+  }
+  unsigned bits = static_cast<unsigned>(x_mask);
+  do {
+    note_xn_prefix(b, at + static_cast<size_t>(trailing_zeroes32(bits)), len,
+                   has_xn);
+    bits &= bits - 1;
+  } while (bits != 0 && !has_xn);
+}
+
 #if ADA_NEON
-  if (rem >= 16) {
-    const uint8x16_t w = vld1q_u8(p + host_start);
-    const uint64_t at = neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('@')));
-    if (at == 0) {
-      return false;
-    }
-    const uint64_t delim = neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('/'))) |
-                           neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('?'))) |
-                           neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('#')));
-    return delim == 0 || std::countr_zero(at) < std::countr_zero(delim);
+ada_really_inline void note_xn_neon(const uint8_t* b, size_t at, uint64_t xs,
+                                    size_t len, bool& has_xn) noexcept {
+  if (has_xn || xs == 0) {
+    return;
   }
-#elif ADA_SSE2
-  if (rem >= 16) {
-    const __m128i w =
-        _mm_loadu_si128(reinterpret_cast<const __m128i*>(p + host_start));
-    const uint16_t at = static_cast<uint16_t>(
-        _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('@'))));
-    if (at == 0) {
-      return false;
-    }
-    const uint16_t delim = static_cast<uint16_t>(
-        _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('/'))) |
-        _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('?'))) |
-        _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('#'))));
-    return delim == 0 || std::countr_zero(at) < std::countr_zero(delim);
-  }
+  do {
+    const int tz = trailing_zeroes64(xs);
+    note_xn_prefix(b, at + (static_cast<size_t>(tz) >> 2), len, has_xn);
+    xs &= ~(uint64_t{0xF} << (static_cast<unsigned>(tz) & ~3u));
+  } while (xs != 0 && !has_xn);
+}
 #endif
-  const size_t lim = host_start + rem;
-  for (size_t i = host_start; i < lim; ++i) {
-    const uint8_t c = p[i];
-    if (c == '@') {
-      return true;
-    }
-    if (c == '/' || c == '?' || c == '#') {
-      return false;
-    }
-  }
-  return false;
+
+ada_really_inline bool is_host_delimiter(uint8_t c) noexcept {
+  return c == '/' || c == '?' || c == '#' || c == ':';
 }
 
 // Returns false if a forbidden host code point is found. On success, *end is
-// the first / ? # or len. has_upper / has_x only count host bytes, not the
+// the first / ? # or len. has_upper / has_xn only count host bytes, not the
 // path/query bytes that may sit in the same SIMD window after the delimiter.
 ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
                                      size_t& end, bool& has_upper,
-                                     bool& has_x) noexcept {
+                                     bool& has_xn) noexcept {
   has_upper = false;
-  has_x = false;
+  has_xn = false;
   size_t i = start;
 #if ADA_PARSER_SSSE3
   if (len - start >= 16) {
@@ -416,9 +438,7 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
         if (up != 0) {
           has_upper = true;
         }
-        if (xs != 0) {
-          has_x = true;
-        }
+        note_xn_mask(b, at, xs, len, has_xn);
         return false;
       }
       const int hit = trailing_zeroes32(static_cast<uint32_t>(mask));
@@ -426,31 +446,58 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
       if ((up & valid) != 0) {
         has_upper = true;
       }
-      if ((xs & valid) != 0) {
-        has_x = true;
-      }
+      note_xn_mask(b, at, xs & valid, len, has_xn);
       end = at + static_cast<size_t>(hit);
       return true;
     };
     for (; i + 32 <= len; i += 32) {
       if (visit(i) || visit(i + 16)) {
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
     }
     for (; i + 16 <= len; i += 16) {
       if (visit(i)) {
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
     }
     // Overlapping tail only after a full 16-byte step so the window cannot
     // start before `start` (a prior '/' would otherwise look like a host stop).
     if (i > start && i < len) {
       if (visit(len - 16) && end >= i) {
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
       end = len;
       return true;
     }
+  } else if (len >= 16 && start < len) {
+    // Remaining host region is shorter than 16, but the whole URL is
+    // not: classify the last 16 bytes and ignore bytes before `start`.
+    const size_t at = len - 16;
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + at));
+    const int skip = static_cast<int>(start - at);
+    const int keep = static_cast<int>(~((1u << skip) - 1u));
+    const int up = sse2_uppercase(w) & keep;
+    const int xs =
+        _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('x'))) & keep;
+    const int mask = ssse3_nibble_mask(w, nibble_load(k_host_nibbles.low),
+                                       nibble_load(k_host_nibbles.high)) &
+                     keep;
+    if (mask == 0) {
+      if (up != 0) {
+        has_upper = true;
+      }
+      note_xn_mask(b, at, xs, len, has_xn);
+      end = len;
+      return true;
+    }
+    const int hit = trailing_zeroes32(static_cast<uint32_t>(mask));
+    const int valid = ((1 << hit) - 1) & keep;
+    if ((up & valid) != 0) {
+      has_upper = true;
+    }
+    note_xn_mask(b, at, xs & valid, len, has_xn);
+    end = at + static_cast<size_t>(hit);
+    return is_host_delimiter(b[end]);
   }
 #elif ADA_SSE2
   const __m128i x_splat = _mm_set1_epi8('x');
@@ -467,18 +514,14 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
         if ((up & valid) != 0) {
           has_upper = true;
         }
-        if ((xs & valid) != 0) {
-          has_x = true;
-        }
+        note_xn_mask(b, i + off, xs & valid, len, has_xn);
         end = i + off + static_cast<size_t>(hit);
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
       if (up != 0) {
         has_upper = true;
       }
-      if (xs != 0) {
-        has_x = true;
-      }
+      note_xn_mask(b, i + off, xs, len, has_xn);
     }
   }
   for (; i + 16 <= len; i += 16) {
@@ -492,18 +535,39 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
       if ((up & valid) != 0) {
         has_upper = true;
       }
-      if ((xs & valid) != 0) {
-        has_x = true;
-      }
+      note_xn_mask(b, i, xs & valid, len, has_xn);
       end = i + static_cast<size_t>(hit);
-      return k_host_class[b[end]] == 1;
+      return is_host_delimiter(b[end]);
     }
     if (up != 0) {
       has_upper = true;
     }
-    if (xs != 0) {
-      has_x = true;
+    note_xn_mask(b, i, xs, len, has_xn);
+  }
+  if (len >= 16 && i < len) {
+    const size_t at = len - 16;
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + at));
+    const int skip = static_cast<int>(i - at);
+    const int keep = static_cast<int>(~((1u << skip) - 1u));
+    const int up = sse2_uppercase(w) & keep;
+    const int xs = _mm_movemask_epi8(_mm_cmpeq_epi8(w, x_splat)) & keep;
+    const int mask = sse2_host_stop(w) & keep;
+    if (mask == 0) {
+      if (up != 0) {
+        has_upper = true;
+      }
+      note_xn_mask(b, at, xs, len, has_xn);
+      end = len;
+      return true;
     }
+    const int hit = trailing_zeroes32(static_cast<uint32_t>(mask));
+    const int valid = ((1 << hit) - 1) & keep;
+    if ((up & valid) != 0) {
+      has_upper = true;
+    }
+    note_xn_mask(b, at, xs & valid, len, has_xn);
+    end = at + static_cast<size_t>(hit);
+    return is_host_delimiter(b[end]);
   }
 #elif ADA_NEON
   if (len - start >= 16) {
@@ -519,9 +583,7 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
         if (up != 0) {
           has_upper = true;
         }
-        if (xs != 0) {
-          has_x = true;
-        }
+        note_xn_neon(b, at, xs, len, has_xn);
         return false;
       }
       const size_t hit = static_cast<size_t>(trailing_zeroes64(bits)) >> 2;
@@ -529,29 +591,53 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
       if ((up & valid) != 0) {
         has_upper = true;
       }
-      if ((xs & valid) != 0) {
-        has_x = true;
-      }
+      note_xn_neon(b, at, xs & valid, len, has_xn);
       end = at + hit;
       return true;
     };
     for (; i + 32 <= len; i += 32) {
       if (visit(i) || visit(i + 16)) {
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
     }
     for (; i + 16 <= len; i += 16) {
       if (visit(i)) {
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
     }
     if (i > start && i < len) {
       if (visit(len - 16) && end >= i) {
-        return k_host_class[b[end]] == 1;
+        return is_host_delimiter(b[end]);
       }
       end = len;
       return true;
     }
+  } else if (len >= 16 && start < len) {
+    const size_t at = len - 16;
+    const uint8x16_t w = vld1q_u8(b + at);
+    const size_t skip = start - at;
+    const uint64_t keep = (skip >= 16) ? 0 : ~((uint64_t{1} << (skip * 4)) - 1);
+    const uint64_t up = neon_uppercase(w) & keep;
+    const uint64_t xs = neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('x'))) & keep;
+    const uint64_t bits = neon_table_stop(w, vld1q_u8(k_host_nibbles.low),
+                                          vld1q_u8(k_host_nibbles.high)) &
+                          keep;
+    if (bits == 0) {
+      if (up != 0) {
+        has_upper = true;
+      }
+      note_xn_neon(b, at, xs, len, has_xn);
+      end = len;
+      return true;
+    }
+    const size_t hit = static_cast<size_t>(trailing_zeroes64(bits)) >> 2;
+    const uint64_t valid = (hit == 0) ? 0 : (uint64_t{1} << (hit * 4)) - 1;
+    if ((up & valid) != 0) {
+      has_upper = true;
+    }
+    note_xn_neon(b, at, xs & valid, len, has_xn);
+    end = at + hit;
+    return is_host_delimiter(b[end]);
   }
 #endif
   for (; i < len; ++i) {
@@ -562,35 +648,59 @@ ADA_PARSER_SIMD bool scan_plain_host(const uint8_t* b, size_t start, size_t len,
       return true;
     }
     if (cls == 2) {
+      end = i;
       return false;
     }
     if (c >= 'A' && c <= 'Z') {
       has_upper = true;
     } else if (c == 'x') {
-      has_x = true;
+      note_xn_prefix(b, i, len, has_xn);
     }
   }
   end = len;
   return true;
 }
 
-ada_really_inline void note_possible_dot_segment(
-    const uint8_t* b, size_t pos, size_t run_start,
-    bool& maybe_dot_segment) noexcept {
+ada_really_inline void note_possible_segment_prefix(const uint8_t* b,
+                                                    size_t pos,
+                                                    size_t run_start,
+                                                    bool& flag) noexcept {
   if (pos == run_start || b[pos - 1] == '/') {
-    maybe_dot_segment = true;
+    flag = true;
+  }
+}
+
+ada_really_inline void note_scalar_path_byte(const uint8_t* b, size_t pos,
+                                             size_t run_start,
+                                             bool& maybe_dot_segment,
+                                             bool& saw_percent) noexcept {
+  if (b[pos] == '.') {
+    note_possible_segment_prefix(b, pos, run_start, maybe_dot_segment);
+  } else if (b[pos] == '%') {
+    saw_percent = true;
   }
 }
 
 #if ADA_PARSER_SSSE3 || ADA_SSE2
 // valid_mask selects bytes in this 16-byte window that belong to the path
-// (bits after a stop are cleared). A '.' starts a possible dot-segment when
-// it is the first path byte or immediately follows '/'.
+// (bits after a stop are cleared). '.' starts a possible dot-segment when it
+// is the first path byte or immediately follows '/'. A raw '%' anywhere is
+// recorded so the caller can skip the %2e walk on the common percent-free
+// path without a second memchr.
 ada_really_inline void note_dots_in_window(const uint8_t* b, size_t i,
                                            size_t run_start, __m128i w,
                                            int valid_mask,
-                                           bool& maybe_dot_segment) noexcept {
-  if (maybe_dot_segment || valid_mask == 0) {
+                                           bool& maybe_dot_segment,
+                                           bool& saw_percent) noexcept {
+  if (valid_mask == 0) {
+    return;
+  }
+  if (!saw_percent &&
+      (_mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('%'))) & valid_mask) !=
+          0) {
+    saw_percent = true;
+  }
+  if (maybe_dot_segment) {
     return;
   }
   const int dots =
@@ -600,20 +710,32 @@ ada_really_inline void note_dots_in_window(const uint8_t* b, size_t i,
   }
   const int slashes =
       _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('/'))) & valid_mask;
-  if (((dots & 1) != 0 && (i == run_start || b[i - 1] == '/')) ||
-      (dots & (slashes << 1)) != 0) {
+  const bool leading_prefix = (i == run_start || b[i - 1] == '/');
+  // Overlapping last-16 windows that start before the path must mark the
+  // first path byte as a segment start separately (see scan_path_run).
+  // Doing that here taxes every dotted aligned window.
+  if (((dots & 1) != 0 && leading_prefix) || (dots & (slashes << 1)) != 0) {
     maybe_dot_segment = true;
   }
 }
 #endif
 
 #if ADA_NEON
-// Each NEON match nibble occupies 4 bits, so a '.' immediately after '/' is
-// (slashes << 4) rather than (slashes << 1).
-ada_really_inline void note_dots_in_window_neon(
-    const uint8_t* b, size_t i, size_t run_start, uint8x16_t w,
-    uint64_t valid_bits, bool& maybe_dot_segment) noexcept {
-  if (maybe_dot_segment || valid_bits == 0) {
+// Each NEON match nibble occupies 4 bits, so a marker immediately after '/'
+// is (slashes << 4) rather than (slashes << 1).
+ada_really_inline void note_dots_in_window_neon(const uint8_t* b, size_t i,
+                                                size_t run_start, uint8x16_t w,
+                                                uint64_t valid_bits,
+                                                bool& maybe_dot_segment,
+                                                bool& saw_percent) noexcept {
+  if (valid_bits == 0) {
+    return;
+  }
+  if (!saw_percent &&
+      (neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('%'))) & valid_bits) != 0) {
+    saw_percent = true;
+  }
+  if (maybe_dot_segment) {
     return;
   }
   const uint64_t dots =
@@ -623,8 +745,8 @@ ada_really_inline void note_dots_in_window_neon(
   }
   const uint64_t slashes =
       neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('/'))) & valid_bits;
-  if (((dots & 0xF) != 0 && (i == run_start || b[i - 1] == '/')) ||
-      (dots & (slashes << 4)) != 0) {
+  const bool leading_prefix = (i == run_start || b[i - 1] == '/');
+  if (((dots & 0xF) != 0 && leading_prefix) || (dots & (slashes << 4)) != 0) {
     maybe_dot_segment = true;
   }
 }
@@ -632,7 +754,8 @@ ada_really_inline void note_dots_in_window_neon(
 
 // Advance i to the first path-class 1 or 2 character (or len).
 ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
-                                   bool& maybe_dot_segment) noexcept {
+                                   bool& maybe_dot_segment,
+                                   bool& saw_percent) noexcept {
   const size_t run_start = i;
 #if ADA_PARSER_SSSE3
   if (i + 16 <= len) {
@@ -645,22 +768,24 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
       if (m0 != 0) {
         const int hit_bit = trailing_zeroes32(static_cast<uint32_t>(m0));
         note_dots_in_window(b, i, run_start, w0, (1 << hit_bit) - 1,
-                            maybe_dot_segment);
+                            maybe_dot_segment, saw_percent);
         i += static_cast<size_t>(hit_bit);
         return;
       }
-      note_dots_in_window(b, i, run_start, w0, 0xFFFF, maybe_dot_segment);
+      note_dots_in_window(b, i, run_start, w0, 0xFFFF, maybe_dot_segment,
+                          saw_percent);
       const __m128i w1 =
           _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + i + 16));
       const int m1 = ssse3_nibble_mask(w1, lo_tbl, hi_tbl);
       if (m1 != 0) {
         const int hit_bit = trailing_zeroes32(static_cast<uint32_t>(m1));
         note_dots_in_window(b, i + 16, run_start, w1, (1 << hit_bit) - 1,
-                            maybe_dot_segment);
+                            maybe_dot_segment, saw_percent);
         i += 16 + static_cast<size_t>(hit_bit);
         return;
       }
-      note_dots_in_window(b, i + 16, run_start, w1, 0xFFFF, maybe_dot_segment);
+      note_dots_in_window(b, i + 16, run_start, w1, 0xFFFF, maybe_dot_segment,
+                          saw_percent);
     }
     for (; i + 16 <= len; i += 16) {
       const __m128i w =
@@ -669,11 +794,12 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
       if (mask != 0) {
         const int hit_bit = trailing_zeroes32(static_cast<uint32_t>(mask));
         note_dots_in_window(b, i, run_start, w, (1 << hit_bit) - 1,
-                            maybe_dot_segment);
+                            maybe_dot_segment, saw_percent);
         i += static_cast<size_t>(hit_bit);
         return;
       }
-      note_dots_in_window(b, i, run_start, w, 0xFFFF, maybe_dot_segment);
+      note_dots_in_window(b, i, run_start, w, 0xFFFF, maybe_dot_segment,
+                          saw_percent);
     }
     if (i > run_start && i < len) {
       const __m128i w =
@@ -685,22 +811,37 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
             static_cast<size_t>(trailing_zeroes32(static_cast<uint32_t>(mask)));
         if (hit >= i) {
           for (size_t j = i; j < hit; ++j) {
-            if (b[j] == '.') {
-              note_possible_dot_segment(b, j, run_start, maybe_dot_segment);
-            }
+            note_scalar_path_byte(b, j, run_start, maybe_dot_segment,
+                                  saw_percent);
           }
           i = hit;
           return;
         }
       }
       for (size_t j = i; j < len; ++j) {
-        if (b[j] == '.') {
-          note_possible_dot_segment(b, j, run_start, maybe_dot_segment);
-        }
+        note_scalar_path_byte(b, j, run_start, maybe_dot_segment, saw_percent);
       }
       i = len;
       return;
     }
+  } else if (len >= 16 && i < len) {
+    // The path delimiter sits before run_start, so it is outside valid_mask.
+    // Note the first path byte as a segment start (https://host/./a).
+    note_scalar_path_byte(b, i, run_start, maybe_dot_segment, saw_percent);
+    const size_t at = len - 16;
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + at));
+    const int skip = static_cast<int>(i - at);
+    const int keep = static_cast<int>(~((1u << skip) - 1u));
+    const int mask = ssse3_nibble_mask(w, nibble_load(k_path_nibbles.low),
+                                       nibble_load(k_path_nibbles.high)) &
+                     keep;
+    const int hit =
+        (mask == 0) ? 16 : trailing_zeroes32(static_cast<uint32_t>(mask));
+    const int valid = (hit == 16) ? keep : (((1 << hit) - 1) & keep);
+    note_dots_in_window(b, at, run_start, w, valid, maybe_dot_segment,
+                        saw_percent);
+    i = (hit == 16) ? len : at + static_cast<size_t>(hit);
+    return;
   }
 #elif ADA_SSE2
   for (; i + 16 <= len; i += 16) {
@@ -709,11 +850,27 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
     if (mask != 0) {
       const int hit_bit = trailing_zeroes32(static_cast<uint32_t>(mask));
       note_dots_in_window(b, i, run_start, w, (1 << hit_bit) - 1,
-                          maybe_dot_segment);
+                          maybe_dot_segment, saw_percent);
       i += static_cast<size_t>(hit_bit);
       return;
     }
-    note_dots_in_window(b, i, run_start, w, 0xFFFF, maybe_dot_segment);
+    note_dots_in_window(b, i, run_start, w, 0xFFFF, maybe_dot_segment,
+                        saw_percent);
+  }
+  if (len >= 16 && i < len) {
+    note_scalar_path_byte(b, i, run_start, maybe_dot_segment, saw_percent);
+    const size_t at = len - 16;
+    const __m128i w = _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + at));
+    const int skip = static_cast<int>(i - at);
+    const int keep = static_cast<int>(~((1u << skip) - 1u));
+    const int mask = sse2_path_stop(w) & keep;
+    const int hit =
+        (mask == 0) ? 16 : trailing_zeroes32(static_cast<uint32_t>(mask));
+    const int valid = (hit == 16) ? keep : (((1 << hit) - 1) & keep);
+    note_dots_in_window(b, at, run_start, w, valid, maybe_dot_segment,
+                        saw_percent);
+    i = (hit == 16) ? len : at + static_cast<size_t>(hit);
+    return;
   }
 #elif ADA_NEON
   if (i + 16 <= len) {
@@ -727,12 +884,13 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
             static_cast<size_t>(trailing_zeroes64(bits0)) >> 2;
         const uint64_t valid =
             (hit_off == 0) ? 0 : (uint64_t{1} << (hit_off * 4)) - 1;
-        note_dots_in_window_neon(b, i, run_start, w0, valid, maybe_dot_segment);
+        note_dots_in_window_neon(b, i, run_start, w0, valid, maybe_dot_segment,
+                                 saw_percent);
         i += hit_off;
         return;
       }
       note_dots_in_window_neon(b, i, run_start, w0, ~uint64_t{0},
-                               maybe_dot_segment);
+                               maybe_dot_segment, saw_percent);
       const uint8x16_t w1 = vld1q_u8(b + i + 16);
       const uint64_t bits1 = neon_table_stop(w1, lo_tbl, hi_tbl);
       if (bits1 != 0) {
@@ -741,12 +899,12 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
         const uint64_t valid =
             (hit_off == 0) ? 0 : (uint64_t{1} << (hit_off * 4)) - 1;
         note_dots_in_window_neon(b, i + 16, run_start, w1, valid,
-                                 maybe_dot_segment);
+                                 maybe_dot_segment, saw_percent);
         i += 16 + hit_off;
         return;
       }
       note_dots_in_window_neon(b, i + 16, run_start, w1, ~uint64_t{0},
-                               maybe_dot_segment);
+                               maybe_dot_segment, saw_percent);
     }
     for (; i + 16 <= len; i += 16) {
       const uint8x16_t w = vld1q_u8(b + i);
@@ -756,12 +914,13 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
             static_cast<size_t>(trailing_zeroes64(bits)) >> 2;
         const uint64_t valid =
             (hit_off == 0) ? 0 : (uint64_t{1} << (hit_off * 4)) - 1;
-        note_dots_in_window_neon(b, i, run_start, w, valid, maybe_dot_segment);
+        note_dots_in_window_neon(b, i, run_start, w, valid, maybe_dot_segment,
+                                 saw_percent);
         i += hit_off;
         return;
       }
       note_dots_in_window_neon(b, i, run_start, w, ~uint64_t{0},
-                               maybe_dot_segment);
+                               maybe_dot_segment, saw_percent);
     }
     if (i > run_start && i < len) {
       const uint8x16_t w = vld1q_u8(b + len - 16);
@@ -771,22 +930,39 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
             len - 16 + (static_cast<size_t>(trailing_zeroes64(bits)) >> 2);
         if (hit >= i) {
           for (size_t j = i; j < hit; ++j) {
-            if (b[j] == '.') {
-              note_possible_dot_segment(b, j, run_start, maybe_dot_segment);
-            }
+            note_scalar_path_byte(b, j, run_start, maybe_dot_segment,
+                                  saw_percent);
           }
           i = hit;
           return;
         }
       }
       for (size_t j = i; j < len; ++j) {
-        if (b[j] == '.') {
-          note_possible_dot_segment(b, j, run_start, maybe_dot_segment);
-        }
+        note_scalar_path_byte(b, j, run_start, maybe_dot_segment, saw_percent);
       }
       i = len;
       return;
     }
+  } else if (len >= 16 && i < len) {
+    note_scalar_path_byte(b, i, run_start, maybe_dot_segment, saw_percent);
+    const size_t at = len - 16;
+    const uint8x16_t w = vld1q_u8(b + at);
+    const size_t skip = i - at;
+    const uint64_t keep = (skip >= 16) ? 0 : ~((uint64_t{1} << (skip * 4)) - 1);
+    const uint64_t bits = neon_table_stop(w, vld1q_u8(k_path_nibbles.low),
+                                          vld1q_u8(k_path_nibbles.high)) &
+                          keep;
+    uint64_t valid = keep;
+    if (bits != 0) {
+      const size_t hit_off = static_cast<size_t>(trailing_zeroes64(bits)) >> 2;
+      valid = (hit_off == 0) ? 0 : (uint64_t{1} << (hit_off * 4)) - 1;
+      i = at + hit_off;
+    } else {
+      i = len;
+    }
+    note_dots_in_window_neon(b, at, run_start, w, valid, maybe_dot_segment,
+                             saw_percent);
+    return;
   }
 #endif
   for (; i < len; ++i) {
@@ -795,9 +971,7 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
     if (cls != 0) {
       return;
     }
-    if (c == '.') {
-      note_possible_dot_segment(b, i, run_start, maybe_dot_segment);
-    }
+    note_scalar_path_byte(b, i, run_start, maybe_dot_segment, saw_percent);
   }
 }
 
@@ -854,6 +1028,19 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
         i = len;                                                             \
         return;                                                              \
       }                                                                      \
+    } else if (len >= 16 && i < len) {                                       \
+      const size_t at = len - 16;                                            \
+      const int skip = static_cast<int>(i - at);                             \
+      const int keep = static_cast<int>(~((1u << skip) - 1u));               \
+      const __m128i w =                                                      \
+          _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + at));         \
+      const int mask = ssse3_nibble_mask(w, nibble_load((nibbles).low),      \
+                                         nibble_load((nibbles).high)) &      \
+                       keep;                                                 \
+      i = (mask == 0) ? len                                                  \
+                      : at + static_cast<size_t>(trailing_zeroes32(          \
+                                 static_cast<uint32_t>(mask)));              \
+      return;                                                                \
     }                                                                        \
     for (; i < len; ++i) {                                                   \
       if ((cls)[b[i]] != 0) {                                                \
@@ -904,6 +1091,19 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
         i = len;                                                              \
         return;                                                               \
       }                                                                       \
+    } else if (len >= 16 && i < len) {                                        \
+      const size_t at = len - 16;                                             \
+      const size_t skip = i - at;                                             \
+      const uint64_t keep =                                                   \
+          (skip >= 16) ? 0 : ~((uint64_t{1} << (skip * 4)) - 1);              \
+      const uint64_t bits =                                                   \
+          neon_table_stop(vld1q_u8(b + at), vld1q_u8((nibbles).low),          \
+                          vld1q_u8((nibbles).high)) &                         \
+          keep;                                                               \
+      i = (bits == 0)                                                         \
+              ? len                                                           \
+              : at + (static_cast<size_t>(trailing_zeroes64(bits)) >> 2);     \
+      return;                                                                 \
     }                                                                         \
     for (; i < len; ++i) {                                                    \
       if ((cls)[b[i]] != 0) {                                                 \
@@ -912,23 +1112,35 @@ ADA_PARSER_SIMD void scan_path_run(const uint8_t* b, size_t& i, size_t len,
     }                                                                         \
   } while (0)
 #elif ADA_SSE2
-#define ADA_SCAN_STOP_RUN(nibbles, cls, sse2_stop)                  \
-  do {                                                              \
-    for (; i + 16 <= len; i += 16) {                                \
-      const __m128i w =                                             \
-          _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + i)); \
-      const int mask = sse2_stop(w);                                \
-      if (mask != 0) {                                              \
-        i += static_cast<size_t>(                                   \
-            trailing_zeroes32(static_cast<uint32_t>(mask)));        \
-        return;                                                     \
-      }                                                             \
-    }                                                               \
-    for (; i < len; ++i) {                                          \
-      if ((cls)[b[i]] != 0) {                                       \
-        return;                                                     \
-      }                                                             \
-    }                                                               \
+#define ADA_SCAN_STOP_RUN(nibbles, cls, sse2_stop)                   \
+  do {                                                               \
+    for (; i + 16 <= len; i += 16) {                                 \
+      const __m128i w =                                              \
+          _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + i));  \
+      const int mask = sse2_stop(w);                                 \
+      if (mask != 0) {                                               \
+        i += static_cast<size_t>(                                    \
+            trailing_zeroes32(static_cast<uint32_t>(mask)));         \
+        return;                                                      \
+      }                                                              \
+    }                                                                \
+    if (len >= 16 && i < len) {                                      \
+      const size_t at = len - 16;                                    \
+      const int skip = static_cast<int>(i - at);                     \
+      const int keep = static_cast<int>(~((1u << skip) - 1u));       \
+      const __m128i w =                                              \
+          _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + at)); \
+      const int mask = sse2_stop(w) & keep;                          \
+      i = (mask == 0) ? len                                          \
+                      : at + static_cast<size_t>(trailing_zeroes32(  \
+                                 static_cast<uint32_t>(mask)));      \
+      return;                                                        \
+    }                                                                \
+    for (; i < len; ++i) {                                           \
+      if ((cls)[b[i]] != 0) {                                        \
+        return;                                                      \
+      }                                                              \
+    }                                                                \
   } while (0)
 #else
 #define ADA_SCAN_STOP_RUN(nibbles, cls, unused_sse2_stop) \
@@ -981,10 +1193,280 @@ bool path_has_dot_segment(std::string_view path) noexcept {
   return false;
 }
 
+// True when a path segment is "." / ".." or a percent-encoded form
+// ("%2e", "%2e%2e", ".%2e", "%2e.") that the path helpers would collapse.
+bool path_has_percent_encoded_dot_segment(std::string_view path) noexcept {
+  size_t i = (!path.empty() && path[0] == '/') ? 1 : 0;
+  while (i <= path.size()) {
+    const size_t end = path.find('/', i);
+    const size_t seg_end = (end == std::string_view::npos) ? path.size() : end;
+    const std::string_view seg(path.data() + i, seg_end - i);
+    if (unicode::is_single_dot_path_segment(seg) ||
+        unicode::is_double_dot_path_segment(seg)) {
+      return true;
+    }
+    if (end == std::string_view::npos) {
+      break;
+    }
+    i = end + 1;
+  }
+  return false;
+}
+
+ada_really_inline bool path_body_needs_normalization(
+    std::string_view path_body, bool maybe_dot_segment,
+    bool maybe_percent_dot) noexcept {
+  if (maybe_dot_segment && path_has_dot_segment(path_body)) {
+    return true;
+  }
+  // ".%2e" starts with '.' so maybe_dot is set, but path_has_dot_segment
+  // does not treat percent-encoded dots. Walk segments only when a
+  // '%' was seen during the path scan.
+  if (maybe_percent_dot) {
+    return path_has_percent_encoded_dot_segment(path_body);
+  }
+  return false;
+}
+
+ada_really_inline bool simple_path_is_canonical(std::string_view path_body,
+                                                bool maybe_dot_segment,
+                                                bool saw_percent) noexcept {
+  if (!maybe_dot_segment && !saw_percent) {
+    return true;
+  }
+  return !path_body_needs_normalization(path_body, maybe_dot_segment,
+                                        saw_percent);
+}
+
+// http/ws/wss/ftp and URLs shorter than 8 bytes are ~4% of the dataset.
+// Keep those compares out of the https:// I-cache.
+ada_never_inline bool match_non_https_special_scheme(
+    uint64_t first8, size_t len, const uint8_t* b, size_t& pos,
+    ada::scheme::type& scheme_type, uint32_t& protocol_end) noexcept {
+  // first8 == 0 means the caller did not load one (short URL or big-endian).
+  if (len >= 8 && first8 != 0) {
+    if ((first8 & 0x00ffffffffffffffull) == 0x002f2f3a70747468ull) {
+      pos = 7;
+      scheme_type = ada::scheme::type::HTTP;
+      protocol_end = 5;
+      return true;
+    }
+    if ((first8 & 0x0000ffffffffffffull) == 0x00002f2f3a737377ull) {
+      pos = 6;
+      scheme_type = ada::scheme::type::WSS;
+      protocol_end = 4;
+      return true;
+    }
+    if ((first8 & 0x0000ffffffffffffull) == 0x00002f2f3a707466ull) {
+      pos = 6;
+      scheme_type = ada::scheme::type::FTP;
+      protocol_end = 4;
+      return true;
+    }
+    if ((first8 & 0x000000ffffffffffull) == 0x0000002f2f3a7377ull) {
+      pos = 5;
+      scheme_type = ada::scheme::type::WS;
+      protocol_end = 3;
+      return true;
+    }
+    return false;
+  }
+  if (len < 6) {
+    return false;
+  }
+  if (b[0] == 'w' && b[1] == 's') {
+    if (b[2] == ':' && b[3] == '/' && b[4] == '/') {
+      pos = 5;
+      scheme_type = ada::scheme::type::WS;
+      protocol_end = 3;
+      return true;
+    }
+    if (b[2] == 's' && b[3] == ':' && b[4] == '/' && b[5] == '/') {
+      pos = 6;
+      scheme_type = ada::scheme::type::WSS;
+      protocol_end = 4;
+      return true;
+    }
+    return false;
+  }
+  if (b[0] == 'f' && b[1] == 't' && b[2] == 'p' && b[3] == ':' && b[4] == '/' &&
+      b[5] == '/') {
+    pos = 6;
+    scheme_type = ada::scheme::type::FTP;
+    protocol_end = 4;
+    return true;
+  }
+  if (len >= 7 && b[0] == 'h' && b[1] == 't' && b[2] == 't' && b[3] == 'p' &&
+      b[4] == ':' && b[5] == '/' && b[6] == '/') {
+    pos = 7;
+    scheme_type = ada::scheme::type::HTTP;
+    protocol_end = 5;
+    return true;
+  }
+  return false;
+}
+
+// Uppercase hosts and numeric last labels are rare on the dataset. Keep
+// their buffers and IPv4 parser out of the hot I-cache.
+ada_never_inline bool reject_uppercase_plain_host(const char* host,
+                                                  size_t host_len) noexcept {
+  char host_buf[256];
+  std::memcpy(host_buf, host, host_len);
+  unicode::to_lower_ascii(host_buf, host_len);
+  const std::string_view hv(host_buf, host_len);
+  if (ada::checkers::last_label_may_be_a_number(hv)) {
+    return true;
+  }
+  static constexpr std::string_view xn{"xn-", 3};
+  return hv.find(xn) != std::string_view::npos;
+}
+
+// Hex/octal/compressed IPv4. Decimal-with-trailing-dot is handled by
+// try_parse_ipv4_fast; this runs only after that miss.
+ada_cold uint64_t try_parse_ipv4_any(std::string_view input) noexcept {
+  if (input.empty()) {
+    return checkers::ipv4_fast_fail;
+  }
+  if (input.back() == '.') {
+    input.remove_suffix(1);
+    if (input.empty()) {
+      return checkers::ipv4_fast_fail;
+    }
+  }
+  const char* p = input.data();
+  const char* end = p + input.size();
+  uint64_t ipv4 = 0;
+  int digit_count = 0;
+  for (; digit_count < 4 && p < end; ++digit_count) {
+    uint64_t segment = 0;
+    bool pure = false;
+    if (!detail::parse_ipv4_number(p, end, segment, pure)) {
+      return checkers::ipv4_fast_fail;
+    }
+    if (p >= end) {
+      const unsigned shift = static_cast<unsigned>(32 - digit_count * 8);
+      if (segment >= (uint64_t{1} << shift)) {
+        return checkers::ipv4_fast_fail;
+      }
+      return (ipv4 << shift) | segment;
+    }
+    if (segment > 255 || *p != '.') {
+      return checkers::ipv4_fast_fail;
+    }
+    ipv4 = (ipv4 << 8) | segment;
+    ++p;
+  }
+  if (digit_count != 4 || p != end) {
+    return checkers::ipv4_fast_fail;
+  }
+  return ipv4;
+}
+
+ada_really_inline char* write_u8_dec(char* p, uint8_t v) noexcept {
+  if (v < 10) {
+    *p++ = static_cast<char>('0' + v);
+  } else if (v < 100) {
+    *p++ = static_cast<char>('0' + v / 10);
+    *p++ = static_cast<char>('0' + v % 10);
+  } else {
+    *p++ = static_cast<char>('0' + v / 100);
+    v = static_cast<uint8_t>(v % 100);
+    *p++ = static_cast<char>('0' + v / 10);
+    *p++ = static_cast<char>('0' + v % 10);
+  }
+  return p;
+}
+
+ada_cold size_t write_ipv4_dotted(char* buf, uint32_t addr) noexcept {
+  char* p = buf;
+  p = write_u8_dec(p, static_cast<uint8_t>(addr >> 24));
+  *p++ = '.';
+  p = write_u8_dec(p, static_cast<uint8_t>(addr >> 16));
+  *p++ = '.';
+  p = write_u8_dec(p, static_cast<uint8_t>(addr >> 8));
+  *p++ = '.';
+  p = write_u8_dec(p, static_cast<uint8_t>(addr));
+  return static_cast<size_t>(p - buf);
+}
+
+// true => leave the simple-absolute path. false => stay; may set is_ipv4
+// and ask the caller to rewrite the host to dotted-decimal.
+ada_never_inline ada_cold bool reject_or_classify_numeric_last_label(
+    std::string_view hv, bool& is_ipv4, uint64_t& ipv4_addr,
+    bool& rewrite_host) noexcept {
+  if (!ada::checkers::last_label_may_be_a_number(hv)) {
+    return false;
+  }
+  const uint64_t fast = checkers::try_parse_ipv4_fast(hv);
+  if (fast < checkers::ipv4_fast_fail) {
+    is_ipv4 = true;
+    ipv4_addr = fast;
+    rewrite_host = hv.back() == '.';
+    return false;
+  }
+  const uint64_t any = try_parse_ipv4_any(hv);
+  if (any < checkers::ipv4_fast_fail) {
+    is_ipv4 = true;
+    ipv4_addr = any;
+    rewrite_host = true;
+    return false;
+  }
+  return true;
+}
+
 }  // namespace
 
+// Percent-encoding / dot-segment handoff. Kept out of the already-canonical
+// fast-path I-cache: this is the uncommon rest_simple=false tail.
 template <class result_type>
-ada_never_inline bool finish_simple_absolute_with_port(
+ada_never_inline ada_cold void finish_simple_absolute_handoff(
+    std::string_view input, result_type& out, size_t host_start,
+    size_t host_end, size_t host_len, uint32_t protocol_end, bool has_upper,
+    bool has_path, size_t path_start, size_t path_end, size_t query_start,
+    size_t hash_start) {
+  constexpr bool is_aggregator =
+      std::is_same_v<result_type, ada::url_aggregator>;
+  const size_t len = input.size();
+  const std::string_view path_view =
+      has_path
+          ? std::string_view(input.data() + path_start, path_end - path_start)
+          : std::string_view{};
+  auto apply_query_and_hash = [&]() {
+    if (query_start != std::string_view::npos) {
+      const size_t q_end =
+          (hash_start != std::string_view::npos) ? hash_start : len;
+      out.update_base_search(std::string_view(input.data() + query_start + 1,
+                                              q_end - query_start - 1),
+                             character_sets::SPECIAL_QUERY_PERCENT_ENCODE);
+    }
+    if (hash_start != std::string_view::npos) {
+      out.update_unencoded_base_hash(std::string_view(
+          input.data() + hash_start + 1, len - hash_start - 1));
+    }
+  };
+  if constexpr (is_aggregator) {
+    out.buffer.assign(input.substr(0, host_end));
+    if (has_upper) {
+      unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
+    }
+    set_plain_host_components(out.components, protocol_end,
+                              static_cast<uint32_t>(host_end),
+                              static_cast<uint32_t>(host_end),
+                              url_components::omitted, url_components::omitted);
+    out.parse_path(path_view);
+    apply_query_and_hash();
+  } else {
+    out.host.emplace(input.data() + host_start, host_len);
+    if (has_upper) {
+      unicode::to_lower_ascii(out.host->data(), host_len);
+    }
+    out.parse_path(path_view);
+    apply_query_and_hash();
+  }
+}
+
+template <class result_type>
+ADA_PARSER_COLD bool finish_simple_absolute_with_port(
     std::string_view input, result_type& out, ada::scheme::type scheme_type,
     uint32_t protocol_end, size_t host_start, size_t host_end, size_t host_len,
     bool has_upper) {
@@ -1023,53 +1505,56 @@ ada_never_inline bool finish_simple_absolute_with_port(
   size_t hash_start = std::string_view::npos;
   bool has_path = false;
   bool maybe_dot_segment = false;
+  bool saw_percent = false;
   bool rest_simple = true;
 
-  if (i < len && b[i] == '/') {
-    has_path = true;
-    path_start = i;
-    ++i;
-    scan_path_run(b, i, len, maybe_dot_segment);
-    if (i < len) {
-      const uint8_t cls = k_path[b[i]];
-      if (cls == 1) {
-        path_end = i;
-        if (b[i] == '?') {
-          query_start = i;
-          ++i;
-          goto scan_query;
-        }
-        hash_start = i;
-        ++i;
-        goto scan_hash;
-      }
-      rest_simple = false;
-      for (; i < len; ++i) {
+  if (i < len) {
+    if (b[i] == '/') {
+      has_path = true;
+      path_start = i;
+      ++i;
+      scan_path_run(b, i, len, maybe_dot_segment, saw_percent);
+      if (i < len) {
         if (b[i] == '?') {
           path_end = i;
           query_start = i;
           ++i;
-          goto scan_query_boundary;
+          goto scan_query;
         }
         if (b[i] == '#') {
           path_end = i;
           hash_start = i;
           ++i;
-          goto after_rest;
+          goto scan_hash;
         }
+        rest_simple = false;
+        for (; i < len; ++i) {
+          if (b[i] == '?') {
+            path_end = i;
+            query_start = i;
+            ++i;
+            goto scan_query_boundary;
+          }
+          if (b[i] == '#') {
+            path_end = i;
+            hash_start = i;
+            ++i;
+            goto after_rest;
+          }
+        }
+        path_end = i;
+        goto after_rest;
       }
       path_end = i;
-      goto after_rest;
+    } else if (b[i] == '?') {
+      query_start = i;
+      ++i;
+      goto scan_query;
+    } else {
+      hash_start = i;
+      ++i;
+      goto scan_hash;
     }
-    path_end = i;
-  } else if (i < len && b[i] == '?') {
-    query_start = i;
-    ++i;
-    goto scan_query;
-  } else if (i < len && b[i] == '#') {
-    hash_start = i;
-    ++i;
-    goto scan_hash;
   }
   goto after_rest;
 
@@ -1103,10 +1588,10 @@ scan_hash:
   }
 
 after_rest:
-  if (rest_simple && maybe_dot_segment) {
+  if (rest_simple && has_path && (maybe_dot_segment || saw_percent)) {
     const std::string_view path_body(input.data() + path_start,
                                      path_end - path_start);
-    if (path_has_dot_segment(path_body)) {
+    if (!simple_path_is_canonical(path_body, maybe_dot_segment, saw_percent)) {
       rest_simple = false;
     }
   }
@@ -1122,9 +1607,6 @@ after_rest:
   }
 
   out.type = scheme_type;
-  out.is_valid = true;
-  out.has_opaque_path = false;
-  out.host_type = DEFAULT;
 
   const uint32_t port_bytes = (parsed_port != url_components::omitted)
                                   ? (1 + port_decimal_digit_count(parsed_port))
@@ -1156,22 +1638,17 @@ after_rest:
       if (has_upper) {
         unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
       }
-      out.components.protocol_end = protocol_end;
-      out.components.username_end = protocol_end + 2;
-      out.components.host_start = protocol_end + 2;
-      out.components.host_end = static_cast<uint32_t>(host_end);
-      out.components.port = parsed_port;
-      out.components.pathname_start = static_cast<uint32_t>(out.buffer.size());
-      out.components.search_start = url_components::omitted;
-      out.components.hash_start = url_components::omitted;
+      set_plain_host_components(
+          out.components, protocol_end, static_cast<uint32_t>(host_end),
+          static_cast<uint32_t>(out.buffer.size()), url_components::omitted,
+          url_components::omitted, parsed_port);
       out.parse_path(path_view);
       apply_query_and_hash();
     } else {
-      std::string host_str(input.substr(host_start, host_len));
+      out.host.emplace(input.data() + host_start, host_len);
       if (has_upper) {
-        unicode::to_lower_ascii(host_str.data(), host_str.size());
+        unicode::to_lower_ascii(out.host->data(), host_len);
       }
-      out.host = std::move(host_str);
       if (parsed_port != url_components::omitted) {
         out.port = static_cast<uint16_t>(parsed_port);
       }
@@ -1210,28 +1687,23 @@ after_rest:
     const int32_t tail_delta = static_cast<int32_t>(pathname_start) +
                                (insert_slash ? 1 : 0) -
                                static_cast<int32_t>(authority_end);
-    out.components.protocol_end = protocol_end;
-    out.components.username_end = protocol_end + 2;
-    out.components.host_start = protocol_end + 2;
-    out.components.host_end = static_cast<uint32_t>(host_end);
-    out.components.port = parsed_port;
-    out.components.pathname_start = pathname_start;
-    out.components.search_start =
+    set_plain_host_components(
+        out.components, protocol_end, static_cast<uint32_t>(host_end),
+        pathname_start,
         (query_start != std::string_view::npos)
             ? static_cast<uint32_t>(static_cast<int32_t>(query_start) +
                                     tail_delta)
-            : url_components::omitted;
-    out.components.hash_start =
+            : url_components::omitted,
         (hash_start != std::string_view::npos)
             ? static_cast<uint32_t>(static_cast<int32_t>(hash_start) +
                                     tail_delta)
-            : url_components::omitted;
+            : url_components::omitted,
+        parsed_port);
   } else {
-    std::string host_str(input.substr(host_start, host_len));
+    out.host.emplace(input.data() + host_start, host_len);
     if (has_upper) {
-      unicode::to_lower_ascii(host_str.data(), host_str.size());
+      unicode::to_lower_ascii(out.host->data(), host_len);
     }
-    out.host = std::move(host_str);
     if (parsed_port != url_components::omitted) {
       out.port = static_cast<uint16_t>(parsed_port);
     }
@@ -1253,224 +1725,102 @@ after_rest:
   return true;
 }
 
-// Fast path for already-canonical special-scheme URLs of the shape
-// scheme://host[/path][?query][#fragment]. When the host is a plain domain
-// but the rest needs encoding or dot-segment normalization, the host is
-// kept and the path/query/hash helpers finish the URL.
+// Host is already canonical (IPv4 dotted-decimal or IPv6 with brackets) and
+// is not a slice of `input`. Port / path / query / hash still come from input
+// after `host_end`.
 template <class result_type>
-ada_never_inline bool try_parse_simple_absolute(std::string_view input,
-                                                result_type& out) {
+ADA_PARSER_COLD bool finish_simple_absolute_literal_host(
+    std::string_view input, result_type& out, ada::scheme::type scheme_type,
+    uint32_t protocol_end, size_t host_start, size_t host_end,
+    std::string_view host, url_host_type parsed_host_type) {
   constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
   constexpr bool is_aggregator =
       std::is_same_v<result_type, ada::url_aggregator>;
   static_assert(is_ada_url || is_aggregator);
 
   const size_t len = input.size();
-  // Shortest accepted form is "ws://x" (6).
-  if (len < 6) [[unlikely]] {
-    return false;
-  }
   const auto* b = reinterpret_cast<const uint8_t*>(input.data());
-
-  size_t pos = 0;
-  ada::scheme::type scheme_type = ada::scheme::type::NOT_SPECIAL;
-  uint32_t protocol_end = 0;
-#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
-    defined(_M_X64) || defined(_M_IX86) || defined(_M_AMD64)
-  // One 8-byte load + integer compare is a single cmp/jcc on x86-64.
-  // Masked compares cover the shorter special schemes without extra loads.
-  if (len >= 8) {
-    uint64_t first8 = 0;
-    std::memcpy(&first8, b, 8);
-    if (first8 == 0x2f2f3a7370747468ull) {  // "https://"
-      pos = 8;
-      scheme_type = ada::scheme::type::HTTPS;
-      protocol_end = 6;
-    } else if ((first8 & 0x00ffffffffffffffull) ==
-               0x002f2f3a70747468ull) {  // "http://"
-      pos = 7;
-      scheme_type = ada::scheme::type::HTTP;
-      protocol_end = 5;
-    } else if ((first8 & 0x0000ffffffffffffull) ==
-               0x00002f2f3a737377ull) {  // "wss://"
-      pos = 6;
-      scheme_type = ada::scheme::type::WSS;
-      protocol_end = 4;
-    } else if ((first8 & 0x0000ffffffffffffull) ==
-               0x00002f2f3a707466ull) {  // "ftp://"
-      pos = 6;
-      scheme_type = ada::scheme::type::FTP;
-      protocol_end = 4;
-    } else if ((first8 & 0x000000ffffffffffull) ==
-               0x0000002f2f3a7377ull) {  // "ws://"
-      pos = 5;
-      scheme_type = ada::scheme::type::WS;
-      protocol_end = 3;
-    } else {
+  size_t p = host_end;
+  uint32_t parsed_port = url_components::omitted;
+  if (p < len && b[p] == ':') {
+    ++p;
+    uint32_t port_value = 0;
+    bool any_digit = false;
+    while (p < len && b[p] >= '0' && b[p] <= '9') {
+      any_digit = true;
+      port_value = port_value * 10 + static_cast<uint32_t>(b[p] - '0');
+      if (port_value > 65535) [[unlikely]] {
+        return false;
+      }
+      ++p;
+    }
+    if (p < len && b[p] != '/' && b[p] != '?' && b[p] != '#') [[unlikely]] {
       return false;
     }
-  } else if (b[0] == 'w' && b[1] == 's') {
-    if (b[2] == ':' && b[3] == '/' && b[4] == '/') {
-      pos = 5;
-      scheme_type = ada::scheme::type::WS;
-      protocol_end = 3;
-    } else if (b[2] == 's' && b[3] == ':' && b[4] == '/' && b[5] == '/') {
-      pos = 6;
-      scheme_type = ada::scheme::type::WSS;
-      protocol_end = 4;
-    } else {
-      return false;
+    const uint16_t default_port = ada::scheme::get_special_port(scheme_type);
+    if (any_digit && port_value != default_port) {
+      parsed_port = port_value;
     }
-  } else if (b[0] == 'f' && b[1] == 't' && b[2] == 'p' && b[3] == ':' &&
-             b[4] == '/' && b[5] == '/') {
-    pos = 6;
-    scheme_type = ada::scheme::type::FTP;
-    protocol_end = 4;
-  } else if (len >= 7 && b[0] == 'h' && b[1] == 't' && b[2] == 't' &&
-             b[3] == 'p' && b[4] == ':' && b[5] == '/' && b[6] == '/') {
-    pos = 7;
-    scheme_type = ada::scheme::type::HTTP;
-    protocol_end = 5;
-  } else {
-    return false;
   }
-#else
-  // Big-endian / uncommon arches: byte-wise special-scheme match.
-  if (len >= 8 && b[0] == 'h' && b[1] == 't' && b[2] == 't' && b[3] == 'p' &&
-      b[4] == 's' && b[5] == ':' && b[6] == '/' && b[7] == '/') {
-    pos = 8;
-    scheme_type = ada::scheme::type::HTTPS;
-    protocol_end = 6;
-  } else if (len >= 7 && b[0] == 'h' && b[1] == 't' && b[2] == 't' &&
-             b[3] == 'p' && b[4] == ':' && b[5] == '/' && b[6] == '/') {
-    pos = 7;
-    scheme_type = ada::scheme::type::HTTP;
-    protocol_end = 5;
-  } else if (b[0] == 'w' && b[1] == 's') {
-    if (b[2] == ':' && b[3] == '/' && b[4] == '/') {
-      pos = 5;
-      scheme_type = ada::scheme::type::WS;
-      protocol_end = 3;
-    } else if (len >= 6 && b[2] == 's' && b[3] == ':' && b[4] == '/' &&
-               b[5] == '/') {
-      pos = 6;
-      scheme_type = ada::scheme::type::WSS;
-      protocol_end = 4;
-    } else {
-      return false;
-    }
-  } else if (b[0] == 'f' && b[1] == 't' && b[2] == 'p' && b[3] == ':' &&
-             b[4] == '/' && b[5] == '/') {
-    pos = 6;
-    scheme_type = ada::scheme::type::FTP;
-    protocol_end = 4;
-  } else {
-    return false;
-  }
-#endif
-  if (pos < len && (b[pos] == '/' || b[pos] == '\\')) [[unlikely]] {
-    return false;
-  }
+  const size_t authority_end = p;
 
-  // Digit-led hosts are IPv4/numeric; '[' is IPv6. Skip before scanning.
-  if (pos < len && ((b[pos] >= '0' && b[pos] <= '9') || b[pos] == '[')) {
-    return false;
-  }
-
-  const size_t host_start = pos;
-  bool has_upper = false;
-  bool has_x = false;
-  size_t host_end = pos;
-  if (!scan_plain_host(b, pos, len, host_end, has_upper, has_x)) {
-    return false;
-  }
-  if (host_start == host_end) [[unlikely]] {
-    return false;
-  }
-  const size_t host_len = host_end - host_start;
-  if (host_len > 253) [[unlikely]] {
-    return false;
-  }
-  {
-    std::string_view hv(input.data() + host_start, host_len);
-    char host_buf[256];
-    if (has_upper) [[unlikely]] {
-      std::memcpy(host_buf, input.data() + host_start, host_len);
-      unicode::to_lower_ascii(host_buf, host_len);
-      hv = std::string_view(host_buf, host_len);
-    }
-    if (ada::checkers::last_label_may_be_a_number(hv)) [[unlikely]] {
-      return false;
-    }
-    // Punycode is "xn--...". The host scan already notes a lowercase 'x';
-    // uppercase 'X' is covered by has_upper after the in-place lower.
-    static constexpr std::string_view xn{"xn-", 3};
-    if ((has_x || has_upper) && hv.find(xn) != std::string_view::npos)
-        [[unlikely]] {
-      return false;
-    }
-  }
-
-  if (host_end < len && b[host_end] == ':') [[unlikely]] {
-    return finish_simple_absolute_with_port(input, out, scheme_type,
-                                            protocol_end, host_start, host_end,
-                                            host_len, has_upper);
-  }
-
-  size_t i = host_end;
+  size_t i = authority_end;
   size_t path_start = host_end;
   size_t path_end = host_end;
   size_t query_start = std::string_view::npos;
   size_t hash_start = std::string_view::npos;
   bool has_path = false;
   bool maybe_dot_segment = false;
+  bool saw_percent = false;
   bool rest_simple = true;
 
-  if (i < len && b[i] == '/') {
-    has_path = true;
-    path_start = i;
-    ++i;
-    scan_path_run(b, i, len, maybe_dot_segment);
-    if (i < len) {
-      const uint8_t cls = k_path[b[i]];
-      if (cls == 1) {
-        path_end = i;
-        if (b[i] == '?') {
-          query_start = i;
-          ++i;
-          goto scan_query;
-        }
-        hash_start = i;
-        ++i;
-        goto scan_hash;
-      }
-      rest_simple = false;
-      for (; i < len; ++i) {
+  if (i < len) {
+    if (b[i] == '/') {
+      has_path = true;
+      path_start = i;
+      ++i;
+      scan_path_run(b, i, len, maybe_dot_segment, saw_percent);
+      if (i < len) {
         if (b[i] == '?') {
           path_end = i;
           query_start = i;
           ++i;
-          goto scan_query_boundary;
+          goto scan_query;
         }
         if (b[i] == '#') {
           path_end = i;
           hash_start = i;
           ++i;
-          goto after_rest;
+          goto scan_hash;
         }
+        rest_simple = false;
+        for (; i < len; ++i) {
+          if (b[i] == '?') {
+            path_end = i;
+            query_start = i;
+            ++i;
+            goto scan_query_boundary;
+          }
+          if (b[i] == '#') {
+            path_end = i;
+            hash_start = i;
+            ++i;
+            goto after_rest;
+          }
+        }
+        path_end = i;
+        goto after_rest;
       }
       path_end = i;
-      goto after_rest;
+    } else if (b[i] == '?') {
+      query_start = i;
+      ++i;
+      goto scan_query;
+    } else {
+      hash_start = i;
+      ++i;
+      goto scan_hash;
     }
-    path_end = i;
-  } else if (i < len && b[i] == '?') {
-    query_start = i;
-    ++i;
-    goto scan_query;
-  } else if (i < len && b[i] == '#') {
-    hash_start = i;
-    ++i;
-    goto scan_hash;
   }
   goto after_rest;
 
@@ -1504,10 +1854,598 @@ scan_hash:
   }
 
 after_rest:
-  if (rest_simple && maybe_dot_segment) {
+  if (rest_simple && has_path && (maybe_dot_segment || saw_percent)) {
     const std::string_view path_body(input.data() + path_start,
                                      path_end - path_start);
-    if (path_has_dot_segment(path_body)) {
+    if (!simple_path_is_canonical(path_body, maybe_dot_segment, saw_percent)) {
+      rest_simple = false;
+    }
+  }
+
+  if (!rest_simple && (unicode::is_c0_control_or_space(input.back()) ||
+                       unicode::has_tabs_or_newline(input))) {
+    return false;
+  }
+
+  out.type = scheme_type;
+  out.host_type = parsed_host_type;
+
+  const uint32_t port_bytes = (parsed_port != url_components::omitted)
+                                  ? (1 + port_decimal_digit_count(parsed_port))
+                                  : 0;
+  const uint32_t new_host_end = static_cast<uint32_t>(host_start + host.size());
+
+  auto apply_query_and_hash = [&]() {
+    if (query_start != std::string_view::npos) {
+      const size_t q_end =
+          (hash_start != std::string_view::npos) ? hash_start : len;
+      out.update_base_search(std::string_view(input.data() + query_start + 1,
+                                              q_end - query_start - 1),
+                             character_sets::SPECIAL_QUERY_PERCENT_ENCODE);
+    }
+    if (hash_start != std::string_view::npos) {
+      out.update_unencoded_base_hash(std::string_view(
+          input.data() + hash_start + 1, len - hash_start - 1));
+    }
+  };
+
+  if (!rest_simple) {
+    const std::string_view path_view =
+        has_path
+            ? std::string_view(input.data() + path_start, path_end - path_start)
+            : std::string_view{};
+    if constexpr (is_aggregator) {
+      out.buffer.clear();
+      out.buffer.reserve(host_start + host.size() + port_bytes +
+                         (has_path ? path_end - path_start : 1) + 8);
+      out.buffer.append(input.substr(0, host_start));
+      out.buffer.append(host);
+      if (parsed_port != url_components::omitted) {
+        append_canonical_port(out.buffer, parsed_port);
+      }
+      set_plain_host_components(out.components, protocol_end, new_host_end,
+                                static_cast<uint32_t>(out.buffer.size()),
+                                url_components::omitted,
+                                url_components::omitted, parsed_port);
+      out.parse_path(path_view);
+      apply_query_and_hash();
+    } else {
+      out.host.emplace(host);
+      if (parsed_port != url_components::omitted) {
+        out.port = static_cast<uint16_t>(parsed_port);
+      }
+      out.parse_path(path_view);
+      apply_query_and_hash();
+    }
+    return true;
+  }
+
+  const bool insert_slash = !has_path;
+  if constexpr (is_aggregator) {
+    const size_t out_len = host_start + host.size() + port_bytes +
+                           (insert_slash ? 1 : 0) + (len - authority_end);
+    out.buffer.clear();
+    out.buffer.reserve(out_len);
+    out.buffer.append(input.substr(0, host_start));
+    out.buffer.append(host);
+    if (parsed_port != url_components::omitted) {
+      append_canonical_port(out.buffer, parsed_port);
+    }
+    if (insert_slash) {
+      out.buffer.push_back('/');
+    }
+    if (authority_end < len) {
+      out.buffer.append(input.substr(authority_end));
+    }
+    const uint32_t pathname_start = new_host_end + port_bytes;
+    const int32_t tail_delta = static_cast<int32_t>(pathname_start) +
+                               (insert_slash ? 1 : 0) -
+                               static_cast<int32_t>(authority_end);
+    set_plain_host_components(
+        out.components, protocol_end, new_host_end, pathname_start,
+        (query_start != std::string_view::npos)
+            ? static_cast<uint32_t>(static_cast<int32_t>(query_start) +
+                                    tail_delta)
+            : url_components::omitted,
+        (hash_start != std::string_view::npos)
+            ? static_cast<uint32_t>(static_cast<int32_t>(hash_start) +
+                                    tail_delta)
+            : url_components::omitted,
+        parsed_port);
+  } else {
+    out.host.emplace(host);
+    if (parsed_port != url_components::omitted) {
+      out.port = static_cast<uint16_t>(parsed_port);
+    }
+    if (insert_slash) {
+      out.path = "/";
+    } else {
+      out.path.assign(input.data() + path_start, path_end - path_start);
+    }
+    if (query_start != std::string_view::npos) {
+      const size_t q_end =
+          (hash_start != std::string_view::npos) ? hash_start : len;
+      out.query.emplace(input.data() + query_start + 1,
+                        q_end - query_start - 1);
+    }
+    if (hash_start != std::string_view::npos) {
+      out.hash.emplace(input.data() + hash_start + 1, len - hash_start - 1);
+    }
+  }
+  return true;
+}
+
+// After the host scanner misses on '[', finish a bracket IPv6 host. The
+// character after ']' must be a real authority/path delimiter; otherwise
+// the state machine rejects (e.g. http://[::1]foo).
+template <class result_type>
+ADA_PARSER_COLD bool try_finish_simple_ipv6(std::string_view input,
+                                            result_type& out,
+                                            ada::scheme::type scheme_type,
+                                            uint32_t protocol_end,
+                                            size_t host_start) {
+  const auto* b = reinterpret_cast<const uint8_t*>(input.data());
+  const size_t len = input.size();
+  size_t close = host_start + 1;
+  while (close < len && b[close] != ']') {
+    ++close;
+  }
+  if (close >= len) {
+    return false;
+  }
+  const size_t after = close + 1;
+  if (after < len) {
+    const uint8_t c = b[after];
+    if (c != ':' && c != '/' && c != '?' && c != '#') {
+      return false;
+    }
+  }
+  std::array<uint16_t, 8> addr{};
+  if (!detail::parse_ipv6_address(
+          std::string_view(input.data() + host_start + 1,
+                           close - host_start - 1),
+          addr)) {
+    return false;
+  }
+  const std::string canon = ada::serializers::ipv6(addr);
+  return finish_simple_absolute_literal_host(
+      input, out, scheme_type, protocol_end, host_start, after, canon, IPV6);
+}
+
+// Already-canonical `user[:password]@host[:port][/path][?query][#hash]`.
+// Invoked only after the host scanner misses or a port parse fails, so the
+// 99% no-credential path never pays for an '@' check.
+template <class result_type>
+ADA_PARSER_COLD bool try_finish_simple_userinfo(std::string_view input,
+                                                result_type& out,
+                                                ada::scheme::type scheme_type,
+                                                uint32_t protocol_end,
+                                                size_t auth_start) {
+  constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
+  constexpr bool is_aggregator =
+      std::is_same_v<result_type, ada::url_aggregator>;
+  static_assert(is_ada_url || is_aggregator);
+
+  const auto* b = reinterpret_cast<const uint8_t*>(input.data());
+  const size_t len = input.size();
+  size_t at = auth_start;
+  for (; at < len; ++at) {
+    const uint8_t c = b[at];
+    if (c == '@') {
+      break;
+    }
+    if (c == '/' || c == '?' || c == '#') {
+      return false;
+    }
+  }
+  if (at >= len || b[at] != '@') {
+    return false;
+  }
+
+  const std::string_view userinfo(input.data() + auth_start, at - auth_start);
+  const size_t colon = userinfo.find(':');
+  const std::string_view username =
+      colon == std::string_view::npos ? userinfo : userinfo.substr(0, colon);
+  const std::string_view password = colon == std::string_view::npos
+                                        ? std::string_view{}
+                                        : userinfo.substr(colon + 1);
+  // Empty credentials serialize without '@'. An empty password after ':'
+  // drops the colon (`user:@host` -> `user@host`). Leave those to the
+  // state machine so href stays canonical.
+  if ((username.empty() && password.empty()) ||
+      (password.empty() && colon != std::string_view::npos)) {
+    return false;
+  }
+  if (unicode::percent_encode_index(username,
+                                    character_sets::USERINFO_PERCENT_ENCODE) !=
+          username.size() ||
+      unicode::percent_encode_index(password,
+                                    character_sets::USERINFO_PERCENT_ENCODE) !=
+          password.size()) {
+    return false;
+  }
+
+  const size_t host_begin = at + 1;
+  bool has_upper = false;
+  bool has_xn = false;
+  size_t host_end = host_begin;
+  if (!scan_plain_host(b, host_begin, len, host_end, has_upper, has_xn)) {
+    return false;
+  }
+  const size_t host_len = host_end - host_begin;
+  if (host_len - 1 >= 253 || has_xn) {
+    return false;
+  }
+  {
+    uint8_t lastc = b[host_end - 1];
+    if (lastc == '.' && host_len > 1) {
+      lastc = b[host_end - 2];
+    }
+    if (has_upper) {
+      if (reject_uppercase_plain_host(input.data() + host_begin, host_len)) {
+        return false;
+      }
+    } else if (ada::checkers::is_ipv4_number_char(static_cast<char>(lastc)) &&
+               ada::checkers::last_label_may_be_a_number(
+                   std::string_view(input.data() + host_begin, host_len))) {
+      return false;
+    }
+  }
+
+  size_t p = host_end;
+  uint32_t parsed_port = url_components::omitted;
+  if (p < len && b[p] == ':') {
+    ++p;
+    uint32_t port_value = 0;
+    bool any_digit = false;
+    while (p < len && b[p] >= '0' && b[p] <= '9') {
+      any_digit = true;
+      port_value = port_value * 10 + static_cast<uint32_t>(b[p] - '0');
+      if (port_value > 65535) {
+        return false;
+      }
+      ++p;
+    }
+    if (p < len && b[p] != '/' && b[p] != '?' && b[p] != '#') {
+      return false;
+    }
+    const uint16_t default_port = ada::scheme::get_special_port(scheme_type);
+    if (!any_digit || port_value == default_port) {
+      // Empty or default port: href drops the colon. `https://u@h://x`
+      // must not keep the extra ':' in the aggregator buffer.
+      return false;
+    }
+    // `:0080` parses as 80 but href writes `:80`. Only finish when the
+    // digits are already the canonical decimal form.
+    if (p - (host_end + 1) != port_decimal_digit_count(port_value)) {
+      return false;
+    }
+    parsed_port = port_value;
+  }
+  const size_t authority_end = p;
+
+  size_t i = authority_end;
+  size_t path_start = authority_end;
+  size_t path_end = authority_end;
+  size_t query_start = std::string_view::npos;
+  size_t hash_start = std::string_view::npos;
+  bool has_path = false;
+  bool maybe_dot_segment = false;
+  bool saw_percent = false;
+  if (i < len && b[i] == '/') {
+    has_path = true;
+    path_start = i;
+    ++i;
+    scan_path_run(b, i, len, maybe_dot_segment, saw_percent);
+    if (i < len && k_path[b[i]] == 2) {
+      return false;
+    }
+    path_end = i;
+  }
+  if (i < len && b[i] == '?') {
+    query_start = i;
+    ++i;
+    scan_query_run(b, i, len);
+    if (i < len && b[i] != '#') {
+      return false;
+    }
+  }
+  if (i < len && b[i] == '#') {
+    hash_start = i;
+    ++i;
+    scan_hash_run(b, i, len);
+    if (i < len) {
+      return false;
+    }
+  } else if (i < len) {
+    return false;
+  }
+  if (has_path && (maybe_dot_segment || saw_percent) &&
+      !simple_path_is_canonical(
+          std::string_view(input.data() + path_start, path_end - path_start),
+          maybe_dot_segment, saw_percent)) {
+    return false;
+  }
+
+  out.type = scheme_type;
+  out.host_type = DEFAULT;
+  const bool insert_slash = !has_path;
+  const uint32_t username_end =
+      protocol_end + 2 + static_cast<uint32_t>(username.size());
+  const uint32_t at_host_start = static_cast<uint32_t>(at);
+  const uint32_t pathname_start =
+      static_cast<uint32_t>(insert_slash ? authority_end : path_start);
+  const uint32_t tail_delta = insert_slash ? 1 : 0;
+
+  if constexpr (is_aggregator) {
+    if (!insert_slash) {
+      out.buffer.assign(input);
+    } else {
+      out.buffer.clear();
+      out.buffer.reserve(len + 1);
+      out.buffer.append(input.substr(0, authority_end));
+      out.buffer.push_back('/');
+      if (authority_end < len) {
+        out.buffer.append(input.substr(authority_end));
+      }
+    }
+    if (has_upper) {
+      unicode::to_lower_ascii(out.buffer.data() + host_begin, host_len);
+    }
+    out.components.protocol_end = protocol_end;
+    out.components.username_end = username_end;
+    out.components.host_start = at_host_start;
+    out.components.host_end = static_cast<uint32_t>(host_end);
+    out.components.port = parsed_port;
+    out.components.pathname_start = pathname_start;
+    out.components.search_start =
+        (query_start != std::string_view::npos)
+            ? static_cast<uint32_t>(query_start + tail_delta)
+            : url_components::omitted;
+    out.components.hash_start =
+        (hash_start != std::string_view::npos)
+            ? static_cast<uint32_t>(hash_start + tail_delta)
+            : url_components::omitted;
+  } else {
+    out.username.assign(username);
+    out.password.assign(password);
+    out.host.emplace(input.substr(host_begin, host_len));
+    if (has_upper) {
+      unicode::to_lower_ascii(out.host->data(), host_len);
+    }
+    if (parsed_port != url_components::omitted) {
+      out.port = static_cast<uint16_t>(parsed_port);
+    }
+    if (insert_slash) {
+      out.path = "/";
+    } else {
+      out.path.assign(input.substr(path_start, path_end - path_start));
+    }
+    if (query_start != std::string_view::npos) {
+      const size_t q_end =
+          (hash_start != std::string_view::npos) ? hash_start : len;
+      out.query.emplace(input.substr(query_start + 1, q_end - query_start - 1));
+    }
+    if (hash_start != std::string_view::npos) {
+      out.hash.emplace(input.substr(hash_start + 1, len - hash_start - 1));
+    }
+  }
+  return true;
+}
+
+// Fast path for already-canonical special-scheme URLs of the shape
+// scheme://host[/path][?query][#fragment]. When the host is a plain domain
+// but the rest needs encoding or dot-segment normalization, the host is
+// kept and the path/query/hash helpers finish the URL.
+template <class result_type>
+ADA_PARSER_FASTPATH bool try_parse_simple_absolute(std::string_view input,
+                                                   result_type& out) {
+  constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
+  constexpr bool is_aggregator =
+      std::is_same_v<result_type, ada::url_aggregator>;
+  static_assert(is_ada_url || is_aggregator);
+
+  const size_t len = input.size();
+  const auto* b = reinterpret_cast<const uint8_t*>(input.data());
+
+  size_t pos = 0;
+  ada::scheme::type scheme_type = ada::scheme::type::NOT_SPECIAL;
+  uint32_t protocol_end = 0;
+#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
+    defined(_M_X64) || defined(_M_IX86) || defined(_M_AMD64)
+  // One 8-byte load + integer compare is a single cmp/jcc on x86-64.
+  // Non-https schemes stay in a never_inline helper (~4% of URLs).
+  if (len >= 8) [[likely]] {
+    uint64_t first8 = 0;
+    std::memcpy(&first8, b, 8);
+    if (first8 == 0x2f2f3a7370747468ull) {  // "https://"
+      pos = 8;
+      scheme_type = ada::scheme::type::HTTPS;
+      protocol_end = 6;
+    } else if (!match_non_https_special_scheme(first8, len, b, pos, scheme_type,
+                                               protocol_end)) {
+      return false;
+    }
+  } else if (!match_non_https_special_scheme(0, len, b, pos, scheme_type,
+                                             protocol_end)) {
+    return false;
+  }
+#else
+  // Big-endian / uncommon arches: byte-wise special-scheme match.
+  if (len >= 8 && b[0] == 'h' && b[1] == 't' && b[2] == 't' && b[3] == 'p' &&
+      b[4] == 's' && b[5] == ':' && b[6] == '/' && b[7] == '/') {
+    pos = 8;
+    scheme_type = ada::scheme::type::HTTPS;
+    protocol_end = 6;
+  } else if (!match_non_https_special_scheme(0, len, b, pos, scheme_type,
+                                             protocol_end)) {
+    return false;
+  }
+#endif
+
+  const size_t host_start = pos;
+  bool has_upper = false;
+  bool has_xn = false;
+  size_t host_end = pos;
+  if (!scan_plain_host(b, pos, len, host_end, has_upper, has_xn)) {
+    // '[' is a host-class reject. Only inspect it after the scanner misses
+    // so the 99% domain path never pays for an IPv6 check.
+    if (pos < len && b[pos] == '[') {
+      return try_finish_simple_ipv6(input, out, scheme_type, protocol_end, pos);
+    }
+    return try_finish_simple_userinfo(input, out, scheme_type, protocol_end,
+                                      pos);
+  }
+  const size_t host_len = host_end - host_start;
+  // Empty (0) or too long (>253): (0-1) wraps to SIZE_MAX.
+  // Extra slashes after "://" are an empty host here; the state machine
+  // consumes them, so this correctly misses the fast path.
+  if (host_len - 1 >= 253) [[unlikely]] {
+    return false;
+  }
+  bool is_ipv4 = false;
+  {
+    uint8_t lastc = b[host_end - 1];
+    if (lastc == '.' && host_len > 1) {
+      lastc = b[host_end - 2];
+    }
+    if (has_upper) [[unlikely]] {
+      if (reject_uppercase_plain_host(input.data() + host_start, host_len)) {
+        return false;
+      }
+    } else if (ada::checkers::is_ipv4_number_char(static_cast<char>(lastc)))
+        [[unlikely]] {
+      // .com/.org/.net never enter: last letter is not an IPv4 number char
+      // ('m' and 'g' are outside 0-9a-fxX).
+      const std::string_view hv(input.data() + host_start, host_len);
+      uint64_t ipv4_addr = 0;
+      bool rewrite_host = false;
+      if (reject_or_classify_numeric_last_label(hv, is_ipv4, ipv4_addr,
+                                                rewrite_host)) {
+        return false;
+      }
+      if (rewrite_host) {
+        char dotted[16];
+        const size_t n =
+            write_ipv4_dotted(dotted, static_cast<uint32_t>(ipv4_addr));
+        return finish_simple_absolute_literal_host(
+            input, out, scheme_type, protocol_end, host_start, host_end,
+            std::string_view(dotted, n), IPV4);
+      }
+    }
+    if (has_xn) [[unlikely]] {
+      return false;
+    }
+  }
+
+  if (host_end < len && b[host_end] == ':') [[unlikely]] {
+    if (finish_simple_absolute_with_port(input, out, scheme_type, protocol_end,
+                                         host_start, host_end, host_len,
+                                         has_upper)) {
+      if (is_ipv4) {
+        out.host_type = IPV4;
+      }
+      return true;
+    }
+    // `user:pass@host` looks like a port until the '@'.
+    return try_finish_simple_userinfo(input, out, scheme_type, protocol_end,
+                                      host_start);
+  }
+
+  size_t i = host_end;
+  size_t path_start = host_end;
+  size_t path_end = host_end;
+  size_t query_start = std::string_view::npos;
+  size_t hash_start = std::string_view::npos;
+  bool has_path = false;
+  bool maybe_dot_segment = false;
+  bool saw_percent = false;
+  bool rest_simple = true;
+
+  if (i < len) {
+    if (b[i] == '/') {
+      has_path = true;
+      path_start = i;
+      ++i;
+      scan_path_run(b, i, len, maybe_dot_segment, saw_percent);
+      if (i < len) {
+        if (b[i] == '?') {
+          path_end = i;
+          query_start = i;
+          ++i;
+          goto scan_query;
+        }
+        if (b[i] == '#') {
+          path_end = i;
+          hash_start = i;
+          ++i;
+          goto scan_hash;
+        }
+        rest_simple = false;
+        for (; i < len; ++i) {
+          if (b[i] == '?') {
+            path_end = i;
+            query_start = i;
+            ++i;
+            goto scan_query_boundary;
+          }
+          if (b[i] == '#') {
+            path_end = i;
+            hash_start = i;
+            ++i;
+            goto after_rest;
+          }
+        }
+        path_end = i;
+        goto after_rest;
+      }
+      path_end = i;
+    } else if (b[i] == '?') {
+      query_start = i;
+      ++i;
+      goto scan_query;
+    } else {
+      hash_start = i;
+      ++i;
+      goto scan_hash;
+    }
+  }
+  goto after_rest;
+
+scan_query:
+  scan_query_run(b, i, len);
+  if (i < len) {
+    if (b[i] == '#') {
+      hash_start = i;
+      ++i;
+      goto scan_hash;
+    }
+    rest_simple = false;
+    goto scan_query_boundary;
+  }
+  goto after_rest;
+
+scan_query_boundary:
+  for (; i < len; ++i) {
+    if (b[i] == '#') {
+      hash_start = i;
+      ++i;
+      goto after_rest;
+    }
+  }
+  goto after_rest;
+
+scan_hash:
+  scan_hash_run(b, i, len);
+  if (i < len) {
+    rest_simple = false;
+  }
+
+after_rest:
+  if (rest_simple && has_path && (maybe_dot_segment || saw_percent)) {
+    const std::string_view path_body(input.data() + path_start,
+                                     path_end - path_start);
+    if (!simple_path_is_canonical(path_body, maybe_dot_segment, saw_percent)) {
       rest_simple = false;
     }
   }
@@ -1523,78 +2461,34 @@ after_rest:
   }
 
   out.type = scheme_type;
-  out.is_valid = true;
-  out.has_opaque_path = false;
-  out.host_type = DEFAULT;
+  if (is_ipv4) {
+    out.host_type = IPV4;
+  }
 
   if (!rest_simple) {
-    // Host is a plain domain. Finish path/query/hash with
-    // the regular helpers
-    // so percent-encoding and dot segments do not re-parse the authority.
-    const std::string_view path_view =
-        has_path
-            ? std::string_view(input.data() + path_start, path_end - path_start)
-            : std::string_view{};
-    auto apply_query_and_hash = [&]() {
-      if (query_start != std::string_view::npos) {
-        const size_t q_end =
-            (hash_start != std::string_view::npos) ? hash_start : len;
-        out.update_base_search(std::string_view(input.data() + query_start + 1,
-                                                q_end - query_start - 1),
-                               character_sets::SPECIAL_QUERY_PERCENT_ENCODE);
-      }
-      if (hash_start != std::string_view::npos) {
-        out.update_unencoded_base_hash(std::string_view(
-            input.data() + hash_start + 1, len - hash_start - 1));
-      }
-    };
-    if constexpr (is_aggregator) {
-      out.buffer.assign(input.substr(0, host_end));
-      if (has_upper) {
-        unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
-      }
-      out.components.protocol_end = protocol_end;
-      out.components.username_end = protocol_end + 2;
-      out.components.host_start = protocol_end + 2;
-      out.components.host_end = static_cast<uint32_t>(host_end);
-      out.components.port = url_components::omitted;
-      out.components.pathname_start = static_cast<uint32_t>(host_end);
-      out.components.search_start = url_components::omitted;
-      out.components.hash_start = url_components::omitted;
-      out.parse_path(path_view);
-      apply_query_and_hash();
-    } else {
-      std::string host_str(input.substr(host_start, host_len));
-      if (has_upper) {
-        unicode::to_lower_ascii(host_str.data(), host_str.size());
-      }
-      out.host = std::move(host_str);
-      out.parse_path(path_view);
-      apply_query_and_hash();
-    }
+    finish_simple_absolute_handoff<result_type>(
+        input, out, host_start, host_end, host_len, protocol_end, has_upper,
+        has_path, path_start, path_end, query_start, hash_start);
     return true;
   }
 
   const bool need_slash = !has_path;
   if constexpr (is_aggregator) {
-    if (!need_slash) {
+    if (!need_slash) [[likely]] {
       // assign copies once. resize()+memcpy would value-init then overwrite.
-      out.buffer.assign(input);
+      out.buffer.assign(input.data(), input.size());
       if (has_upper) {
         unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
       }
-      out.components.protocol_end = protocol_end;
-      out.components.username_end = protocol_end + 2;
-      out.components.host_start = protocol_end + 2;
-      out.components.host_end = static_cast<uint32_t>(host_end);
-      out.components.port = url_components::omitted;
-      out.components.pathname_start = static_cast<uint32_t>(path_start);
-      out.components.search_start = (query_start != std::string_view::npos)
-                                        ? static_cast<uint32_t>(query_start)
-                                        : url_components::omitted;
-      out.components.hash_start = (hash_start != std::string_view::npos)
-                                      ? static_cast<uint32_t>(hash_start)
-                                      : url_components::omitted;
+      set_plain_host_components(out.components, protocol_end,
+                                static_cast<uint32_t>(host_end),
+                                static_cast<uint32_t>(path_start),
+                                (query_start != std::string_view::npos)
+                                    ? static_cast<uint32_t>(query_start)
+                                    : url_components::omitted,
+                                (hash_start != std::string_view::npos)
+                                    ? static_cast<uint32_t>(hash_start)
+                                    : url_components::omitted);
     } else {
       out.buffer.clear();
       out.buffer.reserve(len + 1);
@@ -1606,25 +2500,21 @@ after_rest:
       if (has_upper) {
         unicode::to_lower_ascii(out.buffer.data() + host_start, host_len);
       }
-      out.components.protocol_end = protocol_end;
-      out.components.username_end = protocol_end + 2;
-      out.components.host_start = protocol_end + 2;
-      out.components.host_end = static_cast<uint32_t>(host_end);
-      out.components.port = url_components::omitted;
-      out.components.pathname_start = static_cast<uint32_t>(host_end);
-      out.components.search_start = (query_start != std::string_view::npos)
-                                        ? static_cast<uint32_t>(query_start + 1)
-                                        : url_components::omitted;
-      out.components.hash_start = (hash_start != std::string_view::npos)
-                                      ? static_cast<uint32_t>(hash_start + 1)
-                                      : url_components::omitted;
+      set_plain_host_components(out.components, protocol_end,
+                                static_cast<uint32_t>(host_end),
+                                static_cast<uint32_t>(host_end),
+                                (query_start != std::string_view::npos)
+                                    ? static_cast<uint32_t>(query_start + 1)
+                                    : url_components::omitted,
+                                (hash_start != std::string_view::npos)
+                                    ? static_cast<uint32_t>(hash_start + 1)
+                                    : url_components::omitted);
     }
   } else {
-    std::string host_str(input.substr(host_start, host_len));
+    out.host.emplace(input.data() + host_start, host_len);
     if (has_upper) {
-      unicode::to_lower_ascii(host_str.data(), host_str.size());
+      unicode::to_lower_ascii(out.host->data(), host_len);
     }
-    out.host = std::move(host_str);
     if (need_slash) {
       out.path = "/";
     } else {
@@ -1647,9 +2537,9 @@ after_rest:
 // `#fragment` against a special-scheme base. Scheme-relative (`//`) and
 // scheme-like first segments (`foo:bar`) stay on the state machine.
 template <class result_type>
-ada_never_inline bool try_parse_simple_relative(std::string_view input,
-                                                const result_type& base,
-                                                result_type& out) {
+ADA_PARSER_FASTPATH bool try_parse_simple_relative(std::string_view input,
+                                                   const result_type& base,
+                                                   result_type& out) {
   constexpr bool is_ada_url = std::is_same_v<result_type, ada::url>;
   constexpr bool is_aggregator =
       std::is_same_v<result_type, ada::url_aggregator>;
@@ -1681,6 +2571,7 @@ ada_never_inline bool try_parse_simple_relative(std::string_view input,
   size_t hash_start = std::string_view::npos;
   bool has_path = false;
   bool maybe_dot_segment = false;
+  bool saw_percent = false;
 
   if (first == '/' || path_relative) {
     has_path = true;
@@ -1688,7 +2579,7 @@ ada_never_inline bool try_parse_simple_relative(std::string_view input,
     if (first == '/') {
       i = 1;
     }
-    scan_path_run(b, i, len, maybe_dot_segment);
+    scan_path_run(b, i, len, maybe_dot_segment, saw_percent);
     if (i < len) {
       const uint8_t cls = k_path[b[i]];
       if (cls == 2) {
@@ -1745,17 +2636,14 @@ ada_never_inline bool try_parse_simple_relative(std::string_view input,
     }
   }
 
-  if (has_path && maybe_dot_segment) {
-    const std::string_view path_body(input.data() + path_start,
-                                     path_end - path_start);
-    if (path_has_dot_segment(path_body)) {
-      return false;
-    }
+  if (has_path && (maybe_dot_segment || saw_percent) &&
+      !simple_path_is_canonical(
+          std::string_view(input.data() + path_start, path_end - path_start),
+          maybe_dot_segment, saw_percent)) {
+    return false;
   }
 
   out = base;
-  out.is_valid = true;
-  out.has_opaque_path = false;
 
   const size_t q_end =
       (hash_start != std::string_view::npos) ? hash_start : len;
@@ -1829,16 +2717,17 @@ ada_never_inline bool try_parse_simple_relative(std::string_view input,
 }
 
 template <class result_type, bool store_values>
-result_type parse_url_impl(std::string_view user_input,
-                           const result_type* base_url) {
+result_type& parse_url_impl_into(result_type& url, std::string_view user_input,
+                                 const result_type* base_url,
+                                 bool try_fast_path) {
   // We can specialize the implementation per type.
   // Important: result_type_is_ada_url is evaluated at *compile time*. This
   // means that doing if constexpr(result_type_is_ada_url) { something } else {
   // something else } is free (at runtime). This means that ada::url_aggregator
   // and ada::url **do not have to support the exact same API**.
-  constexpr bool result_type_is_ada_url = std::is_same_v<url, result_type>;
+  constexpr bool result_type_is_ada_url = std::is_same_v<ada::url, result_type>;
   constexpr bool result_type_is_ada_url_aggregator =
-      std::is_same_v<url_aggregator, result_type>;
+      std::is_same_v<ada::url_aggregator, result_type>;
   static_assert(result_type_is_ada_url ||
                 result_type_is_ada_url_aggregator);  // We don't support
                                                      // anything else for now.
@@ -1847,14 +2736,12 @@ result_type parse_url_impl(std::string_view user_input,
           " bytes],", (base_url != nullptr ? base_url->to_string() : "null"),
           ")");
 
-  result_type url{};
-
-  const uint32_t max_input_length = ada::get_max_input_length();
-
-  // We refuse to parse URL strings that exceed the maximum input length.
-  // By default, this is 4GB but can be configured via
-  // ada::set_max_input_length().
-  if (user_input.size() > max_input_length) [[unlikely]] {
+  // Default max is ~4 GB. Skip the atomic unless set_max_input_length ran.
+  // parse() already applied this check on the no-base miss path.
+  if (try_fast_path &&
+      (user_input.size() > std::numeric_limits<uint32_t>::max() ||
+       (ada::max_input_length_customized &&
+        user_input.size() > ada::get_max_input_length()))) [[unlikely]] {
     url.is_valid = false;
   }
   // Going forward, user_input.size() is in [0,
@@ -1868,42 +2755,31 @@ result_type parse_url_impl(std::string_view user_input,
   }
 
   // Simple absolute / relative fast paths (before tabs/newline scan).
+  // IPv6 ('[') is a host-class reject; dotted-decimal IPv4 is finished
+  // inside try_parse_simple_absolute. No extra preamble on the 99% path.
   if constexpr (store_values) {
-    bool hit_fast_path = false;
-    if (base_url == nullptr) {
-      // IPv4/IPv6 and userinfo miss the fast path. Skip the never_inline
-      // call so those URLs (including SetHref) do not pay for a miss.
-      const auto* p = reinterpret_cast<const uint8_t*>(user_input.data());
-      const size_t n = user_input.size();
-      size_t host_start = 0;
-      if (n >= 8 && p[4] == ':' && p[5] == '/' && p[6] == '/') {
-        host_start = 7;
-      } else if (n >= 9 && p[5] == ':' && p[6] == '/' && p[7] == '/') {
-        host_start = 8;
-      }
-      const uint8_t host_first = host_start != 0 ? p[host_start] : 0;
-      const bool skip_ip =
-          host_first == '[' || (host_first >= '0' && host_first <= '9');
-      const bool skip_userinfo =
-          host_start != 0 && authority_has_at(p, host_start, n);
-      hit_fast_path = !skip_ip && !skip_userinfo &&
-                      try_parse_simple_absolute(user_input, url);
-    } else {
-      hit_fast_path = try_parse_simple_relative(user_input, *base_url, url);
-    }
+    const bool hit_fast_path =
+        try_fast_path &&
+        ((base_url == nullptr)
+             ? try_parse_simple_absolute(user_input, url)
+             : try_parse_simple_relative(user_input, *base_url, url));
     if (hit_fast_path) {
-      if constexpr (result_type_is_ada_url_aggregator) {
-        if (url.buffer.size() > max_input_length) [[unlikely]] {
-          url.is_valid = false;
-        }
-      } else {
-        // For a small absolute input, even worst-case normalization cannot
-        // exceed the limit: percent encoding expands at most 3x and IDNA at
-        // most 4.5x. Avoid traversing every stored component on the common
-        // default-limit path.
-        if ((base_url != nullptr ||
-             user_input.size() > static_cast<size_t>(max_input_length) / 5) &&
-            url.get_href_size() > max_input_length) [[unlikely]] {
+      // Percent-encoding expands at most 3x and IDNA at most 4.5x. Skip
+      // the post-parse length walk when the input (absolute) cannot grow
+      // past the limit. Relative resolution can grow to base+input, so
+      // always recheck that path.
+      const bool may_expand_past_max =
+          ada::max_input_length_customized
+              ? user_input.size() >
+                    static_cast<size_t>(ada::get_max_input_length()) / 5
+              : user_input.size() > std::numeric_limits<uint32_t>::max() / 5;
+      if (base_url != nullptr || may_expand_past_max) [[unlikely]] {
+        const uint32_t max_input_length = ada::get_max_input_length();
+        if constexpr (result_type_is_ada_url_aggregator) {
+          if (url.buffer.size() > max_input_length) {
+            url.is_valid = false;
+          }
+        } else if (url.get_href_size() > max_input_length) {
           url.is_valid = false;
         }
       }
@@ -2826,12 +3702,19 @@ result_type parse_url_impl(std::string_view user_input,
   // original input size.
   if constexpr (store_values) {
     if (url.is_valid) {
-      if constexpr (result_type_is_ada_url_aggregator) {
-        if (url.buffer.size() > max_input_length) {
-          url.is_valid = false;
-        }
-      } else {
-        if (url.get_href_size() > max_input_length) {
+      const bool may_exceed =
+          ada::max_input_length_customized ||
+          user_input.size() > std::numeric_limits<uint32_t>::max() / 5;
+      if (may_exceed) [[unlikely]] {
+        const uint32_t max_input_length =
+            ada::max_input_length_customized
+                ? ada::get_max_input_length()
+                : std::numeric_limits<uint32_t>::max();
+        if constexpr (result_type_is_ada_url_aggregator) {
+          if (url.buffer.size() > max_input_length) {
+            url.is_valid = false;
+          }
+        } else if (url.get_href_size() > max_input_length) {
           url.is_valid = false;
         }
       }
@@ -2850,11 +3733,49 @@ template bool finish_simple_absolute_with_port<url>(std::string_view, url&,
 template bool finish_simple_absolute_with_port<url_aggregator>(
     std::string_view, url_aggregator&, ada::scheme::type, uint32_t, size_t,
     size_t, size_t, bool);
+template bool finish_simple_absolute_literal_host<url>(std::string_view, url&,
+                                                       ada::scheme::type,
+                                                       uint32_t, size_t, size_t,
+                                                       std::string_view,
+                                                       url_host_type);
+template bool finish_simple_absolute_literal_host<url_aggregator>(
+    std::string_view, url_aggregator&, ada::scheme::type, uint32_t, size_t,
+    size_t, std::string_view, url_host_type);
+template bool try_finish_simple_userinfo<url>(std::string_view, url&,
+                                              ada::scheme::type, uint32_t,
+                                              size_t);
+template bool try_finish_simple_userinfo<url_aggregator>(std::string_view,
+                                                         url_aggregator&,
+                                                         ada::scheme::type,
+                                                         uint32_t, size_t);
+template void finish_simple_absolute_handoff<url>(std::string_view, url&,
+                                                  size_t, size_t, size_t,
+                                                  uint32_t, bool, bool, size_t,
+                                                  size_t, size_t, size_t);
+template void finish_simple_absolute_handoff<url_aggregator>(
+    std::string_view, url_aggregator&, size_t, size_t, size_t, uint32_t, bool,
+    bool, size_t, size_t, size_t, size_t);
 template bool try_parse_simple_relative<url>(std::string_view, const url&,
                                              url&);
 template bool try_parse_simple_relative<url_aggregator>(std::string_view,
                                                         const url_aggregator&,
                                                         url_aggregator&);
+
+template url& parse_url_impl_into<url, true>(url&, std::string_view, const url*,
+                                             bool);
+template url_aggregator& parse_url_impl_into<url_aggregator, true>(
+    url_aggregator&, std::string_view, const url_aggregator*, bool);
+template url_aggregator& parse_url_impl_into<url_aggregator, false>(
+    url_aggregator&, std::string_view, const url_aggregator*, bool);
+
+template <class result_type, bool store_values>
+result_type parse_url_impl(std::string_view user_input,
+                           const result_type* base_url) {
+  result_type url{};
+  parse_url_impl_into<result_type, store_values>(url, user_input, base_url,
+                                                 true);
+  return url;
+}
 
 template url parse_url_impl<url, true>(std::string_view user_input,
                                        const url* base_url = nullptr);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -665,7 +665,9 @@ ada_really_inline void note_possible_segment_prefix(const uint8_t* b,
                                                     size_t pos,
                                                     size_t run_start,
                                                     bool& flag) noexcept {
-  if (pos == run_start || b[pos - 1] == '/') {
+  // pos==0 and pos!=run_start is an overlapping window that starts at the
+  // first input byte; do not read b[-1].
+  if (pos == run_start || (pos != 0 && b[pos - 1] == '/')) {
     flag = true;
   }
 }
@@ -710,7 +712,7 @@ ada_really_inline void note_dots_in_window(const uint8_t* b, size_t i,
   }
   const int slashes =
       _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi8('/'))) & valid_mask;
-  const bool leading_prefix = (i == run_start || b[i - 1] == '/');
+  const bool leading_prefix = i == run_start || (i != 0 && b[i - 1] == '/');
   // Overlapping last-16 windows that start before the path must mark the
   // first path byte as a segment start separately (see scan_path_run).
   // Doing that here taxes every dotted aligned window.
@@ -745,7 +747,7 @@ ada_really_inline void note_dots_in_window_neon(const uint8_t* b, size_t i,
   }
   const uint64_t slashes =
       neon_nibble_bits(vceqq_u8(w, vdupq_n_u8('/'))) & valid_bits;
-  const bool leading_prefix = (i == run_start || b[i - 1] == '/');
+  const bool leading_prefix = i == run_start || (i != 0 && b[i - 1] == '/');
   if (((dots & 0xF) != 0 && leading_prefix) || (dots & (slashes << 4)) != 0) {
     maybe_dot_segment = true;
   }

--- a/src/parser_finish.cpp
+++ b/src/parser_finish.cpp
@@ -1,0 +1,10 @@
+// Cold simple-absolute finish helpers and relative resolution. Own TU so
+// the unity ada.cpp I-cache for setters and the absolute fast-path I-cache
+// are not displaced by userinfo / IPv6 / port / handoff / relative.
+// Scanners are compiled here because the finish helpers call them.
+// Amalgamation leaves ADA_PARSER_FINISH_SEPARATE_TU unset and compiles
+// the full parser.cpp once via ada.cpp.
+#define ADA_SKIP_PARSER_FASTPATH
+#define ADA_SKIP_PARSER_IMPL
+// Relative resolution lives here with the other non-absolute helpers.
+#include "parser.cpp"

--- a/src/parser_hot.cpp
+++ b/src/parser_hot.cpp
@@ -1,0 +1,8 @@
+// Simple-absolute fast path and ada::parse. Own TU so the SIMD scanners
+// and try_parse do not displace setter I-cache in the unity ada.cpp.
+// Relative resolution lives in parser_finish.cpp. parse_url_impl stays
+// in ada.cpp (always_inline helpers).
+#define ADA_SKIP_PARSER_FINISH
+#define ADA_SKIP_PARSER_IMPL
+#define ADA_SKIP_PARSER_RELATIVE
+#include "parser.cpp"

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -316,6 +316,8 @@ ada_really_inline bool url::parse_host(std::string_view input) {
   return true;
 }
 
+void url::parse_path_outlined(std::string_view input) { parse_path(input); }
+
 ada_really_inline void url::parse_path(std::string_view input) {
   ada_log("parse_path ", input);
   std::string tmp_buffer;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -682,8 +682,8 @@ bool url::set_port(const std::string_view input) {
   // Find the first non-digit character to determine the length of digits
   auto first_non_digit =
       std::ranges::find_if_not(trimmed, ada::unicode::is_ascii_digit);
-  std::string_view digits_to_parse = std::string_view(
-      trimmed.data(), static_cast<size_t>(first_non_digit - trimmed.begin()));
+  const std::string_view digits_to_parse =
+      trimmed.substr(0, static_cast<size_t>(first_non_digit - trimmed.begin()));
 
   // Revert changes if parse_port fails.
   std::optional<uint16_t> previous_port = port;

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -10,12 +10,14 @@
 #include <array>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <ranges>
 #include <string>
 #include <string_view>
 
 namespace ada {
+extern bool max_input_length_customized;
 
 bool url::parse_opaque_host(std::string_view input) {
   ada_log("parse_opaque_host ", input, " [", input.size(), " bytes]");
@@ -96,136 +98,10 @@ bool url::parse_ipv4(std::string_view input) {
 
 bool url::parse_ipv6(std::string_view input) {
   ada_log("parse_ipv6 ", input, " [", input.size(), " bytes]");
-  if (input.empty() || input.size() > 45) [[unlikely]] {
-    return is_valid = false;
-  }
   std::array<uint16_t, 8> address{};
-#if defined(ADA_AVX512_IPV6)
-  if (bool simd_valid; detail::try_parse_ipv6_avx512(input.data(), input.size(),
-                                                     address, simd_valid)) {
-    if (!simd_valid) [[unlikely]] {
-      return is_valid = false;
-    }
-    host = ada::serializers::ipv6(address);
-    host_type = IPV6;
-    return true;
-  }
-  address = {};
-#endif
-  const char* pointer = input.data();
-  const char* const end = pointer + input.size();
-  int piece_index = 0;
-  int compress = -1;
-
-  if (*pointer == ':') {
-    if (input.size() == 1 || pointer[1] != ':') [[unlikely]] {
-      return is_valid = false;
-    }
-    pointer += 2;
-    compress = ++piece_index;
-  }
-
-  while (pointer != end) {
-    if (piece_index == 8) [[unlikely]] {
-      return is_valid = false;
-    }
-    if (*pointer == ':') {
-      if (compress != -1) [[unlikely]] {
-        return is_valid = false;
-      }
-      ++pointer;
-      compress = ++piece_index;
-      continue;
-    }
-
-    uint16_t value = 0;
-    const int length = detail::parse_hex_piece(pointer, end, value);
-
-    if (pointer != end && *pointer == '.') {
-      if (length == 0) [[unlikely]] {
-        return is_valid = false;
-      }
-      pointer -= length;
-      if (piece_index > 6) [[unlikely]] {
-        return is_valid = false;
-      }
-
-      int numbers_seen = 0;
-      while (pointer != end) {
-        int ipv4_piece = -1;
-        if (numbers_seen > 0) {
-          if (*pointer == '.' && numbers_seen < 4) {
-            ++pointer;
-          } else {
-            return is_valid = false;
-          }
-        }
-        if (pointer == end || *pointer < '0' || *pointer > '9') [[unlikely]] {
-          return is_valid = false;
-        }
-        ipv4_piece = *pointer - '0';
-        ++pointer;
-        if (pointer != end && *pointer >= '0' && *pointer <= '9') {
-          if (ipv4_piece == 0) [[unlikely]] {
-            return is_valid = false;
-          }
-          ipv4_piece = ipv4_piece * 10 + (*pointer - '0');
-          ++pointer;
-          if (pointer != end && *pointer >= '0' && *pointer <= '9') {
-            ipv4_piece = ipv4_piece * 10 + (*pointer - '0');
-            ++pointer;
-            if (ipv4_piece > 255) [[unlikely]] {
-              return is_valid = false;
-            }
-          }
-        }
-        address[static_cast<size_t>(piece_index)] = static_cast<uint16_t>(
-            address[static_cast<size_t>(piece_index)] * 0x100 +
-            static_cast<uint16_t>(ipv4_piece));
-        ++numbers_seen;
-        if (numbers_seen == 2 || numbers_seen == 4) {
-          ++piece_index;
-        }
-      }
-      if (numbers_seen != 4) [[unlikely]] {
-        return is_valid = false;
-      }
-      break;
-    }
-
-    if (length == 0) [[unlikely]] {
-      return is_valid = false;
-    }
-
-    if (pointer != end && *pointer == ':') {
-      ++pointer;
-      if (pointer == end) [[unlikely]] {
-        return is_valid = false;
-      }
-    } else if (pointer != end) [[unlikely]] {
-      return is_valid = false;
-    }
-
-    address[static_cast<size_t>(piece_index)] = value;
-    ++piece_index;
-  }
-
-  if (compress != -1) {
-    const int right = piece_index - compress;
-    if (right > 0) {
-      const size_t dest = static_cast<size_t>(8 - right);
-      const size_t src = static_cast<size_t>(compress);
-      if (dest != src) {
-        for (size_t i = static_cast<size_t>(right); i-- > 0;) {
-          address[dest + i] = address[src + i];
-          address[src + i] = 0;
-        }
-      }
-    }
-  } else if (piece_index != 8) [[unlikely]] {
+  if (!detail::parse_ipv6_address(input, address)) [[unlikely]] {
     return is_valid = false;
   }
-
   host = ada::serializers::ipv6(address);
   ada_log("parse_ipv6 ", *host);
   host_type = IPV6;
@@ -610,6 +486,10 @@ ada_really_inline void url::parse_path(std::string_view input) {
 }
 
 bool url::needs_rollback_snapshot(size_t input_len) const noexcept {
+  if (!ada::max_input_length_customized) [[likely]] {
+    return get_href_size() + input_len + 16 >
+           std::numeric_limits<uint32_t>::max();
+  }
   return get_href_size() + input_len + 16 > ada::get_max_input_length();
 }
 
@@ -621,12 +501,17 @@ bool url::set_host_or_hostname(const std::string_view input) {
 
   url saved_url(*this);
 
-  size_t host_end_pos = input.find('#');
-  std::string _host(input.data(), host_end_pos != std::string_view::npos
-                                      ? host_end_pos
-                                      : input.size());
-  helpers::remove_ascii_tab_or_newline(_host);
-  std::string_view new_host(_host);
+  std::string cleaned;
+  std::string_view new_host = input;
+  if (const size_t host_end_pos = input.find('#');
+      host_end_pos != std::string_view::npos) {
+    new_host = input.substr(0, host_end_pos);
+  }
+  if (unicode::has_tabs_or_newline(new_host)) {
+    cleaned.assign(new_host);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    new_host = cleaned;
+  }
 
   auto check_url_size = [&]() -> bool {
     if (get_href_size() > ada::get_max_input_length()) {
@@ -639,7 +524,7 @@ bool url::set_host_or_hostname(const std::string_view input) {
   // If url's scheme is "file", then set state to file host state, instead of
   // host state.
   if (type != ada::scheme::type::FILE) {
-    std::string_view host_view(_host.data(), _host.length());
+    std::string_view host_view = new_host;
     auto [location, found_colon] =
         helpers::get_host_delimiter_location(is_special(), host_view);
 
@@ -777,8 +662,13 @@ bool url::set_port(const std::string_view input) {
     return true;
   }
 
-  std::string trimmed(input);
-  helpers::remove_ascii_tab_or_newline(trimmed);
+  std::string cleaned;
+  std::string_view trimmed = input;
+  if (unicode::has_tabs_or_newline(input)) {
+    cleaned.assign(input);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    trimmed = cleaned;
+  }
 
   if (trimmed.empty()) {
     return true;
@@ -792,8 +682,8 @@ bool url::set_port(const std::string_view input) {
   // Find the first non-digit character to determine the length of digits
   auto first_non_digit =
       std::ranges::find_if_not(trimmed, ada::unicode::is_ascii_digit);
-  std::string_view digits_to_parse =
-      std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
+  std::string_view digits_to_parse = std::string_view(
+      trimmed.data(), static_cast<size_t>(first_non_digit - trimmed.begin()));
 
   // Revert changes if parse_port fails.
   std::optional<uint16_t> previous_port = port;
@@ -817,9 +707,13 @@ void url::set_hash(const std::string_view input) {
     return;
   }
 
-  std::string new_value;
-  new_value = input[0] == '#' ? input.substr(1) : input;
-  helpers::remove_ascii_tab_or_newline(new_value);
+  std::string cleaned;
+  std::string_view new_value = input[0] == '#' ? input.substr(1) : input;
+  if (unicode::has_tabs_or_newline(new_value)) {
+    cleaned.assign(new_value);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    new_value = cleaned;
+  }
   auto previous_hash = std::move(hash);
   hash = unicode::percent_encode(new_value,
                                  ada::character_sets::FRAGMENT_PERCENT_ENCODE);
@@ -835,9 +729,13 @@ void url::set_search(const std::string_view input) {
     return;
   }
 
-  std::string new_value;
-  new_value = input[0] == '?' ? input.substr(1) : input;
-  helpers::remove_ascii_tab_or_newline(new_value);
+  std::string cleaned;
+  std::string_view new_value = input[0] == '?' ? input.substr(1) : input;
+  if (unicode::has_tabs_or_newline(new_value)) {
+    cleaned.assign(new_value);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    new_value = cleaned;
+  }
 
   auto query_percent_encode_set =
       is_special() ? ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE
@@ -865,8 +763,13 @@ bool url::set_pathname(const std::string_view input) {
 }
 
 bool url::set_protocol(const std::string_view input) {
-  std::string view(input);
-  helpers::remove_ascii_tab_or_newline(view);
+  std::string cleaned;
+  std::string_view view = input;
+  if (unicode::has_tabs_or_newline(input)) {
+    cleaned.assign(input);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    view = cleaned;
+  }
   if (view.empty()) {
     return true;
   }
@@ -876,34 +779,34 @@ bool url::set_protocol(const std::string_view input) {
     return false;
   }
 
-  view.append(":");
-
-  std::string::iterator pointer =
-      std::ranges::find_if_not(view, unicode::is_alnum_plus);
-
-  if (pointer != view.end() && *pointer == ':') {
-    std::optional<url> saved_url;
-    if (needs_rollback_snapshot(view.size())) {
-      saved_url = *this;
-    }
-    bool result = parse_scheme<true>(
-        std::string_view(view.data(), pointer - view.begin()));
-    if (result && saved_url && get_href_size() > ada::get_max_input_length()) {
-      *this = std::move(*saved_url);
-      return false;
-    }
-    return result;
+  size_t n = 0;
+  while (n < view.size() && unicode::is_alnum_plus(view[n])) {
+    ++n;
   }
-  return false;
+  if (n < view.size() && view[n] != ':') {
+    return false;
+  }
+
+  std::optional<url> saved_url;
+  if (needs_rollback_snapshot(n + 1)) {
+    saved_url = *this;
+  }
+  const bool result = parse_scheme<true>(view.substr(0, n));
+  if (result && saved_url && get_href_size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
+    return false;
+  }
+  return result;
 }
 
 bool url::set_href(const std::string_view input) {
   ada::result<ada::url> out = ada::parse<ada::url>(input);
 
   if (out) {
-    // The parser enforces get_max_input_length() on both the input and the
-    // normalized result. This is a defense-in-depth check.
-    if (out->get_href_size() > ada::get_max_input_length()) {
+    // parse() already enforces the default ~4 GB cap. Only reload the
+    // atomic when set_max_input_length installed a tighter limit.
+    if (ada::max_input_length_customized &&
+        out->get_href_size() > ada::get_max_input_length()) {
       return false;
     }
     *this = *out;

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -421,6 +421,10 @@ bool url_aggregator::set_pathname(const std::string_view input) {
   return true;
 }
 
+void url_aggregator::parse_path_outlined(std::string_view input) {
+  parse_path(input);
+}
+
 ada_really_inline void url_aggregator::parse_path(std::string_view input) {
   ada_log("url_aggregator::parse_path ", input);
   ADA_ASSERT_TRUE(validate());

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iterator>
+#include <limits>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -37,6 +38,8 @@ ada_really_inline void apply_shifted_non_scheme_offsets(
 }  // namespace
 
 namespace ada {
+extern bool max_input_length_customized;
+
 template <bool has_state_override>
 [[nodiscard]] ada_really_inline bool url_aggregator::parse_scheme_with_colon(
     const std::string_view input_with_colon) {
@@ -213,7 +216,12 @@ inline void url_aggregator::set_scheme(std::string_view new_scheme) {
 bool url_aggregator::needs_rollback_snapshot(size_t input_len) const noexcept {
   // 3x should cover worst-case percent-encoding of every input byte; the
   // constant covers the handful of delimiter bytes a setter may add ("/.", "?",
-  // "#" and so on)
+  // "#" and so on). The default max is ~4 GB: skip the atomic unless a
+  // tighter limit was installed.
+  if (!ada::max_input_length_customized) [[likely]] {
+    return buffer.size() + input_len * 3 + 16 >
+           std::numeric_limits<uint32_t>::max();
+  }
   return buffer.size() + input_len * 3 + 16 > ada::get_max_input_length();
 }
 
@@ -221,8 +229,13 @@ bool url_aggregator::set_protocol(const std::string_view input) {
   ada_log("url_aggregator::set_protocol ", input);
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
-  std::string view(input);
-  helpers::remove_ascii_tab_or_newline(view);
+  std::string cleaned;
+  std::string_view view = input;
+  if (unicode::has_tabs_or_newline(input)) {
+    cleaned.assign(input);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    view = cleaned;
+  }
   if (view.empty()) {
     return true;
   }
@@ -232,25 +245,37 @@ bool url_aggregator::set_protocol(const std::string_view input) {
     return false;
   }
 
-  view.append(":");
-
-  std::string::iterator pointer =
-      std::ranges::find_if_not(view, unicode::is_alnum_plus);
-
-  if (pointer != view.end() && *pointer == ':') {
-    std::optional<url_aggregator> saved_url;
-    if (needs_rollback_snapshot(view.size())) {
-      saved_url = *this;
-    }
-    bool result = parse_scheme_with_colon<true>(
-        view.substr(0, pointer - view.begin() + 1));
-    if (result && saved_url && buffer.size() > ada::get_max_input_length()) {
-      *this = std::move(*saved_url);
-      return false;
-    }
-    return result;
+  size_t n = 0;
+  while (n < view.size() && unicode::is_alnum_plus(view[n])) {
+    ++n;
   }
-  return false;
+  if (n < view.size() && view[n] != ':') {
+    return false;
+  }
+
+  char stack[64];
+  std::string heap;
+  std::string_view with_colon;
+  if (n + 1 <= sizeof(stack)) {
+    std::memcpy(stack, view.data(), n);
+    stack[n] = ':';
+    with_colon = std::string_view(stack, n + 1);
+  } else {
+    heap.assign(view.data(), n);
+    heap.push_back(':');
+    with_colon = heap;
+  }
+
+  std::optional<url_aggregator> saved_url;
+  if (needs_rollback_snapshot(n + 1)) {
+    saved_url = *this;
+  }
+  const bool result = parse_scheme_with_colon<true>(with_colon);
+  if (result && saved_url && buffer.size() > ada::get_max_input_length()) {
+    *this = std::move(*saved_url);
+    return false;
+  }
+  return result;
 }
 
 bool url_aggregator::set_username(const std::string_view input) {
@@ -322,8 +347,13 @@ bool url_aggregator::set_port(const std::string_view input) {
     return true;
   }
 
-  std::string trimmed(input);
-  helpers::remove_ascii_tab_or_newline(trimmed);
+  std::string cleaned;
+  std::string_view trimmed = input;
+  if (unicode::has_tabs_or_newline(input)) {
+    cleaned.assign(input);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    trimmed = cleaned;
+  }
 
   if (trimmed.empty()) {
     return true;
@@ -337,8 +367,8 @@ bool url_aggregator::set_port(const std::string_view input) {
   // Find the first non-digit character to determine the length of digits
   auto first_non_digit =
       std::ranges::find_if_not(trimmed, ada::unicode::is_ascii_digit);
-  std::string_view digits_to_parse =
-      std::string_view(trimmed.data(), first_non_digit - trimmed.begin());
+  std::string_view digits_to_parse = std::string_view(
+      trimmed.data(), static_cast<size_t>(first_non_digit - trimmed.begin()));
 
   // parse_port only touches the buffer once the digits are already known to
   // be in range, so an invalid port never mutates anything and needs no
@@ -442,9 +472,13 @@ void url_aggregator::set_search(const std::string_view input) {
     return;
   }
 
-  std::string new_value;
-  new_value = input[0] == '?' ? input.substr(1) : input;
-  helpers::remove_ascii_tab_or_newline(new_value);
+  std::string cleaned;
+  std::string_view new_value = input[0] == '?' ? input.substr(1) : input;
+  if (unicode::has_tabs_or_newline(new_value)) {
+    cleaned.assign(new_value);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    new_value = cleaned;
+  }
 
   auto query_percent_encode_set =
       is_special() ? ada::character_sets::SPECIAL_QUERY_PERCENT_ENCODE
@@ -475,9 +509,13 @@ void url_aggregator::set_hash(const std::string_view input) {
     return;
   }
 
-  std::string new_value;
-  new_value = input[0] == '#' ? input.substr(1) : input;
-  helpers::remove_ascii_tab_or_newline(new_value);
+  std::string cleaned;
+  std::string_view new_value = input[0] == '#' ? input.substr(1) : input;
+  if (unicode::has_tabs_or_newline(new_value)) {
+    cleaned.assign(new_value);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    new_value = cleaned;
+  }
   std::optional<url_aggregator> saved_url;
   if (needs_rollback_snapshot(new_value.size())) {
     saved_url = *this;
@@ -497,9 +535,10 @@ bool url_aggregator::set_href(const std::string_view input) {
   ada_log("url_aggregator::set_href, success :", out.has_value());
 
   if (out) {
-    // The parser enforces get_max_input_length() on both the input and the
-    // normalized result. This is a defense-in-depth check.
-    if (out->buffer.size() > ada::get_max_input_length()) {
+    // parse() already enforces the default ~4 GB cap. Only reload the
+    // atomic when set_max_input_length installed a tighter limit.
+    if (ada::max_input_length_customized &&
+        out->buffer.size() > ada::get_max_input_length()) {
       return false;
     }
     ada_log("url_aggregator::set_href, parsed ", out->to_string());
@@ -655,12 +694,17 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
 
   url_aggregator saved_url(*this);
 
-  size_t host_end_pos = input.find('#');
-  std::string _host(input.data(), host_end_pos != std::string_view::npos
-                                      ? host_end_pos
-                                      : input.size());
-  helpers::remove_ascii_tab_or_newline(_host);
-  std::string_view new_host(_host);
+  std::string cleaned;
+  std::string_view new_host = input;
+  if (const size_t host_end_pos = input.find('#');
+      host_end_pos != std::string_view::npos) {
+    new_host = input.substr(0, host_end_pos);
+  }
+  if (unicode::has_tabs_or_newline(new_host)) {
+    cleaned.assign(new_host);
+    helpers::remove_ascii_tab_or_newline(cleaned);
+    new_host = cleaned;
+  }
 
   auto check_url_size = [&]() -> bool {
     if (buffer.size() > ada::get_max_input_length()) {
@@ -673,7 +717,7 @@ bool url_aggregator::set_host_or_hostname(const std::string_view input) {
   // If url's scheme is "file", then set state to file host state, instead of
   // host state.
   if (type != ada::scheme::type::FILE) {
-    std::string_view host_view(_host.data(), _host.length());
+    std::string_view host_view = new_host;
     auto [location, found_colon] =
         helpers::get_host_delimiter_location(is_special(), host_view);
 
@@ -1117,136 +1161,8 @@ bool url_aggregator::parse_ipv6(std::string_view input) {
   ada_log("parse_ipv6 ", input, " [", input.size(), " bytes]");
   ADA_ASSERT_TRUE(validate());
   ADA_ASSERT_TRUE(!helpers::overlaps(input, buffer));
-  if (input.empty() || input.size() > 45) [[unlikely]] {
-    return is_valid = false;
-  }
   std::array<uint16_t, 8> address{};
-#if defined(ADA_AVX512_IPV6)
-  if (bool simd_valid; detail::try_parse_ipv6_avx512(input.data(), input.size(),
-                                                     address, simd_valid)) {
-    if (!simd_valid) [[unlikely]] {
-      return is_valid = false;
-    }
-    const std::string serialized = ada::serializers::ipv6(address);
-    if (get_hostname() != serialized) {
-      update_base_hostname(serialized);
-    }
-    host_type = IPV6;
-    return true;
-  }
-  address = {};
-#endif
-  const char* pointer = input.data();
-  const char* const end = pointer + input.size();
-  int piece_index = 0;
-  int compress = -1;
-
-  if (*pointer == ':') {
-    if (input.size() == 1 || pointer[1] != ':') [[unlikely]] {
-      return is_valid = false;
-    }
-    pointer += 2;
-    compress = ++piece_index;
-  }
-
-  while (pointer != end) {
-    if (piece_index == 8) [[unlikely]] {
-      return is_valid = false;
-    }
-    if (*pointer == ':') {
-      if (compress != -1) [[unlikely]] {
-        return is_valid = false;
-      }
-      ++pointer;
-      compress = ++piece_index;
-      continue;
-    }
-
-    uint16_t value = 0;
-    const int length = detail::parse_hex_piece(pointer, end, value);
-
-    if (pointer != end && *pointer == '.') {
-      if (length == 0) [[unlikely]] {
-        return is_valid = false;
-      }
-      pointer -= length;
-      if (piece_index > 6) [[unlikely]] {
-        return is_valid = false;
-      }
-
-      int numbers_seen = 0;
-      while (pointer != end) {
-        int ipv4_piece = -1;
-        if (numbers_seen > 0) {
-          if (*pointer == '.' && numbers_seen < 4) {
-            ++pointer;
-          } else {
-            return is_valid = false;
-          }
-        }
-        if (pointer == end || *pointer < '0' || *pointer > '9') [[unlikely]] {
-          return is_valid = false;
-        }
-        ipv4_piece = *pointer - '0';
-        ++pointer;
-        if (pointer != end && *pointer >= '0' && *pointer <= '9') {
-          if (ipv4_piece == 0) [[unlikely]] {
-            return is_valid = false;
-          }
-          ipv4_piece = ipv4_piece * 10 + (*pointer - '0');
-          ++pointer;
-          if (pointer != end && *pointer >= '0' && *pointer <= '9') {
-            ipv4_piece = ipv4_piece * 10 + (*pointer - '0');
-            ++pointer;
-            if (ipv4_piece > 255) [[unlikely]] {
-              return is_valid = false;
-            }
-          }
-        }
-        address[static_cast<size_t>(piece_index)] = static_cast<uint16_t>(
-            address[static_cast<size_t>(piece_index)] * 0x100 +
-            static_cast<uint16_t>(ipv4_piece));
-        ++numbers_seen;
-        if (numbers_seen == 2 || numbers_seen == 4) {
-          ++piece_index;
-        }
-      }
-      if (numbers_seen != 4) [[unlikely]] {
-        return is_valid = false;
-      }
-      break;
-    }
-
-    if (length == 0) [[unlikely]] {
-      return is_valid = false;
-    }
-
-    if (pointer != end && *pointer == ':') {
-      ++pointer;
-      if (pointer == end) [[unlikely]] {
-        return is_valid = false;
-      }
-    } else if (pointer != end) [[unlikely]] {
-      return is_valid = false;
-    }
-
-    address[static_cast<size_t>(piece_index)] = value;
-    ++piece_index;
-  }
-
-  if (compress != -1) {
-    const int right = piece_index - compress;
-    if (right > 0) {
-      const size_t dest = static_cast<size_t>(8 - right);
-      const size_t src = static_cast<size_t>(compress);
-      if (dest != src) {
-        for (size_t i = static_cast<size_t>(right); i-- > 0;) {
-          address[dest + i] = address[src + i];
-          address[src + i] = 0;
-        }
-      }
-    }
-  } else if (piece_index != 8) [[unlikely]] {
+  if (!detail::parse_ipv6_address(input, address)) [[unlikely]] {
     return is_valid = false;
   }
 

--- a/src/url_aggregator.cpp
+++ b/src/url_aggregator.cpp
@@ -261,7 +261,7 @@ bool url_aggregator::set_protocol(const std::string_view input) {
     stack[n] = ':';
     with_colon = std::string_view(stack, n + 1);
   } else {
-    heap.assign(view.data(), n);
+    heap.assign(view.substr(0, n));
     heap.push_back(':');
     with_colon = heap;
   }
@@ -367,8 +367,8 @@ bool url_aggregator::set_port(const std::string_view input) {
   // Find the first non-digit character to determine the length of digits
   auto first_non_digit =
       std::ranges::find_if_not(trimmed, ada::unicode::is_ascii_digit);
-  std::string_view digits_to_parse = std::string_view(
-      trimmed.data(), static_cast<size_t>(first_non_digit - trimmed.begin()));
+  const std::string_view digits_to_parse =
+      trimmed.substr(0, static_cast<size_t>(first_non_digit - trimmed.begin()));
 
   // parse_port only touches the buffer once the digits are already known to
   // be in range, so an invalid port never mutates anything and needs no

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -263,6 +263,22 @@ TYPED_TEST(basic_tests, readme8) {
   SUCCEED();
 }
 
+TYPED_TEST(basic_tests, setters_strip_ascii_tab_or_newline) {
+  auto url = ada::parse<TypeParam>(
+      "https://user:pass@www.example.com:8080/path?q=1#h");
+  ASSERT_TRUE(url);
+  ASSERT_TRUE(url->set_protocol("w\tss"));
+  ASSERT_EQ(url->get_protocol(), "wss:");
+  ASSERT_TRUE(url->set_port("90\t90"));
+  ASSERT_EQ(url->get_port(), "9090");
+  url->set_search("?a=\t1");
+  ASSERT_EQ(url->get_search(), "?a=1");
+  url->set_hash("#new\tfrag");
+  ASSERT_EQ(url->get_hash(), "#newfrag");
+  ASSERT_TRUE(url->set_hostname("www.newhost.exam\tple.org"));
+  ASSERT_EQ(url->get_hostname(), "www.newhost.example.org");
+}
+
 TYPED_TEST(basic_tests, host_nfc_reorders_precomposed_starter) {
   // A precomposed starter followed by a combining mark of lower combining class
   // is not in NFC: normalization decomposes the starter and reorders the marks.
@@ -606,6 +622,9 @@ TEST(basic_tests, can_parse_consistency_clean_http_frontend) {
            "http:///path",
            "http://Example.com/",
            "http://example.com:65536/",
+           "https://www.google.com/webhp?hl=en",
+           "https://images-na.ssl-images-amazon.com/images/I/x.css",
+           "http://abcdefghijklmnopqrstuvwxyz0123456789-._~example.com/path",
            "http://1.2.3.999/",
            "http://xn--/",
            "http://example.com./",
@@ -1726,8 +1745,8 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path) {
 }
 
 TYPED_TEST(basic_tests, last_label_may_be_a_number_gate) {
-  // Ordinary .com hosts end with a hex letter; the last-label gate must
-  // still treat them as domains, not IPv4.
+  // Ordinary .com/.org hosts end with a letter outside 0-9a-fxX, so the
+  // last-label gate rejects IPv4 without walking the label.
   {
     auto url = ada::parse<TypeParam>("https://www.google.com/search");
     ASSERT_TRUE(url);
@@ -1798,7 +1817,8 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
     ASSERT_EQ(url->get_hostname(), "[2001:db8::1]");
   }
 
-  // Last-label gate inside the fast path (non-digit-led hosts).
+  // Last-label gate inside the fast path. Digit-led domains are accepted;
+  // a numeric last label that is not dotted-decimal IPv4 is rejected.
   ASSERT_FALSE(ada::parse<TypeParam>("https://foo.123"));
   ASSERT_FALSE(ada::parse<TypeParam>("https://foo.123."));
   ASSERT_FALSE(ada::parse<TypeParam>("https://foo.0xFF"));
@@ -1806,6 +1826,134 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
     auto url = ada::parse<TypeParam>("ws://123");
     ASSERT_TRUE(url);
     ASSERT_EQ(url->get_hostname(), "0.0.0.123");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://1and1.com/x"), u));
+    ASSERT_EQ(u.get_hostname(), "1and1.com");
+    ASSERT_EQ(u.get_pathname(), "/x");
+    ASSERT_EQ(u.host_type, ada::DEFAULT);
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://123.com/"), u));
+    ASSERT_EQ(u.get_hostname(), "123.com");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://192.168.1.1"), u));
+    ASSERT_EQ(u.get_hostname(), "192.168.1.1");
+    ASSERT_EQ(u.get_pathname(), "/");
+    ASSERT_EQ(u.host_type, ada::IPV4);
+  }
+  {
+    auto url = ada::parse<TypeParam>("http://192.168.1.1/x");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "192.168.1.1");
+    ASSERT_EQ(url->get_pathname(), "/x");
+    ASSERT_EQ(url->host_type, ada::IPV4);
+  }
+  {
+    // Trailing-dot IPv4 is rewritten to dotted-decimal on the fast path.
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://192.168.1.1./"), u));
+    ASSERT_EQ(u.get_hostname(), "192.168.1.1");
+    ASSERT_EQ(u.host_type, ada::IPV4);
+    auto url = ada::parse<TypeParam>("http://192.168.1.1./");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "192.168.1.1");
+    ASSERT_EQ(url->host_type, ada::IPV4);
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://0x7f.0x0.0x0.0x1"), u));
+    ASSERT_EQ(u.get_hostname(), "127.0.0.1");
+    ASSERT_EQ(u.get_pathname(), "/");
+    ASSERT_EQ(u.get_href(), "http://127.0.0.1/");
+    ASSERT_EQ(u.host_type, ada::IPV4);
+    auto url = ada::parse<TypeParam>("http://0x7f.0x0.0x0.0x1");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "127.0.0.1");
+    ASSERT_EQ(url->get_href(), "http://127.0.0.1/");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://127.1"), u));
+    ASSERT_EQ(u.get_hostname(), "127.0.0.1");
+    ASSERT_EQ(u.host_type, ada::IPV4);
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[::1]/"), u));
+    ASSERT_EQ(u.get_hostname(), "[::1]");
+    ASSERT_EQ(u.get_pathname(), "/");
+    ASSERT_EQ(u.get_href(), "http://[::1]/");
+    ASSERT_EQ(u.host_type, ada::IPV6);
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://[2001:db8::1]/path"), u));
+    ASSERT_EQ(u.get_hostname(), "[2001:db8::1]");
+    ASSERT_EQ(u.get_pathname(), "/path");
+    ASSERT_EQ(u.host_type, ada::IPV6);
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[0:0:0:0:0:0:0:1]"), u));
+    ASSERT_EQ(u.get_hostname(), "[::1]");
+    ASSERT_EQ(u.get_href(), "http://[::1]/");
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[::1]?q=1"), u));
+    ASSERT_EQ(u.get_search(), "?q=1");
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[::1]#f"), u));
+    ASSERT_EQ(u.get_hash(), "#f");
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[::1]:8080/"), u));
+    ASSERT_EQ(u.get_port(), "8080");
+    // Junk after ']' is not a hash. The state machine rejects it.
+    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[::1]foo"), u));
+    ASSERT_FALSE(ada::parse<TypeParam>("http://[::1]foo"));
+    ASSERT_EQ(ada::can_parse("http://[::1]foo"), false);
+    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://[::1]bar/"), u));
+    ASSERT_FALSE(ada::parse<TypeParam>("http://[::1]bar/"));
+  }
+  {
+    // ada_c fuzzer aborts when can_parse and parse disagree.
+    static constexpr const char* kSchemes[] = {
+        "http://", "https://", "ws://", "wss://", "ftp://", "file://"};
+    static constexpr const char* kHosts[] = {
+        "example.com", "0x7f.1", "[::1]", "127.1", "3232235777", "a"};
+    static constexpr const char* kRest[] = {"",   "/",   "/path", "?q=1",
+                                            "#f", "foo", "bar/"};
+    for (const char* scheme : kSchemes) {
+      for (const char* host : kHosts) {
+        for (const char* rest : kRest) {
+          const std::string input = std::string(scheme) + host + rest;
+          ASSERT_EQ(ada::can_parse(input),
+                    ada::parse<TypeParam>(input).has_value())
+              << input;
+        }
+      }
+    }
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://192.168.1.1:8080/"), u));
+    ASSERT_EQ(u.get_hostname(), "192.168.1.1");
+    ASSERT_EQ(u.get_port(), "8080");
+    ASSERT_EQ(u.host_type, ada::IPV4);
+    auto url = ada::parse<TypeParam>("http://192.168.1.1:8080/");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "192.168.1.1");
+    ASSERT_EQ(url->get_port(), "8080");
+    ASSERT_EQ(url->host_type, ada::IPV4);
   }
   {
     auto url = ada::parse<TypeParam>("https://foo.x/");
@@ -1823,6 +1971,14 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
     auto url = ada::parse<TypeParam>("http://xn--ls8h.com/");
     ASSERT_TRUE(url);
     ASSERT_EQ(url->get_hostname(), "xn--ls8h.com");
+    ada::url u;
+    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+        std::string_view("http://xn--ls8h.com/"), u));
+    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://foo.xn--bar.com/"), u));
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://example.com/"), u));
+    ASSERT_EQ(u.get_hostname(), "example.com");
   }
   {
     const std::string long_host(254, 'a');
@@ -1893,6 +2049,63 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
     auto url = ada::parse<TypeParam>("https://example.com/foo/..");
     ASSERT_TRUE(url);
     ASSERT_EQ(url->get_pathname(), "/");
+  }
+
+  // Overlapping 16-byte host window: remaining host region is < 16.
+  {
+    auto url = ada::parse<TypeParam>("https://ab.com/x");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "ab.com");
+    ASSERT_EQ(url->get_pathname(), "/x");
+    ASSERT_EQ(url->get_href(), "https://ab.com/x");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://a.co");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "a.co");
+    ASSERT_EQ(url->get_href(), "https://a.co/");
+  }
+
+  // '%' in a path is copyable unless the segment is %2e / %2e%2e.
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/a%2fb%20c");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/a%2fb%20c");
+    ASSERT_EQ(url->get_href(), "https://example.com/a%2fb%20c");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://example.com/a%2fb"), u));
+    ASSERT_EQ(u.get_pathname(), "/a%2fb");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://example.com/foo/%2e"), u));
+    ASSERT_EQ(u.get_pathname(), "/foo/");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/foo/%2E");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/foo/");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/%2e%2e/x");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/x");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://example.com/.%2e");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/");
+  }
+  {
+    // Mid-segment %2e is not a dot-segment.
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://example.com/foo%2ebar"), u));
+    ASSERT_EQ(u.get_pathname(), "/foo%2ebar");
   }
 
   // Path encoding then query/hash; query encoding then hash.
@@ -1995,6 +2208,66 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
     ASSERT_EQ(url->get_href(),
               "https://user:pass@www.example.com:8080/path/to/"
               "resource?foo=bar&baz=qux#section");
+  }
+  // Userinfo without a password, empty userinfo, and a missing path.
+  {
+    auto url = ada::parse<TypeParam>("https://user@example.com/x");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_username(), "user");
+    ASSERT_EQ(url->get_password(), "");
+    ASSERT_EQ(url->get_hostname(), "example.com");
+    ASSERT_EQ(url->get_href(), "https://user@example.com/x");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://@example.com/");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_username(), "");
+    ASSERT_EQ(url->get_hostname(), "example.com");
+    ASSERT_EQ(url->get_href(), "https://example.com/");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://user:pass@example.com");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/");
+    ASSERT_EQ(url->get_href(), "https://user:pass@example.com/");
+  }
+  {
+    auto url = ada::parse<TypeParam>("https://user:pass@example.com?q=1#f");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_pathname(), "/");
+    ASSERT_EQ(url->get_search(), "?q=1");
+    ASSERT_EQ(url->get_hash(), "#f");
+    ASSERT_EQ(url->get_href(), "https://user:pass@example.com/?q=1#f");
+  }
+  // Encoding-needed userinfo must fall through (space is not copyable).
+  {
+    auto url = ada::parse<TypeParam>("https://user name@example.com/");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_username(), "user%20name");
+  }
+  assert_can_parse_consistent(
+      "https://user:pass@www.example.com:8080/path/to/"
+      "resource?foo=bar&baz=qux#section");
+  assert_can_parse_consistent("https://user@example.com/x");
+  assert_can_parse_consistent("https://@example.com/");
+  assert_can_parse_consistent("https://user:pass@example.com");
+  // Empty port after userinfo (`host://`) must not keep the colon.
+  assert_can_parse_consistent("https://htt@ps://example.com/ath?q=1/.?x/./x");
+  assert_can_parse_consistent("https://e@ample.com:0080/x");
+  {
+    auto url = ada::parse<TypeParam>("https://e@ample.com:0080/x");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_port(), "80");
+    ASSERT_EQ(std::string(url->get_href()), "https://e@ample.com:80/x");
+  }
+  {
+    auto url =
+        ada::parse<TypeParam>("https://htt@ps://example.com/ath?q=1/.?x/./x");
+    ASSERT_TRUE(url);
+    ASSERT_EQ(std::string(url->get_href()),
+              std::string(ada::parse<ada::url_aggregator>(
+                              "https://htt@ps://example.com/ath?q=1/.?x/./x")
+                              ->get_href()));
   }
   // 8-byte scheme match + 32-byte host window (BBC-style CDN hosts).
   {
@@ -2133,10 +2406,14 @@ TEST(basic_tests, try_parse_simple_absolute_ada_url) {
   }
   {
     ada::url u;
-    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
         std::string_view("http://192.168.1.1/x"), u));
-    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+    ASSERT_EQ(u.get_hostname(), "192.168.1.1");
+    ASSERT_EQ(u.host_type, ada::IPV4);
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
         std::string_view("http://user@example.com/x"), u));
+    ASSERT_EQ(u.get_username(), "user");
+    ASSERT_EQ(u.get_href(), "http://user@example.com/x");
     ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
         std::string_view("http:////example.com/x"), u));
   }
@@ -2170,6 +2447,31 @@ TEST(basic_tests, try_parse_simple_absolute_ada_url) {
     ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
         std::string_view("https://xn--nxasmq6b.com/"), u));
   }
+  {
+    // Overlapping last-16 path: first path byte is '.' and the '/' before
+    // it is outside the SIMD valid mask.
+    ada::url u;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://example.com/./a"), u));
+    ASSERT_EQ(u.get_pathname(), "/a");
+    ASSERT_EQ(u.get_href(), "https://example.com/a");
+  }
+  {
+    ada::url u;
+    ASSERT_TRUE(
+        ada::parser::try_parse_simple_absolute(std::string_view("ws://x"), u));
+    ASSERT_EQ(u.get_href(), "ws://x/");
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("ftp://example.com/f"), u));
+    ASSERT_EQ(u.get_href(), "ftp://example.com/f");
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(
+        std::string_view("wss://example.com/c"), u));
+    ASSERT_EQ(u.get_href(), "wss://example.com/c");
+    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https:///extra"), u));
+    ASSERT_FALSE(ada::parser::try_parse_simple_absolute(
+        std::string_view("https://"), u));
+  }
 }
 
 TEST(basic_tests, ada_url_get_href_assembly) {
@@ -2191,14 +2493,42 @@ TEST(basic_tests, ada_url_get_href_assembly) {
     ASSERT_EQ(u->get_href(), "https://user:pass@example.com/x");
     ASSERT_EQ(u->get_href_size(), u->get_href().size());
   }
+  {
+    auto u = ada::parse<ada::url>("http://example.com/path");
+    ASSERT_TRUE(u);
+    ASSERT_EQ(u->get_href(), "http://example.com/path");
+    ASSERT_EQ(u->get_href_size(), u->get_href().size());
+  }
 }
 
 TEST(basic_tests, last_label_may_be_a_number_cases) {
+  using ada::checkers::is_ipv4_number_char;
   using ada::checkers::last_label_may_be_a_number;
+  ASSERT_FALSE(is_ipv4_number_char('m'));
+  ASSERT_FALSE(is_ipv4_number_char('g'));
+  ASSERT_FALSE(is_ipv4_number_char('t'));
+  ASSERT_TRUE(is_ipv4_number_char('e'));
+  ASSERT_TRUE(is_ipv4_number_char('c'));
+  ASSERT_TRUE(is_ipv4_number_char('x'));
+  ASSERT_TRUE(is_ipv4_number_char('X'));
+  ASSERT_TRUE(is_ipv4_number_char('A'));
+  ASSERT_TRUE(is_ipv4_number_char('F'));
+  ASSERT_TRUE(is_ipv4_number_char('9'));
+  ASSERT_TRUE(is_ipv4_number_char('0'));
+  ASSERT_FALSE(is_ipv4_number_char('.'));
+  ASSERT_FALSE(is_ipv4_number_char('z'));
+  ASSERT_TRUE(ada::checkers::ends_with_dot_com("example.com", 11));
+  ASSERT_TRUE(ada::checkers::ends_with_dot_com("example.COM.", 12));
+  ASSERT_FALSE(ada::checkers::ends_with_dot_com("example.org", 11));
   ASSERT_FALSE(last_label_may_be_a_number(""));
   ASSERT_FALSE(last_label_may_be_a_number("."));
   ASSERT_FALSE(last_label_may_be_a_number("example.com"));
   ASSERT_FALSE(last_label_may_be_a_number("example.com."));
+  ASSERT_FALSE(last_label_may_be_a_number("example.COM"));
+  ASSERT_FALSE(last_label_may_be_a_number("www.google.com"));
+  ASSERT_FALSE(last_label_may_be_a_number("wikipedia.org"));
+  ASSERT_FALSE(last_label_may_be_a_number("foo.gov"));
+  ASSERT_FALSE(last_label_may_be_a_number("foo.edu"));
   ASSERT_FALSE(last_label_may_be_a_number("abc."));
   ASSERT_TRUE(last_label_may_be_a_number("foo.123"));
   ASSERT_TRUE(last_label_may_be_a_number("foo.123."));
@@ -2214,6 +2544,22 @@ TEST(basic_tests, last_label_may_be_a_number_cases) {
   ASSERT_TRUE(last_label_may_be_a_number("19%2E68.1.10."));
   ASSERT_TRUE(last_label_may_be_a_number("19.68.1.10."));
   ASSERT_TRUE(last_label_may_be_a_number("0xffffffff."));
+}
+
+TYPED_TEST(basic_tests, aggregator_href_buffer_reuse) {
+  // Successive parses must not leak a previous href into a later URL.
+  const char* long_url =
+      "https://this-is-a-long-hostname.example.com/"
+      "abcdefghijklmnopqrstuvwxyz0123456789/path?q=1#frag";
+  for (int i = 0; i < 8; ++i) {
+    auto url = ada::parse<TypeParam>(long_url);
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_href(), long_url);
+  }
+  auto short_url = ada::parse<TypeParam>("https://example.com/x");
+  ASSERT_TRUE(short_url);
+  ASSERT_EQ(short_url->get_href(), "https://example.com/x");
+  ASSERT_EQ(short_url->get_hostname(), "example.com");
 }
 
 TYPED_TEST(basic_tests,

--- a/tests/basic_tests.cpp
+++ b/tests/basic_tests.cpp
@@ -2209,6 +2209,32 @@ TYPED_TEST(basic_tests, simple_absolute_fast_path_edges) {
               "https://user:pass@www.example.com:8080/path/to/"
               "resource?foo=bar&baz=qux#section");
   }
+  // 16-byte inputs use an overlapping last-16 path window that starts at
+  // byte 0. A leading '.' in that window must not read b[-1].
+  {
+    constexpr std::string_view k16 = "https://u@x/c.de";
+    ASSERT_EQ(k16.size(), 16u);
+    auto url = ada::parse<TypeParam>(k16);
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_username(), "u");
+    ASSERT_EQ(url->get_hostname(), "x");
+    ASSERT_EQ(url->get_pathname(), "/c.de");
+    ASSERT_EQ(url->get_href(), "https://u@x/c.de");
+    ada::url fast;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(k16, fast));
+    ASSERT_EQ(fast.get_href(), "https://u@x/c.de");
+  }
+  {
+    constexpr std::string_view k16 = "https://a.com/.x";
+    ASSERT_EQ(k16.size(), 16u);
+    auto url = ada::parse<TypeParam>(k16);
+    ASSERT_TRUE(url);
+    ASSERT_EQ(url->get_hostname(), "a.com");
+    ASSERT_EQ(url->get_pathname(), "/.x");
+    ada::url fast;
+    ASSERT_TRUE(ada::parser::try_parse_simple_absolute(k16, fast));
+    ASSERT_EQ(fast.get_pathname(), "/.x");
+  }
   // Userinfo without a password, empty userinfo, and a missing path.
   {
     auto url = ada::parse<TypeParam>("https://user@example.com/x");

--- a/tools/run-clangcldocker.sh
+++ b/tools/run-clangcldocker.sh
@@ -18,10 +18,11 @@ DOCKER_IMAGE=xianpengshen/clang-tools:22
 ALL_ADA_FILES=$(cd "$MAINSOURCE" && \
   git ls-tree --full-tree --name-only -r HEAD | grep -E '.*\.(c|h|cc|cpp|hh)$')
 
-# ada.cpp is the single translation unit that #includes every other .cpp file.
-# Running clang-tidy on it covers all first-party code; HeaderFilterRegex in
-# .clang-tidy controls which included files generate diagnostics.
-TIDY_SRC=src/ada.cpp
+# ada.cpp is the unity translation unit. parser_hot.cpp and
+# parser_finish.cpp #include parser.cpp with complementary skip macros,
+# and can_parse.cpp is a separate TU. HeaderFilterRegex in .clang-tidy
+# controls which included files generate diagnostics.
+TIDY_SRCS=(src/ada.cpp src/parser_hot.cpp src/parser_finish.cpp src/can_parse.cpp)
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -85,7 +86,7 @@ run_tidy() {
     -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=ON \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCMAKE_CXX_FLAGS="-stdlib=libc++"
-  "$tidy" -p build-clang-tidy "$TIDY_SRC"
+  "$tidy" -p build-clang-tidy "${TIDY_SRCS[@]}"
 }
 
 if have_tool_version clang-tidy-22 && command -v clang++-22 >/dev/null 2>&1; then
@@ -111,6 +112,6 @@ else
         -DADA_USE_UNSAFE_STD_REGEX_PROVIDER=ON \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DCMAKE_CXX_FLAGS='-stdlib=libc++'
-      clang-tidy-22 -p build-clang-tidy "$TIDY_SRC"
+      clang-tidy-22 -p build-clang-tidy src/ada.cpp src/parser_hot.cpp src/parser_finish.cpp src/can_parse.cpp
     "
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second of three PRs that split #1237. Targets `main` (includes #1240 until that lands).

Move these out of the unity `ada.cpp` TU so its inlining budget is not spent on them:

- SIMD percent-encode kernel (`unicode_percent_encode.cpp`)
- Simple-absolute fast path (`parser_hot.cpp`)
- Cold finish helpers and relative resolution (`parser_finish.cpp`)
- `can_parse` (`can_parse.cpp`)

Also inline the SSSE3 scanners, reuse the host delimiter, and drop `npos` cmovs.

Merge after #1240. Does **not** include setter isolation (#1241).

## Related

1. #1240 — parse-path instruction cuts
2. **This PR (#1239)** — TU isolation
3. #1241 — isolate credential setters

## Test plan

- [x] Full stack (`#1241`) `basic_tests`, `max_input_length`, WPT, `ada_c`, `basic_fuzzer`
- [ ] Builds with `ADA_PARSER_FINISH_SEPARATE_TU` / `ADA_CAN_PARSE_SEPARATE_TU` on gcc-12 and clang
- [ ] Pedantic / ABI / lint (includes the new TUs)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04656-80e9-787a-a056-aa4e5be32491?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04656-80e9-787a-a056-aa4e5be32491&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

