### PR TITLE
Fix ada::url host_end one byte short of its documented position

### DIFF
--- a/include/ada/url-inl.h
+++ b/include/ada/url-inl.h
@@ -71,15 +71,18 @@ inline std::ostream& operator<<(std::ostream& out, const ada::url& u) {
         out.host_start += uint32_t(password.size() + 1);
       }
 
-      out.host_end = uint32_t(out.host_start + host->size());
+      // host_start is the '@' when there are credentials, exactly as
+      // url_aggregator reports it, so the host itself begins one byte later.
+      out.host_end = uint32_t(out.host_start + 1 + host->size());
     } else {
       out.username_end = out.host_start;
 
       // Host does not start with "@" if it does not include credentials.
-      out.host_end = uint32_t(out.host_start + host->size()) - 1;
+      out.host_end = uint32_t(out.host_start + host->size());
     }
 
-    running_index = out.host_end + 1;
+    // host_end is one past the host, so it is already the next index.
+    running_index = out.host_end;
   } else {
     // Update host start and end date to the same index, since it does not
     // exist.

--- a/tests/url_components.cpp
+++ b/tests/url_components.cpp
@@ -109,6 +109,10 @@ TEST(url_components, urltestdata_encoding) {
         }
         ASSERT_EQ(href.substr(host_start, url.get_hostname().size()),
                   url.get_hostname());
+        // host_end is one past the host, so slicing to it is the hostname.
+        // Nothing pinned this before, and it was one byte short.
+        ASSERT_EQ(href.substr(host_start, out.host_end - host_start),
+                  url.get_hostname());
 
         if (url.port.has_value()) {
           ASSERT_EQ(out.port, url.port.value());


### PR DESCRIPTION
`ada::url::get_components().host_end` is one byte short of the position the `url_components` documentation diagram describes (one past the host) in both branches of `url-inl.h`: the no-credentials branch subtracts one, and the credentials branch omits the '@' byte that `host_start` sits on. `ada::url_aggregator` reports the documented position on the same inputs, so the two implementations of the one contract disagree, and slicing `href` by `[host_start, host_end)` from `ada::url` truncates the host:

```
url             https://example.com/path            host_end=18  substr -> "example.co"
url_aggregator  https://example.com/path            host_end=19  substr -> "example.com"
url             https://user:pass@example.com/path  host_end=28  substr -> "@example.co"
url_aggregator  https://user:pass@example.com/path  host_end=29  substr -> "@example.com"
```

The computation was internally self-correcting - `running_index` added the missing byte back - which is why every other offset agrees between the two implementations and only the exposed `host_end` is wrong. The existing test slices by `get_hostname().size()` and never reads `host_end`, which is how it survived. This change fixes both branches, updates `running_index` accordingly (it is now already one past the host), and pins `[host_start, host_end)` to the hostname in `url_components.cpp`, which runs over the full WPT `urltestdata` corpus. The new assertion fails before the fix and passes after; the full suite (353 tests) is green with the change.

Per AI_USAGE_POLICY.md: this defect was found by an automated analysis loop built on Claude; the fix and test were reviewed by me before filing, I am accountable for them, and I am happy to answer questions during review. clang-format 22 has been applied to the touched files.
